### PR TITLE
Added SynapseIndexMap.h and BGTypes.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,38 +3,44 @@ project(SummerOfBrain)
 
 set(CMAKE_CXX_STANDARD 14)
 
-# Add all directories that contain used classes
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+# Add all directories that contain required classes
 include_directories(
         ../SummerOfBrain
         Core
         Core/FunctionNodes
-        Testing)
+        Testing
+        Utils)
 
 # Including Googletest subdirectories
 add_subdirectory(Testing/lib/googletest-master)
 include_directories(Testing/lib/googletest-master/googletest/include)
 
-# CPU SIMULATOR EXECUTABLE
+# ------ CPU SIMULATOR EXECUTABLE -------
 # Add all class paths needed for dependencies
 #add_executable(BrainGrid)
 
-# GPU SIMULATOR EXECUTABLE
+# ------ GPU SIMULATOR EXECUTABLE ------
 # Add all class paths needed for dependencies
 #add_executable(BrainGrid-cuda)
 
-# TEST EXECUTABLE
+# ------ TESTS EXECUTABLE ------
 # Add all class paths needed for dependencies
 add_executable(Tests
-        Testing/RunTests.cpp
-        Testing/Core/Foo.h
-        Testing/Core/Foo.cpp
-        Core/FunctionNodes/GenericFunctionNode.h
-        Core/FunctionNodes/GenericFunctionNode.cpp
         Core/OperationManager.h
         Core/OperationManager.cpp
         Core/Operations.h
+        Core/SynapseIndexMap.h
+        Core/FunctionNodes/GenericFunctionNode.h
+        Core/FunctionNodes/GenericFunctionNode.cpp
+        Testing/RunTests.cpp
+        Testing/Core/Foo.h
+        Testing/Core/Foo.cpp
         Testing/Core/FunctionNodeTests.cpp
-        Testing/Core/OperationManagerTests.cpp)
+        Testing/Core/OperationManagerTests.cpp
+        Testing/Core/SynapseIndexMapTests.cpp
+        Utils/BGTypes.h)
 
-# Links the Googletest framework with the testing classes
+# Links the Googletest framework with the testing executable
 target_link_libraries(Tests gtest gtest_main)

--- a/Core/SynapseIndexMap.h
+++ b/Core/SynapseIndexMap.h
@@ -1,0 +1,82 @@
+/**
+ *  @file SynapseIndexMap.h
+ *
+ *  @brief A structure maintains outgoing and active synapses list (forward map).
+ *
+ *  @ingroup Core
+ *
+ *  @struct SynapseIndexMap SynapseIndexMap.h "SynapseIndexMap.h"
+ *
+ *  \latexonly  \subsubsection*{Implementation} \endlatexonly
+ *  \htmlonly   <h3>Implementation</h3> \endhtmlonly
+ *
+ *  The structure maintains a list of outgoing synapses (forward map) and active synapses list.
+ *
+ *  The outgoing synapses list stores all outgoing synapse indexes relevant to a neuron.
+ *  Synapse indexes are stored in the synapse forward map (forwardIndex), and
+ *  the pointer and length of the neuron i's outgoing synapse indexes are specified
+ *  by outgoingSynapse_begin[i] and synapseCount[i] respectively.
+ *  The incoming synapses list is used in calcSummationMapDevice() device function to
+ *  calculate sum of PSRs for each neuron simultaneously.
+ *  The list also used in AllSpikingNeurons::advanceNeurons() function to allow back propagation.
+ *
+ *  The active synapses list stores all active synapse indexes.
+ *  The list is referred in advanceSynapsesDevice() device function.
+ *  The list contribute to reduce the number of the device function thread to skip the inactive
+ *  synapses.
+ *
+ *  \latexonly  \subsubsection*{Credits} \endlatexonly
+ *  \htmlonly   <h3>Credits</h3> \endhtmlonly
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "BGTypes.h"
+
+using namespace std;
+
+struct SynapseIndexMap {
+    /// Vector of the outgoing synapse index map.
+    vector<BGSIZE> outgoingSynapseIndexMap_;
+
+    /// The beginning index of the outgoing spiking synapse vector of each neuron.
+    /// Indexed by a source neuron index.
+    vector<BGSIZE> outgoingSynapseBegin_;
+
+    /// The vector of number of outgoing synapses of each neuron.
+    /// Indexed by a source neuron index.
+    vector<BGSIZE> outgoingSynapseCount_;
+
+    /// Vector of the incoming synapse index map.
+    vector<BGSIZE> incomingSynapseIndexMap_;
+
+    /// The beginning index of the incoming spiking synapse vector of each neuron.
+    /// Indexed by a destination neuron index.
+    vector<BGSIZE> incomingSynapseBegin_;
+
+    /// The vector of number of incoming synapses of each neuron.
+    /// Indexed by a destination neuron index.
+    vector<BGSIZE> incomingSynapseCount_;
+
+    SynapseIndexMap() : numOfNeurons_(0), numOfSynapses_(0) {};
+
+    SynapseIndexMap(int neuronCount, int synapseCount) : numOfNeurons_(neuronCount), numOfSynapses_(synapseCount) {
+        outgoingSynapseIndexMap_.resize(synapseCount);
+        outgoingSynapseBegin_.resize(neuronCount);
+        outgoingSynapseCount_.resize(neuronCount);
+
+        incomingSynapseIndexMap_.resize(synapseCount);
+        incomingSynapseBegin_.resize(neuronCount);
+        incomingSynapseCount_.resize(neuronCount);
+    };
+
+private:
+    /// Number of total neurons.
+    BGSIZE numOfNeurons_;
+
+    /// Number of total active synapses.
+    BGSIZE numOfSynapses_;
+};
+

--- a/Testing/Core/SynapseIndexMapTests.cpp
+++ b/Testing/Core/SynapseIndexMapTests.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file SynapseIndexMapTests.cpp
+ *
+ * @brief This file contains the unit tests for SynpaseIndexMap using GTest.
+ *
+ * @ingroup Testing
+ */
+
+#include "gtest/gtest.h"
+
+#include "SynapseIndexMap.h"
+
+/// Static variable used for neuron count initialization of the SynapseIndexMap in the tests
+static int NEURON_COUNT = 50;
+
+/// Static variable used for synapse count initialization of the SynapseIndexMap in the tests
+static int SYNAPSE_COUNT = 100;
+
+/// Testing object with initialized SynapseIndexMap. Used to reduce reused code.
+struct SynapseIndexMapTestObject : public testing::Test {
+    SynapseIndexMapTestObject() {
+        synapseIndexMap = new SynapseIndexMap(NEURON_COUNT, SYNAPSE_COUNT);
+    }
+
+    SynapseIndexMap *synapseIndexMap;
+};
+
+TEST(SynapseIndexMap, DefaultConstructor) {
+    SynapseIndexMap *synapseIndexMap = new SynapseIndexMap();
+    EXPECT_TRUE(synapseIndexMap != nullptr);
+}
+
+TEST(SynapseIndexMap, OverloadedConstructor) {
+    SynapseIndexMap *synapseIndexMap = new SynapseIndexMap(0, 0);
+    EXPECT_TRUE(synapseIndexMap != nullptr);
+}
+
+TEST_F(SynapseIndexMapTestObject, OutgoingSynapseMapInitialiedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->outgoingSynapseIndexMap_.size(), SYNAPSE_COUNT);
+}
+
+TEST_F(SynapseIndexMapTestObject, OutgoingSynapseBeginInitialiedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->outgoingSynapseBegin_.size(), NEURON_COUNT);
+}
+
+TEST_F(SynapseIndexMapTestObject, OutgoingSynapseCountInitialiedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->outgoingSynapseCount_.size(), NEURON_COUNT);
+}
+
+TEST_F(SynapseIndexMapTestObject, IncomingSynapseIndexMapInitialiedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->incomingSynapseIndexMap_.size(), SYNAPSE_COUNT);
+}
+
+TEST_F(SynapseIndexMapTestObject, IncomingSynapseBeginInitialiedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->incomingSynapseBegin_.size(), NEURON_COUNT);
+}
+
+TEST_F(SynapseIndexMapTestObject, IncomingSynapseCountInitializedSuccessfully) {
+    EXPECT_EQ(synapseIndexMap->incomingSynapseCount_.size(), NEURON_COUNT);
+}
+

--- a/Testing/RunTests.cpp
+++ b/Testing/RunTests.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-int main(int argc, char *argv[]) {
+int main() {
     testing::InitGoogleTest();
     int result = RUN_ALL_TESTS();
     if (result != 0) {

--- a/Utils/BGTypes.h
+++ b/Utils/BGTypes.h
@@ -1,0 +1,69 @@
+/**
+ * @file BGTypes.h
+ *
+ * @brief Used to define uniform data type sizes based for all operating systems. Also used to test the speed of
+ * simulation based on the data types.
+ *
+ * @ingroup Utils
+ *
+ *
+ * This type is used to measure the difference between
+ * IEEE Standard 754 single and double-precision floating
+ * point values.
+ *
+ * Single-precision (float) calculations are fast, but only
+ * 23 bits are available to store the decimal.
+ *
+ * Double-precision (double) calculations are an order of magnitude
+ * slower, but 52 bits are available to store the decimal.
+ *
+ * We'd like to avoid doubles, if the simulation output doesn't suffer.
+ *
+ *
+ * For floats, uncomment the following two lines and comment DOUBLEPRECISION and
+ * the other #define BGFLOAT; vice-versa for doubles.
+ */
+
+#pragma once
+
+#define SINGLEPRECISION
+#define BGFLOAT float
+//#define DOUBLEPRECISION
+//#define BGFLOAT double
+
+typedef BGFLOAT *PBGFLOAT;
+
+// TIMEFLOAT is used by the GPU code and needs to be a double
+#define TIMEFLOAT double
+
+// Platform Specific (are the typdef's redundant?)
+#ifdef __linux__
+typedef unsigned int uint32_t;
+typedef signed int int32_t;
+
+#elif defined __APPLE__
+typedef unsigned int uint32_t;
+typedef signed int int32_t;
+
+#elif defined _WIN32 || defined _WIN64
+typedef unsigned __int32 uint32_t;		// included in inttypes.h, which is not 
+                                        // available in WIN32
+typedef signed __int32 int32_t;
+typedef unsigned long long int uint64_t;
+
+#else
+#error "unknown platform"
+#endif // Platform Specific
+
+// AMP
+#ifdef USE_AMP
+#define GPU_COMPAT_BOOL uint32_t
+#else
+#define GPU_COMPAT_BOOL bool
+#endif // AMP
+
+// The type for using array indexes (issue #142).
+#define BGSIZE uint32_t
+//#define BGSIZE uint64_t
+
+


### PR DESCRIPTION
- SynapseIndexMap now uses vectors instead of raw pointers to an array.
- Wrote unit tests for SynapseIndexMap.
- Applied coding standard and comment adjustments.