### PR TITLE
Added log4cplus into all simulator objects and did extensive clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,8 @@ _deps
 Testing/lib/
 lib/
 
-# log4cplus logging file
-Output/Debug/logging.txt
+# log4cplus logging files
+Output/Debug/*.txt
 
 # Result files
 Output/Results/*.xml

--- a/RuntimeFiles/log4cplus_configure.ini
+++ b/RuntimeFiles/log4cplus_configure.ini
@@ -2,11 +2,14 @@
 ########Define log Levels##########
 ###################################
 
-#Used for main classes to show program flow - Prints to both console and the logging file
-log4cplus.logger.main=ALL, MyConsoleAppender
+#Prints to both console and the logging file. Used for tracing the state of the simulator
+log4cplus.logger.console=ALL, MyConsoleAppender, MyFileAppender
 
-#All classes - except those in log4cplus.logger.* - use DEBUG level to print information on file
-log4cplus.rootLogger=DEBUG, MyFileAppender
+#Prints to only the logging.txt file, used to print additional information for debugging purposes
+log4cplus.logger.file=All, MyFileAppender
+
+#Prints to a logging file specifically for tracking neuron information.
+log4cplus.logger.neuron=ALL, NeuronFileAppender
 
 ###################################
 ########Define the Appenders#######
@@ -24,3 +27,11 @@ log4cplus.appender.MyFileAppender.MaxFileSize=16MB
 log4cplus.appender.MyFileAppender.MaxBackupIndex=1
 log4cplus.appender.MyFileAppender.layout=log4cplus::PatternLayout
 log4cplus.appender.MyFileAppender.layout.ConversionPattern=[%-5p][%D{%Y/%m/%d %H:%M:%S:%q}][%-l] %m%n
+
+#NeuronFileAppender
+log4cplus.appender.NeuronFileAppender=log4cplus::RollingFileAppender
+log4cplus.appender.NeuronFileAppender.File=Output/Debug/neurons.txt
+log4cplus.appender.NeuronFileAppender.MaxFileSize=16MB
+log4cplus.appender.NeuronFileAppender.MaxBackupIndex=1
+log4cplus.appender.NeuronFileAppender.layout=log4cplus::PatternLayout
+log4cplus.appender.NeuronFileAppender.layout.ConversionPattern=[%-5p][%D{%Y/%m/%d %H:%M:%S:%q}][%-l] %m%n

--- a/Simulation/Connections/ConnGrowth.h
+++ b/Simulation/Connections/ConnGrowth.h
@@ -75,11 +75,13 @@
 
 #pragma once
 
-#include "Global.h"
-#include "Connections.h"
-#include "Simulator.h"
-#include <vector>
 #include <iostream>
+#include <vector>
+
+#include "Connections.h"
+#include "Global.h"
+#include "Simulator.h"
+
 
 /**
 * cereal
@@ -117,9 +119,8 @@ public:
    virtual void loadParameters();
 
    /**
-    *  Prints out all parameters of the connections to ostream.
-    *
-    *  @param  output  ostream to send output to.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
@@ -131,15 +132,6 @@ public:
     *  @return true if successful, false otherwise.
     */
    virtual bool updateConnections(IAllNeurons &neurons, Layout *layout);
-
-   /**
-    *  Creates a recorder class object for the connection.
-    *  This function tries to create either Xml recorder or
-    *  Hdf5 recorder based on the extension of the file name.
-    *
-    *  @return Pointer to the recorder class object.
-    */
-   virtual IRecorder *createRecorder();
 
    /**
     *  Cereal serialization method
@@ -167,14 +159,14 @@ public:
     *  synaptic strengths from the weight matrix.
     *  Note: Platform Dependent.
     *
-    *  @param  num_neurons         number of neurons to update.
+    *  @param  numNeurons          number of neurons to update.
     *  @param  neurons             the AllNeurons object.
     *  @param  synapses            the AllSynapses object.
     *  @param  m_allNeuronsDevice  Reference to the allNeurons struct in device memory.
     *  @param  m_allSynapsesDevice Reference to the allSynapses struct in device memory.
     *  @param  layout              the Layout object.
     */
-   virtual void updateSynapsesWeights(const int num_neurons,
+   virtual void updateSynapsesWeights(const int numNeurons,
          IAllNeurons &neurons, IAllSynapses &synapses,
          AllSpikingNeuronsDeviceProperties* m_allNeuronsDevice,
          AllSpikingSynapsesDeviceProperties* m_allSynapsesDevice,
@@ -186,14 +178,14 @@ public:
     *  synaptic strengths from the weight matrix.
     *  Note: Platform Dependent.
     *
-    *  @param  num_neurons Number of neurons to update.
+    *  @param  numNeurons Number of neurons to update.
     *  @param  ineurons    the AllNeurons object.
     *  @param  isynapses   the AllSynapses object.
     *  @param  layout      the Layout object.
     * 
     */
    virtual void
-   updateSynapsesWeights(const int num_neurons,
+   updateSynapsesWeights(const int numNeurons,
          IAllNeurons &neurons,
          IAllSynapses &synapses,
          Layout *layout);
@@ -210,18 +202,18 @@ private:
    /**
     *  Update the distance between frontiers of Neurons.
     *
-    *  @param  num_neurons Number of neurons to update.
+    *  @param  numNeurons Number of neurons to update.
     *  @param  layout      Layout information of the neunal network.
     */
-   void updateFrontiers(const int num_neurons, Layout *layout);
+   void updateFrontiers(const int numNeurons, Layout *layout);
 
    /**
     *  Update the areas of overlap in between Neurons.
     *
-    *  @param  num_neurons Number of Neurons to update.
+    *  @param  numNeurons Number of Neurons to update.
     *  @param  layout      Layout information of the neunal network.
     */
-   void updateOverlap(BGFLOAT num_neurons, Layout *layout);
+   void updateOverlap(BGFLOAT numNeurons, Layout *layout);
 
 public:
    struct GrowthParams {

--- a/Simulation/Connections/ConnStatic.h
+++ b/Simulation/Connections/ConnStatic.h
@@ -77,20 +77,10 @@ public:
    virtual void loadParameters();
 
    /**
-    *  Prints out all parameters of the connections to ostream.
-    *
-    *  @param  output  ostream to send output to.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
-
-   /**
-    *  Creates a recorder class object for the connection.
-    *  This function tries to create either Xml recorder or
-    *  Hdf5 recorder based on the extension of the file name.
-    *
-    *  @return Pointer to the recorder class object.
-    */
-   virtual IRecorder *createRecorder();
 
 private:
    //! number of maximum connections per neurons
@@ -110,7 +100,7 @@ private:
 
    struct DistDestNeuron {
       BGFLOAT dist;     // destance to the destination neuron
-      int dest_neuron;  // index of the destination neuron
+      int destNeuron;  // index of the destination neuron
 
       bool operator<(const DistDestNeuron &other) const {
          return (dist < other.dist);

--- a/Simulation/Connections/Connections.cpp
+++ b/Simulation/Connections/Connections.cpp
@@ -37,7 +37,6 @@
 \* --------------------------------------------- */
 
 #include "Connections.h"
-
 #include "IAllSynapses.h"
 #include "IAllNeurons.h"
 #include "AllSynapses.h"
@@ -59,6 +58,9 @@ Connections::Connections() {
    // Register loadParameters function with Operation Manager
    function<void()> function = std::bind(&Connections::loadParameters, this);
    OperationManager::getInstance().registerOperation(Operations::op::loadParameters, function);
+
+   // Get a copy of the file logger to use log4cplus macros
+   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
 Connections::~Connections() {
@@ -88,7 +90,7 @@ bool Connections::updateConnections(IAllNeurons &neurons, Layout *layout) {
 }
 
 #if defined(USE_GPU)
-void Connections::updateSynapsesWeights(const int num_neurons, IAllNeurons &neurons, IAllSynapses &synapses, AllSpikingNeuronsDeviceProperties* m_allNeuronsDevice, AllSpikingSynapsesDeviceProperties* m_allSynapsesDevice, Layout *layout)
+void Connections::updateSynapsesWeights(const int numNeurons, IAllNeurons &neurons, IAllSynapses &synapses, AllSpikingNeuronsDeviceProperties* m_allNeuronsDevice, AllSpikingSynapsesDeviceProperties* m_allSynapsesDevice, Layout *layout)
 {
 }
 #else
@@ -97,11 +99,11 @@ void Connections::updateSynapsesWeights(const int num_neurons, IAllNeurons &neur
  *  Update the weight of the Synapses in the simulation.
  *  Note: Platform Dependent.
  *
- *  @param  num_neurons Number of neurons to update.
+ *  @param  numNeurons Number of neurons to update.
  *  @param  neurons     The Neuron list to search from.
  *  @param  synapses    The Synapse list to search from.
  */
-void Connections::updateSynapsesWeights(const int num_neurons, IAllNeurons &neurons, IAllSynapses &synapses, Layout *layout) {
+void Connections::updateSynapsesWeights(const int numNeurons, IAllNeurons &neurons, IAllSynapses &synapses, Layout *layout) {
 }
 
 #endif // !USE_GPU
@@ -109,31 +111,31 @@ void Connections::updateSynapsesWeights(const int num_neurons, IAllNeurons &neur
 /*
  *  Creates synapses from synapse weights saved in the serialization file.
  *
- *  @param  num_neurons Number of neurons to update.
+ *  @param  numNeurons Number of neurons to update.
  *  @param  layout      Layout information of the neunal network.
  *  @param  ineurons    The Neuron list to search from.
  *  @param  isynapses   The Synapse list to search from.
  */
-void Connections::createSynapsesFromWeights(const int num_neurons, Layout *layout, IAllNeurons &ineurons,
+void Connections::createSynapsesFromWeights(const int numNeurons, Layout *layout, IAllNeurons &ineurons,
                                             IAllSynapses &isynapses) {
    AllNeurons &neurons = dynamic_cast<AllNeurons &>(ineurons);
    AllSynapses &synapses = dynamic_cast<AllSynapses &>(isynapses);
 
    // for each neuron
-   for (int iNeuron = 0; iNeuron < num_neurons; iNeuron++) {
+   for (int iNeuron = 0; iNeuron < numNeurons; iNeuron++) {
       // for each synapse in the neuron
-      for (BGSIZE synapse_index = 0;
-           synapse_index < Simulator::getInstance().getMaxSynapsesPerNeuron(); synapse_index++) {
-         BGSIZE iSyn = Simulator::getInstance().getMaxSynapsesPerNeuron() * iNeuron + synapse_index;
+      for (BGSIZE synapseIndex = 0;
+           synapseIndex < Simulator::getInstance().getMaxSynapsesPerNeuron(); synapseIndex++) {
+         BGSIZE iSyn = Simulator::getInstance().getMaxSynapsesPerNeuron() * iNeuron + synapseIndex;
          // if the synapse weight is not zero (which means there is a connection), create the synapse
          if (synapses.W_[iSyn] != 0.0) {
             BGFLOAT theW = synapses.W_[iSyn];
-            BGFLOAT *sum_point = &(neurons.summationMap_[iNeuron]);
-            int src_neuron = synapses.sourceNeuronIndex_[iSyn];
-            int dest_neuron = synapses.destNeuronIndex_[iSyn];
-            synapseType type = layout->synType(src_neuron, dest_neuron);
+            BGFLOAT *sumPoint = &(neurons.summationMap_[iNeuron]);
+            int srcNeuron = synapses.sourceNeuronIndex_[iSyn];
+            int destNeuron = synapses.destNeuronIndex_[iSyn];
+            synapseType type = layout->synType(srcNeuron, destNeuron);
             synapses.synapseCounts_[iNeuron]++;
-            synapses.createSynapse(iSyn, src_neuron, dest_neuron, sum_point, Simulator::getInstance().getDeltaT(),
+            synapses.createSynapse(iSyn, srcNeuron, destNeuron, sumPoint, Simulator::getInstance().getDeltaT(),
                                    type);
             synapses.W_[iSyn] = theW;
          }

--- a/Simulation/Connections/Connections.h
+++ b/Simulation/Connections/Connections.h
@@ -38,6 +38,8 @@
 
 #include <memory>
 
+#include <log4cplus/loggingmacros.h>
+
 #include "IAllNeurons.h"
 #include "IAllSynapses.h"
 #include "Layout.h"
@@ -79,10 +81,9 @@ public:
    virtual void loadParameters() = 0;
 
    /**
-    *  Prints out all parameters of the connections to ostream.
-    *
-    *  @param  output  ostream to send output to.
-    */
+   *  Prints out all parameters to logging file.
+   *  Registered to OperationManager as Operation::printParameters
+   */
    virtual void printParameters() const = 0;
 
    /**
@@ -95,24 +96,15 @@ public:
    virtual bool updateConnections(IAllNeurons &neurons, Layout *layout);
 
    /**
-    *  Creates a recorder class object for the connection.
-    *  This function tries to create either Xml recorder or
-    *  Hdf5 recorder based on the extension of the file name.
-    *
-    *  @return Pointer to the recorder class object.
-    */
-   virtual IRecorder *createRecorder() = 0;
-
-   /**
     *  Creates synapses from synapse weights saved in the serialization file.
     *
-    *  @param  num_neurons Number of neurons to update.
+    *  @param  numNeurons Number of neurons to update.
     *  @param  layout      Layout information of the neunal network.
     *  @param  ineurons    The Neuron list to search from.
     *  @param  isynapses   The Synapse list to search from.
     */
    void
-   createSynapsesFromWeights(const int num_neurons, Layout *layout, IAllNeurons &ineurons, IAllSynapses &isynapses);
+   createSynapsesFromWeights(const int numNeurons, Layout *layout, IAllNeurons &ineurons, IAllSynapses &isynapses);
 
 #if defined(USE_GPU)
    public:
@@ -120,26 +112,26 @@ public:
         *  Update the weight of the Synapses in the simulation.
         *  Note: Platform Dependent.
         *
-        *  @param  num_neurons         number of neurons to update.
+        *  @param  numNeurons          number of neurons to update.
         *  @param  neurons             the Neuron list to search from.
         *  @param  synapses            the Synapse list to search from.
         *  @param  m_allNeuronsDevice  Reference to the allNeurons struct on device memory.
         *  @param  m_allSynapsesDevice Reference to the allSynapses struct on device memory.
         *  @param  layout              Layout information of the neunal network.
         */
-       virtual void updateSynapsesWeights(const int num_neurons, IAllNeurons &neurons, IAllSynapses &synapses, AllSpikingNeuronsDeviceProperties* m_allNeuronsDevice, AllSpikingSynapsesDeviceProperties* m_allSynapsesDevice, Layout *layout);
+       virtual void updateSynapsesWeights(const int numNeurons, IAllNeurons &neurons, IAllSynapses &synapses, AllSpikingNeuronsDeviceProperties* m_allNeuronsDevice, AllSpikingSynapsesDeviceProperties* m_allSynapsesDevice, Layout *layout);
 #else
 public:
    /**
     *  Update the weight of the Synapses in the simulation.
     *  Note: Platform Dependent.
     *
-    *  @param  num_neurons Number of neurons to update.
+    *  @param  numNeurons Number of neurons to update.
     *  @param  ineurons    The Neuron list to search from.
     *  @param  isynapses   The Synapse list to search from.
     */
    virtual void
-   updateSynapsesWeights(const int num_neurons, IAllNeurons &neurons, IAllSynapses &synapses, Layout *layout);
+   updateSynapsesWeights(const int numNeurons, IAllNeurons &neurons, IAllSynapses &synapses, Layout *layout);
 
 #endif // USE_GPU
 
@@ -148,5 +140,7 @@ protected:
    shared_ptr<IAllSynapses> synapses_;
 
    shared_ptr<SynapseIndexMap> synapseIndexMap_;
+
+   log4cplus::Logger fileLogger_;
 };
 

--- a/Simulation/Core/BGDriver.cpp
+++ b/Simulation/Core/BGDriver.cpp
@@ -64,47 +64,48 @@ void serializeSynapses();
  *  @return -1 if error, else if success.
  */
 int main(int argc, char *argv[]) {
-   // Clear logging file at the start of each simulation
+   // Clear logging files at the start of each simulation
    fstream("Output/Debug/logging.txt", ios::out | ios::trunc);
+   fstream("Output/Debug/neurons.txt", ios::out | ios::trunc);
 
    // Initialize log4cplus and set properties based on configure file
    ::log4cplus::initialize();
    ::log4cplus::PropertyConfigurator::doConfigure("RuntimeFiles/log4cplus_configure.ini");
 
-   // Get the instance of the main logger and print status
-   log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
-   LOG4CPLUS_TRACE(logger, "Initiating Simulator");
+   // Get the instance of the console logger and print status
+   log4cplus::Logger consoleLogger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
+   LOG4CPLUS_TRACE(consoleLogger, "Initiating Simulator");
 
    Simulator &simulator = Simulator::getInstance();
 
    // Handles parsing of the command line.
-   LOG4CPLUS_TRACE(logger, "Parsing command line");
+   LOG4CPLUS_TRACE(consoleLogger, "Parsing command line");
    if (!parseCommandLine(argc, argv)) {
-      LOG4CPLUS_FATAL(logger, "ERROR: failed during command line parse");
+      LOG4CPLUS_FATAL(consoleLogger, "ERROR: failed during command line parse");
       return -1;
    }
 
    // Loads the configuration file into the Parameter Manager.
    if (!ParameterManager::getInstance().loadParameterFile(simulator.getConfigFileName())) {
-      LOG4CPLUS_FATAL(logger, "ERROR: failed to load config file: " << simulator.getConfigFileName());
+      LOG4CPLUS_FATAL(consoleLogger, "ERROR: failed to load config file: " << simulator.getConfigFileName());
       return -1;
    }
 
    // Read in simulator specific parameters from configuration file.
-   LOG4CPLUS_TRACE(logger, "Loading Simulator parameters");
+   LOG4CPLUS_TRACE(consoleLogger, "Loading Simulator parameters");
    simulator.loadParameters();
 
    // Instantiate simulator objects.
-   LOG4CPLUS_TRACE(logger, "Insantiating Simulator objects specified in configuration file");
+   LOG4CPLUS_TRACE(consoleLogger, "Insantiating Simulator objects specified in configuration file");
    if (!simulator.instantiateSimulatorObjects()) {
-      LOG4CPLUS_FATAL(logger, "ERROR: Unable to instantiate all simulator classes, check configuration file: "
-                              + simulator.getConfigFileName()
-                              + " for incorrectly declared class types.");
+      LOG4CPLUS_FATAL(consoleLogger, "ERROR: Unable to instantiate all simulator classes, check configuration file: "
+                                     + simulator.getConfigFileName()
+                                     + " for incorrectly declared class types.");
       return -1;
    }
 
    // Invoke instantiated simulator objects to load parameters from the configuration file
-   LOG4CPLUS_TRACE(logger, "Loading parameters from configuration file");
+   LOG4CPLUS_TRACE(consoleLogger, "Loading parameters from configuration file");
    OperationManager::getInstance().executeOperation(Operations::loadParameters);
 
    time_t start_time, end_time;
@@ -112,7 +113,7 @@ int main(int argc, char *argv[]) {
 
    // in chain of responsibility. still going to exist!
    // setup simulation
-   LOG4CPLUS_TRACE(logger, "Performing Simulator setup");
+   LOG4CPLUS_TRACE(consoleLogger, "Performing Simulator setup");
    simulator.setup();
 
    // Invoke instantiated simulator objects to print parameters, used for testing purposes only.
@@ -120,17 +121,17 @@ int main(int argc, char *argv[]) {
 
    // Deserializes internal state from a prior run of the simulation
    if (!simulator.getSerializationFileName().empty()) {
-      LOG4CPLUS_TRACE(logger, "Deserializing state from file.");
+      LOG4CPLUS_TRACE(consoleLogger, "Deserializing state from file.");
 
       // Deserialization
       if (!deserializeSynapses()) {
-         LOG4CPLUS_FATAL(logger, "Failed while deserializing objects");
+         LOG4CPLUS_FATAL(consoleLogger, "Failed while deserializing objects");
          return -1;
       }
    }
 
    // Run simulation
-   LOG4CPLUS_TRACE(logger, "Starting Simulation");
+   LOG4CPLUS_TRACE(consoleLogger, "Starting Simulation");
    simulator.simulate();
 
    // INPUT OBJECTS ARENT IN PROJECT YET
@@ -143,18 +144,18 @@ int main(int argc, char *argv[]) {
 
    // todo: before this, do copy from gpu.
    // Writes simulation results to an output destination
-   LOG4CPLUS_TRACE(logger, "Simulation ended, saving results");
+   LOG4CPLUS_TRACE(consoleLogger, "Simulation ended, saving results");
    simulator.saveData();
 
    // todo: going to be moved with the "hack"
    // Serializes internal state for the current simulation
    if (!simulator.getSerializationFileName().empty()) {
-      LOG4CPLUS_TRACE(logger, "Serializing current state");
+      LOG4CPLUS_TRACE(consoleLogger, "Serializing current state");
       serializeSynapses();
    }
 
    // Tell simulation to clean-up and run any post-simulation logic.
-   LOG4CPLUS_TRACE(logger, "Simulation finished");
+   LOG4CPLUS_TRACE(consoleLogger, "Simulation finished");
    simulator.finish();
 
    // terminates the simulation recorder

--- a/Simulation/Core/CPUSpikingModel.cpp
+++ b/Simulation/Core/CPUSpikingModel.cpp
@@ -42,12 +42,12 @@ void CPUSpikingModel::updateConnections() {
 
 /// Copy GPU Synapse data to CPU. (Inheritance, no implem)
 void CPUSpikingModel::copyGPUtoCPU() {
-   cerr << "ERROR: CPUSpikingModel::copyGPUtoCPU() was called." << endl;
+   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUSpikingModel::copyGPUtoCPU() was called." << endl);
    exit(EXIT_FAILURE);
 }
 
 /// Copy CPU Synapse data to GPU. (Inheritance, no implem, GPUModel has implem)
 void CPUSpikingModel::copyCPUtoGPU() {
-   cerr << "ERROR: CPUSpikingModel::copyCPUtoGPU() was called." << endl;
+   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUSpikingModel::copyCPUtoGPU() was called." << endl);
    exit(EXIT_FAILURE);
 }

--- a/Simulation/Core/Model.cpp
+++ b/Simulation/Core/Model.cpp
@@ -24,15 +24,17 @@ Model::Model() {
    ParameterManager::getInstance().getStringByXpath("//RecorderParams/@class", type);
    recorder_ = RecorderFactory::getInstance()->createRecorder(type);
    recorder_->init();
+
+   // Get a copy of the file logger to use log4cplus macros
+   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
-/// Destructor todo: this will change
+/// Destructor
 Model::~Model() {
 
 }
 
 /// Save simulation results to an output destination.
-// todo: recorder should be under model if not layout or connections
 void Model::saveData() {
    if (recorder_ != NULL) {
       recorder_->saveSimData(*layout_->getNeurons());
@@ -42,34 +44,27 @@ void Model::saveData() {
 /// Creates all the Neurons and generates data for them.
 // todo: this is going to go away
 void Model::createAllNeurons() {
-   DEBUG(cerr << "\nAllocating neurons..." << endl;)
+   LOG4CPLUS_INFO(fileLogger_, "Allocating Neurons..." );
 
    layout_->generateNeuronTypeMap(Simulator::getInstance().getTotalNeurons());
    layout_->initStarterMap(Simulator::getInstance().getTotalNeurons());
 
    // set their specific types
-   // todo: neurons_
    layout_->getNeurons()->createAllNeurons(layout_.get());
-
-   DEBUG(cerr << "Done initializing neurons..." << endl;)
 }
 
 /// Sets up the Simulation.
-/// ToDo: find siminfo actual things being passed through
-// todo: to be setup: tell layouts and connections to setup. will setup neurons/synapses.
-// todo: setup recorders.
 void Model::setupSim() {
-   DEBUG(cerr << "\tSetting up neurons....";)
+   LOG4CPLUS_INFO(fileLogger_, "Setting up Neurons...");
    layout_->getNeurons()->setupNeurons();
-   DEBUG(cerr << "done.\n\tSetting up synapses....";)
+   LOG4CPLUS_INFO(fileLogger_, "Setting up Synapses...");
    conns_->getSynapses()->setupSynapses();
 #ifdef PERFORMANCE_METRICS
    // Start timer for initialization
    Simulator::getInstance.short_timer.start();
 #endif
-   DEBUG(cerr << "done.\n\tSetting up layout....";)
+   LOG4CPLUS_INFO(fileLogger_, "Setting up Layout...");
    layout_->setupLayout();
-   DEBUG(cerr << "done." << endl;)
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (layout)
    t_host_initialization_layout += Simulator::getInstance().short_timer.lap() / 1000000.0;
@@ -86,6 +81,7 @@ void Model::setupSim() {
    // Start timer for initialization
    Simulator::getInstance().short_timer.start();
 #endif
+   LOG4CPLUS_INFO(fileLogger_, "Setting up Connections...");
    conns_->setupConnections(layout_.get(), layout_->getNeurons().get(), conns_->getSynapses().get());
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (connections)
@@ -93,6 +89,7 @@ void Model::setupSim() {
 #endif
 
    // create a synapse index map
+   LOG4CPLUS_INFO(fileLogger_, "Creating SynapseIndexMap...");
    conns_->createSynapseIndexMap();
 }
 

--- a/Simulation/Core/Model.h
+++ b/Simulation/Core/Model.h
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include <log4cplus/loggingmacros.h>
+
 #include "Layout.h"
 #include "IAllNeurons.h"
 #include "IRecorder.h"
@@ -93,6 +95,8 @@ protected:
    shared_ptr<IRecorder> recorder_;
 
    // shared_ptr<ISInput> input_;    /// Stimulus input object.
+
+   log4cplus::Logger fileLogger_;
 
    // ToDo: Find a good place for this method. Makes sense to put it in Layout
    void createAllNeurons(); /// Populate an instance of IAllNeurons with an initial state for each neuron.

--- a/Simulation/Core/OperationManager.cpp
+++ b/Simulation/Core/OperationManager.cpp
@@ -40,7 +40,7 @@ void OperationManager::registerOperation(const Operations::op &operation, functi
 
 /// Takes in a operation type and invokes all registered functions that are classified as that operation type.
 void OperationManager::executeOperation(const Operations::op &operation) const {
-   LOG4CPLUS_DEBUG(logger_, "Executing operation " + operationToString(operation));
+   LOG4CPLUS_INFO(logger_, "Executing operation " + operationToString(operation));
    if (functionList_.size() > 0) {
       for (auto i = functionList_.begin(); i != functionList_.end(); ++i) {
          (*i)->invokeFunction(operation);

--- a/Simulation/Core/OperationManager.h
+++ b/Simulation/Core/OperationManager.h
@@ -48,7 +48,7 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    OperationManager() {
       // Set logger_ to a reference to the rootLogger
-      logger_ = (log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("rootLogger")));
+      logger_ = (log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file")));
    }
 
    /// LinkedLists of functions based on operation type.

--- a/Simulation/Core/Simulator.h
+++ b/Simulation/Core/Simulator.h
@@ -13,6 +13,8 @@
 
 #include <memory>
 
+#include <log4cplus/loggingmacros.h>
+
 #include "BGTypes.h"
 #include "Global.h"
 #include "Core/Model.h"
@@ -40,7 +42,7 @@ public:
 
    void loadParameters(); /// Load member variables from configuration file
 
-   void printParameters() const; /// Prints out loaded parameters to console.
+   void printParameters() const; /// Prints loaded parameters to logging file.
 
    void copyGPUSynapseToCPU(); /// Copy GPU Synapse data to CPU.
 
@@ -171,6 +173,9 @@ private:
    string stimulusFileName_;    /// File name of the stimulus input file.
 
    shared_ptr<Model> model_;  /// Smart pointer to model class (Model is an interface class)
+
+   log4cplus::Logger consoleLogger_; /// Logger for printing to the console as well as the logging file
+   log4cplus::Logger fileLogger_; /// Logger for printing to the logging file
 
 #ifdef PERFORMANCE_METRICS
    Timer timer;   /// Timer for measuring performance of an epoch.

--- a/Simulation/Edges/AllDSSynapses.cpp
+++ b/Simulation/Edges/AllDSSynapses.cpp
@@ -9,9 +9,9 @@ AllDSSynapses::AllDSSynapses() : AllSpikingSynapses() {
    F_ = NULL;
 }
 
-AllDSSynapses::AllDSSynapses(const int num_neurons, const int max_synapses) :
-      AllSpikingSynapses(num_neurons, max_synapses) {
-   setupSynapses(num_neurons, max_synapses);
+AllDSSynapses::AllDSSynapses(const int numNeurons, const int maxSynapses) :
+      AllSpikingSynapses(numNeurons, maxSynapses) {
+   setupSynapses(numNeurons, maxSynapses);
 }
 
 AllDSSynapses::~AllDSSynapses() {
@@ -21,7 +21,6 @@ AllDSSynapses::~AllDSSynapses() {
 /*
  *  Setup the internal structure of the class (allocate memories and initialize them).
  *
- *  @param  sim_info  SimulationInfo class to read information from.
  */
 void AllDSSynapses::setupSynapses() {
    setupSynapses(Simulator::getInstance().getTotalNeurons(), Simulator::getInstance().getMaxSynapsesPerNeuron());
@@ -30,21 +29,21 @@ void AllDSSynapses::setupSynapses() {
 /*
  *  Setup the internal structure of the class (allocate memories and initialize them).
  *
- *  @param  num_neurons   Total number of neurons in the network.
- *  @param  max_synapses  Maximum number of synapses per neuron.
+ *  @param  numNeurons   Total number of neurons in the network.
+ *  @param  maxSynapses  Maximum number of synapses per neuron.
  */
-void AllDSSynapses::setupSynapses(const int num_neurons, const int max_synapses) {
-   AllSpikingSynapses::setupSynapses(num_neurons, max_synapses);
+void AllDSSynapses::setupSynapses(const int numNeurons, const int maxSynapses) {
+   AllSpikingSynapses::setupSynapses(numNeurons, maxSynapses);
 
-   BGSIZE max_total_synapses = max_synapses * num_neurons;
+   BGSIZE maxTotalSynapses = maxSynapses * numNeurons;
 
-   if (max_total_synapses != 0) {
-      lastSpike_ = new uint64_t[max_total_synapses];
-      r_ = new BGFLOAT[max_total_synapses];
-      u_ = new BGFLOAT[max_total_synapses];
-      D_ = new BGFLOAT[max_total_synapses];
-      U_ = new BGFLOAT[max_total_synapses];
-      F_ = new BGFLOAT[max_total_synapses];
+   if (maxTotalSynapses != 0) {
+      lastSpike_ = new uint64_t[maxTotalSynapses];
+      r_ = new BGFLOAT[maxTotalSynapses];
+      u_ = new BGFLOAT[maxTotalSynapses];
+      D_ = new BGFLOAT[maxTotalSynapses];
+      U_ = new BGFLOAT[maxTotalSynapses];
+      F_ = new BGFLOAT[maxTotalSynapses];
    }
 }
 
@@ -52,9 +51,9 @@ void AllDSSynapses::setupSynapses(const int num_neurons, const int max_synapses)
  *  Cleanup the class (deallocate memories).
  */
 void AllDSSynapses::cleanupSynapses() {
-   BGSIZE max_total_synapses = maxSynapsesPerNeuron_ * countNeurons_;
+   BGSIZE maxTotalSynapses = maxSynapsesPerNeuron_ * countNeurons_;
 
-   if (max_total_synapses != 0) {
+   if (maxTotalSynapses != 0) {
       delete[] lastSpike_;
       delete[] r_;
       delete[] u_;
@@ -73,13 +72,15 @@ void AllDSSynapses::cleanupSynapses() {
    AllSpikingSynapses::cleanupSynapses();
 }
 
-/*
- *  Prints out all parameters of the neurons to console.
+/**
+ *  Prints out all parameters to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void AllDSSynapses::printParameters() const {
    AllSpikingSynapses::printParameters();
-   cout << "\t*AllDSSynapses Parameters*" << endl;
-   cout << "\tEdges type: AllDSSynapses" << endl << endl;
+
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDSSynapses Parameters---" << endl
+                                          << "\tEdges type: AllDSSynapses" << endl << endl);
 }
 
 /*
@@ -140,17 +141,16 @@ void AllDSSynapses::resetSynapse(const BGSIZE iSyn, const BGFLOAT deltaT) {
 /*
  *  Create a Synapse and connect it to the model.
  *
- *  @param  synapses    The synapse list to reference.
  *  @param  iSyn        Index of the synapse to set.
- *  @param  source      Coordinates of the source Neuron.
- *  @param  dest        Coordinates of the destination Neuron.
- *  @param  sum_point   Summation point address.
+ *  @param  srcNeuron      Coordinates of the source Neuron.
+ *  @param  destNeuron        Coordinates of the destination Neuron.
+ *  @param  sumPoint   Summation point address.
  *  @param  deltaT      Inner simulation step duration.
  *  @param  type        Type of the Synapse to create.
  */
-void AllDSSynapses::createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sum_point,
+void AllDSSynapses::createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint,
                                   const BGFLOAT deltaT, synapseType type) {
-   AllSpikingSynapses::createSynapse(iSyn, source_index, dest_index, sum_point, deltaT, type);
+   AllSpikingSynapses::createSynapse(iSyn, srcNeuron, destNeuron, sumPoint, deltaT, type);
 
    U_[iSyn] = DEFAULT_U;
 
@@ -220,7 +220,7 @@ void AllDSSynapses::changePSR(const BGSIZE iSyn, const BGFLOAT deltaT) {
 #endif // !defined(USE_GPU)
 
 /*
- *  Prints SynapsesProps data.
+ *  Prints SynapsesProps data to console.
  */
 void AllDSSynapses::printSynapsesProps() const {
    AllSpikingSynapses::printSynapsesProps();

--- a/Simulation/Edges/AllDSSynapses.h
+++ b/Simulation/Edges/AllDSSynapses.h
@@ -66,7 +66,7 @@ class AllDSSynapses : public AllSpikingSynapses {
 public:
    AllDSSynapses();
 
-   AllDSSynapses(const int num_neurons, const int max_synapses);
+   AllDSSynapses(const int numNeurons, const int maxSynapses);
 
    virtual ~AllDSSynapses();
 
@@ -74,8 +74,6 @@ public:
 
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses();
 
@@ -93,26 +91,26 @@ public:
    virtual void resetSynapse(const BGSIZE iSyn, const BGFLOAT deltaT);
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
-    *  @param  source      Coordinates of the source Neuron.
-    *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron     Coordinates of the source Neuron.
+    *  @param  destNeuron        Coordinates of the destination Neuron.
+    *  @param  sumPoint   Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type);
 
    /**
-    *  Prints SynapsesProps data.
+    *  Prints SynapsesProps data to console.
     */
    virtual void printSynapsesProps() const;
 
@@ -120,10 +118,10 @@ protected:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  num_neurons   Total number of neurons in the network.
-    *  @param  max_synapses  Maximum number of synapses per neuron.
+    *  @param  numNeurons   Total number of neurons in the network.
+    *  @param  maxSynapses  Maximum number of synapses per neuron.
     */
-   virtual void setupSynapses(const int num_neurons, const int max_synapses);
+   virtual void setupSynapses(const int numNeurons, const int maxSynapses);
 
    /**
     *  Sets the data for Synapse to input's data.
@@ -148,25 +146,23 @@ protected:
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice);
 
        /**
         *  Allocate GPU memories to store all synapses' states,
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron);
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
        virtual void deleteSynapseDeviceStruct( void* allSynapsesDevice );
 
@@ -174,26 +170,24 @@ protected:
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice );
 
        /**
         *  Copy all synapses' data from host to device.
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Copy all synapses' data from device to host.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseDeviceToHost( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseDeviceToHost( void* allSynapsesDevice);
 
        /**
         *  Set synapse class ID defined by enumClassSynapses for the caller's Synapse class.
@@ -220,11 +214,11 @@ protected:
         *  and copy them from host to GPU memory.
         *  (Helper function of allocSynapseDeviceStruct)
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void allocDeviceStruct( AllDSSynapsesDeviceProperties &allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void allocDeviceStruct( AllDSSynapsesDeviceProperties &allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Delete GPU memories.
@@ -238,21 +232,19 @@ protected:
         *  Copy all synapses' data from host to device.
         *  (Helper function of copySynapseHostToDevice)
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void copyHostToDevice( void* allSynapsesDevice, AllDSSynapsesDeviceProperties& allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void copyHostToDevice( void* allSynapsesDevice, AllDSSynapsesDeviceProperties& allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Copy all synapses' data from device to host.
         *  (Helper function of copySynapseDeviceToHost)
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
-        *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
+        *  @param  allSynapses  Reference to the allSynapses struct on device memory.
         */
-       void copyDeviceToHost( AllDSSynapsesDeviceProperties& allSynapses, const SimulationInfo *sim_info );
+       void copyDeviceToHost( AllDSSynapsesDeviceProperties& allSynapses);
 #else // !defined(USE_GPU)
 protected:
    /**

--- a/Simulation/Edges/AllDynamicSTDPSynapses.cpp
+++ b/Simulation/Edges/AllDynamicSTDPSynapses.cpp
@@ -9,9 +9,9 @@ AllDynamicSTDPSynapses::AllDynamicSTDPSynapses() : AllSTDPSynapses() {
     F_ = NULL;
 }
 
-AllDynamicSTDPSynapses::AllDynamicSTDPSynapses(const int num_neurons, const int max_synapses) :
-      AllSTDPSynapses(num_neurons, max_synapses) {
-    setupSynapses(num_neurons, max_synapses);
+AllDynamicSTDPSynapses::AllDynamicSTDPSynapses(const int numNeurons, const int maxSynapses) :
+      AllSTDPSynapses(numNeurons, maxSynapses) {
+    setupSynapses(numNeurons, maxSynapses);
 }
 
 AllDynamicSTDPSynapses::~AllDynamicSTDPSynapses() {
@@ -20,8 +20,6 @@ AllDynamicSTDPSynapses::~AllDynamicSTDPSynapses() {
 
 /*
  *  Setup the internal structure of the class (allocate memories and initialize them).
- *
- *  @param  sim_info  SimulationInfo class to read information from.
  */
 void AllDynamicSTDPSynapses::setupSynapses() {
     setupSynapses(Simulator::getInstance().getDeltaT(), Simulator::getInstance().getMaxSynapsesPerNeuron());
@@ -30,21 +28,21 @@ void AllDynamicSTDPSynapses::setupSynapses() {
 /*
  *  Setup the internal structure of the class (allocate memories and initialize them).
  * 
- *  @param  num_neurons   Total number of neurons in the network.
- *  @param  max_synapses  Maximum number of synapses per neuron.
+ *  @param  numNeurons   Total number of neurons in the network.
+ *  @param  maxSynapses  Maximum number of synapses per neuron.
  */
-void AllDynamicSTDPSynapses::setupSynapses(const int num_neurons, const int max_synapses) {
-    AllSTDPSynapses::setupSynapses(num_neurons, max_synapses);
+void AllDynamicSTDPSynapses::setupSynapses(const int numNeurons, const int maxSynapses) {
+    AllSTDPSynapses::setupSynapses(numNeurons, maxSynapses);
 
-    BGSIZE max_total_synapses = max_synapses * num_neurons;
+    BGSIZE maxTotalSynapses = maxSynapses * numNeurons;
 
-    if (max_total_synapses != 0) {
-        lastSpike_ = new uint64_t[max_total_synapses];
-        r_ = new BGFLOAT[max_total_synapses];
-        u_ = new BGFLOAT[max_total_synapses];
-        D_ = new BGFLOAT[max_total_synapses];
-        U_ = new BGFLOAT[max_total_synapses];
-        F_ = new BGFLOAT[max_total_synapses];
+    if (maxTotalSynapses != 0) {
+        lastSpike_ = new uint64_t[maxTotalSynapses];
+        r_ = new BGFLOAT[maxTotalSynapses];
+        u_ = new BGFLOAT[maxTotalSynapses];
+        D_ = new BGFLOAT[maxTotalSynapses];
+        U_ = new BGFLOAT[maxTotalSynapses];
+        F_ = new BGFLOAT[maxTotalSynapses];
     }
 }
 
@@ -52,9 +50,9 @@ void AllDynamicSTDPSynapses::setupSynapses(const int num_neurons, const int max_
  *  Cleanup the class (deallocate memories).
  */
 void AllDynamicSTDPSynapses::cleanupSynapses() {
-    BGSIZE max_total_synapses = maxSynapsesPerNeuron_ * countNeurons_;
+    BGSIZE maxTotalSynapses = maxSynapsesPerNeuron_ * countNeurons_;
 
-    if (max_total_synapses != 0) {
+    if (maxTotalSynapses != 0) {
         delete[] lastSpike_;
         delete[] r_;
         delete[] u_;
@@ -73,14 +71,15 @@ void AllDynamicSTDPSynapses::cleanupSynapses() {
     AllSTDPSynapses::cleanupSynapses();
 }
 
-/*
- *  Prints out all parameters of the neurons to console.
+/**
+ *  Prints out all parameters to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void AllDynamicSTDPSynapses::printParameters() const {
    AllSTDPSynapses::printParameters();
 
-   cout << "\t*AllDynamicSTDPSynapses Parameters*" << endl;
-   cout << "\tEdges type: AllDynamicSTDPSynapses" << endl << endl;
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDynamicSTDPSynapses Parameters---" << endl
+   << "\tEdges type: AllDynamicSTDPSynapses" << endl << endl);
 }
 
 /*
@@ -141,17 +140,16 @@ void AllDynamicSTDPSynapses::resetSynapse(const BGSIZE iSyn, const BGFLOAT delta
 /*
  *  Create a Synapse and connect it to the model.
  *
- *  @param  synapses    The synapse list to reference.
  *  @param  iSyn        Index of the synapse to set.
- *  @param  source      Coordinates of the source Neuron.
- *  @param  dest        Coordinates of the destination Neuron.
- *  @param  sum_point   Summation point address.
+ *  @param  srcNeuron   Coordinates of the source Neuron.
+ *  @param  destNeuron  Coordinates of the destination Neuron.
+ *  @param  sumPoint    Summation point address.
  *  @param  deltaT      Inner simulation step duration.
  *  @param  type        Type of the Synapse to create.
  */
-void AllDynamicSTDPSynapses::createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sum_point,
+void AllDynamicSTDPSynapses::createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint,
                                            const BGFLOAT deltaT, synapseType type) {
-    AllSTDPSynapses::createSynapse(iSyn, source_index, dest_index, sum_point, deltaT, type);
+    AllSTDPSynapses::createSynapse(iSyn, srcNeuron, destNeuron, sumPoint, deltaT, type);
 
     U_[iSyn] = DEFAULT_U;
 

--- a/Simulation/Edges/AllDynamicSTDPSynapses.h
+++ b/Simulation/Edges/AllDynamicSTDPSynapses.h
@@ -81,7 +81,7 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 public:
    AllDynamicSTDPSynapses();
 
-   AllDynamicSTDPSynapses(const int num_neurons, const int max_synapses);
+   AllDynamicSTDPSynapses(const int numNeurons, const int maxSynapses);
 
    virtual ~AllDynamicSTDPSynapses();
 
@@ -89,8 +89,6 @@ public:
 
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses();
 
@@ -108,22 +106,22 @@ public:
    virtual void resetSynapse(const BGSIZE iSyn, const BGFLOAT deltaT);
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
-    *  @param  source      Coordinates of the source Neuron.
-    *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron   Coordinates of the source Neuron.
+    *  @param  destNeuron  Coordinates of the destination Neuron.
+    *  @param  sumPoint    Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type);
 
    /**
@@ -135,10 +133,10 @@ protected:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  num_neurons   Total number of neurons in the network.
-    *  @param  max_synapses  Maximum number of synapses per neuron.
+    *  @param  numNeurons   Total number of neurons in the network.
+    *  @param  maxSynapses  Maximum number of synapses per neuron.
     */
-   virtual void setupSynapses(const int num_neurons, const int max_synapses);
+   virtual void setupSynapses(const int numNeurons, const int maxSynapses);
 
    /**
     *  Sets the data for Synapse to input's data.

--- a/Simulation/Edges/AllSTDPSynapses.h
+++ b/Simulation/Edges/AllSTDPSynapses.h
@@ -91,7 +91,7 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 public:
    AllSTDPSynapses();
 
-   AllSTDPSynapses(const int num_neurons, const int max_synapses);
+   AllSTDPSynapses(const int numNeurons, const int maxSynapses);
 
    virtual ~AllSTDPSynapses();
 
@@ -99,8 +99,6 @@ public:
 
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses();
 
@@ -126,22 +124,22 @@ public:
    virtual bool allowBackPropagation();
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
-    *  @param  source      Coordinates of the source Neuron.
-    *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron   Coordinates of the source Neuron.
+    *  @param  destNeuron  Coordinates of the destination Neuron.
+    *  @param  sumPoint    Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type);
 
    /**
@@ -153,10 +151,10 @@ protected:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  num_neurons   Total number of neurons in the network.
-    *  @param  max_synapses  Maximum number of synapses per neuron.
+    *  @param  numNeurons   Total number of neurons in the network.
+    *  @param  maxSynapses  Maximum number of synapses per neuron.
     */
-   virtual void setupSynapses(const int num_neurons, const int max_synapses);
+   virtual void setupSynapses(const int numNeurons, const int maxSynapses);
 
    /**
     *  Sets the data for Synapse to input's data.
@@ -188,25 +186,23 @@ protected:
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice);
 
        /**
         *  Allocate GPU memories to store all synapses' states,
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron);
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
        virtual void deleteSynapseDeviceStruct( void* allSynapsesDevice );
 
@@ -214,26 +210,24 @@ protected:
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice);
 
        /**
         *  Copy all synapses' data from host to device.
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Copy all synapses' data from device to host.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseDeviceToHost( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseDeviceToHost( void* allSynapsesDevice);
 
        /**
         *  Advance all the Synapses in the simulation.
@@ -242,9 +236,8 @@ protected:
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
-        *  @param  sim_info               SimulationInfo class to read information from.
         */
-       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice, const SimulationInfo *sim_info);
+       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice);
 
        /**
         *  Set synapse class ID defined by enumClassSynapses for the caller's Synapse class.
@@ -272,10 +265,10 @@ protected:
         *  (Helper function of allocSynapseDeviceStruct)
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons           Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void allocDeviceStruct( AllSTDPSynapsesDeviceProperties &allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void allocDeviceStruct( AllSTDPSynapsesDeviceProperties &allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Delete GPU memories.
@@ -289,21 +282,21 @@ protected:
         *  Copy all synapses' data from host to device.
         *  (Helper function of copySynapseHostToDevice)
         *
-        *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  allSynapsesDevice    Reference to the allSynapses struct on device memory.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void copyHostToDevice( void* allSynapsesDevice, AllSTDPSynapsesDeviceProperties& allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void copyHostToDevice( void* allSynapsesDevice, AllSTDPSynapsesDeviceProperties& allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Copy all synapses' data from device to host.
         *  (Helper function of copySynapseDeviceToHost)
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons           Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void copyDeviceToHost( AllSTDPSynapsesDeviceProperties& allSynapses, const SimulationInfo *sim_info );
+       void copyDeviceToHost( AllSTDPSynapsesDeviceProperties& allSynapses);
 #else // !defined(USE_GPU)
 public:
    /**
@@ -311,7 +304,6 @@ public:
     *  Update the state of synapse for a time step
     *
     *  @param  iSyn      Index of the Synapse to connect to.
-    *  @param  sim_info  SimulationInfo class to read information from.
     *  @param  neurons   The Neuron list to search from.
     */
    virtual void advanceSynapse(const BGSIZE iSyn, IAllNeurons *neurons);

--- a/Simulation/Edges/AllSpikingSynapses.h
+++ b/Simulation/Edges/AllSpikingSynapses.h
@@ -49,7 +49,7 @@ class AllSpikingSynapses : public AllSynapses {
 public:
    AllSpikingSynapses();
 
-   AllSpikingSynapses(const int num_neurons, const int max_synapses);
+   AllSpikingSynapses(const int numNeurons, const int maxSynapses);
 
    virtual ~AllSpikingSynapses();
 
@@ -59,8 +59,6 @@ public:
 
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses();
 
@@ -78,34 +76,34 @@ public:
    virtual void resetSynapse(const BGSIZE iSyn, const BGFLOAT deltaT);
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
-    *  @param  source      Coordinates of the source Neuron.
-    *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron   Coordinates of the source Neuron.
+    *  @param  destNeuron  Coordinates of the destination Neuron.
+    *  @param  sumPoint    Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type);
 
    /**
     *  Check if the back propagation (notify a spike event to the pre neuron)
     *  is allowed in the synapse class.
     *
-    *  @retrun true if the back propagation is allowed.
+    *  @return true if the back propagation is allowed.
     */
    virtual bool allowBackPropagation();
 
    /**
-    *  Prints SynapsesProps data.
+    *  Prints SynapsesProps data to console.
     */
    virtual void printSynapsesProps() const;
 
@@ -113,10 +111,10 @@ protected:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  num_neurons   Total number of neurons in the network.
-    *  @param  max_synapses  Maximum number of synapses per neuron.
+    *  @param  numNeurons   Total number of neurons in the network.
+    *  @param  maxSynapses  Maximum number of synapses per neuron.
     */
-   virtual void setupSynapses(const int num_neurons, const int max_synapses);
+   virtual void setupSynapses(const int numNeurons, const int maxSynapses);
 
    /**
     *  Initializes the queues for the Synapse.
@@ -157,25 +155,23 @@ protected:
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice);
 
        /**
         *  Allocate GPU memories to store all synapses' states,
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
        virtual void deleteSynapseDeviceStruct( void* allSynapsesDevice );
 
@@ -183,41 +179,37 @@ protected:
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice);
 
        /**
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons           Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron );
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron );
        /**
         *  Copy all synapses' data from device to host.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseDeviceToHost( void* allSynapsesDevice, const SimulationInfo *sim_info );
+       virtual void copySynapseDeviceToHost( void* allSynapsesDevice);
 
        /**
         *  Get synapse_counts in AllSynapses struct on device memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyDeviceSynapseCountsToHost(void* allSynapsesDevice, const SimulationInfo *sim_info);
+       virtual void copyDeviceSynapseCountsToHost(void* allSynapsesDevice);
 
        /**
         *  Get summationCoord and in_use in AllSynapses struct on device memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyDeviceSynapseSumIdxToHost(void* allSynapsesDevice, const SimulationInfo *sim_info);
+       virtual void copyDeviceSynapseSumIdxToHost(void* allSynapsesDevice);
 
        /**
         *  Advance all the Synapses in the simulation.
@@ -226,9 +218,8 @@ protected:
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
-        *  @param  sim_info               SimulationInfo class to read information from.
         */
-       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice, const SimulationInfo *sim_info);
+       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice);
 
        /**
         *  Set some parameters used for advanceSynapsesDevice.
@@ -262,10 +253,10 @@ protected:
         *  (Helper function of allocSynapseDeviceStruct)
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void allocDeviceStruct( AllSpikingSynapsesDeviceProperties &allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void allocDeviceStruct( AllSpikingSynapsesDeviceProperties &allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Delete GPU memories.
@@ -280,27 +271,26 @@ protected:
         *  (Helper function of copySynapseHostToDevice)
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void copyHostToDevice( void* allSynapsesDevice, AllSpikingSynapsesDeviceProperties& allSynapses, int num_neurons, int maxSynapsesPerNeuron );
+       void copyHostToDevice( void* allSynapsesDevice, AllSpikingSynapsesDeviceProperties& allSynapses, int numNeurons, int maxSynapsesPerNeuron );
 
        /**
         *  Copy all synapses' data from device to host.
         *  (Helper function of copySynapseDeviceToHost)
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons            Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       void copyDeviceToHost( AllSpikingSynapsesDeviceProperties& allSynapses, const SimulationInfo *sim_info );
+       void copyDeviceToHost( AllSpikingSynapsesDeviceProperties& allSynapses);
 #else  // !defined(USE_GPU)
 public:
    /**
     *  Advance one specific Synapse.
     *
     *  @param  iSyn      Index of the Synapse to connect to.
-    *  @param  sim_info  SimulationInfo class to read information from.
     *  @param  neurons   The Neuron list to search from.
     */
    virtual void advanceSynapse(const BGSIZE iSyn, IAllNeurons *neurons);

--- a/Simulation/Edges/AllSynapses.h
+++ b/Simulation/Edges/AllSynapses.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <log4cplus/loggingmacros.h>
+
 #include "Global.h"
 #include "Core/Simulator.h"
 #include "IAllSynapses.h"
@@ -58,14 +60,12 @@ class AllSynapses : public IAllSynapses {
 public:
    AllSynapses();
 
-   AllSynapses(const int num_neurons, const int max_synapses);
+   AllSynapses(const int numNeurons, const int maxSynapses);
 
    virtual ~AllSynapses();
 
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses();
 
@@ -81,7 +81,8 @@ public:
    virtual void loadParameters();
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
@@ -98,34 +99,32 @@ public:
     *
     *  @param  iSyn        Index of the synapse to be added.
     *  @param  type        The type of the Synapse to add.
-    *  @param  src_neuron  The Neuron that sends to this Synapse.
-    *  @param  dest_neuron The Neuron that receives from the Synapse.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron   The Neuron that sends to this Synapse.
+    *  @param  destNeuron  The Neuron that receives from the Synapse.
+    *  @param  sumPoint    Summation point address.
     *  @param  deltaT      Inner simulation step duration
     */
    virtual void
-   addSynapse(BGSIZE &iSyn, synapseType type, const int src_neuron, const int dest_neuron, BGFLOAT *sum_point,
+   addSynapse(BGSIZE &iSyn, synapseType type, const int srcNeuron, const int destNeuron, BGFLOAT *sumPoint,
               const BGFLOAT deltaT);
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
     *  @param  source      Coordinates of the source Neuron.
     *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  sumPoint    Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type) = 0;
 
    /**
-    *  Create a synapse index map.
+    *  Create a synapse index map and returns it .
     *
-    *  @param  synapseIndexMap   Reference to thw pointer to SynapseIndexMap structure.
-    *  @param  sim_info          Pointer to the simulation information.
+    * @return the created SynapseIndexMap
     */
    virtual SynapseIndexMap *createSynapseIndexMap();
 
@@ -138,7 +137,7 @@ public:
    int synSign(const synapseType type);
 
    /**
-    *  Prints SynapsesProps data.
+    *  Prints SynapsesProps data to console.
     */
    virtual void printSynapsesProps() const;
 
@@ -160,10 +159,10 @@ protected:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  num_neurons   Total number of neurons in the network.
-    *  @param  max_synapses  Maximum number of synapses per neuron.
+    *  @param  numNeurons   Total number of neurons in the network.
+    *  @param  maxSynapses  Maximum number of synapses per neuron.
     */
-   virtual void setupSynapses(const int num_neurons, const int max_synapses);
+   virtual void setupSynapses(const int numNeurons, const int maxSynapses);
 
    /**
     *  Sets the data for Synapse to input's data.
@@ -184,10 +183,13 @@ protected:
    /**
     *  Returns an appropriate synapseType object for the given integer.
     *
-    *  @param  type_ordinal    Integer that correspond with a synapseType.
+    *  @param  typeOrdinal    Integer that correspond with a synapseType.
     *  @return the SynapseType that corresponds with the given integer.
     */
-   synapseType synapseOrdinalToType(const int type_ordinal);
+   synapseType synapseOrdinalToType(const int typeOrdinal);
+
+   /// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
+   log4cplus::Logger fileLogger_;
 
 #if !defined(USE_GPU)
 public:
@@ -195,7 +197,6 @@ public:
     *  Advance all the Synapses in the simulation.
     *  Update the state of all synapses for a time step.
     *
-    *  @param  sim_info  SimulationInfo class to read information from.
     *  @param  neurons   The Neuron list to search from.
     *  @param  synapseIndexMap   Pointer to SynapseIndexMap structure.
     */
@@ -204,10 +205,10 @@ public:
    /**
     *  Remove a synapse from the network.
     *
-    *  @param  neuron_index   Index of a neuron to remove from.
+    *  @param  neuronIndex   Index of a neuron to remove from.
     *  @param  iSyn           Index of a synapse to remove.
     */
-   virtual void eraseSynapse(const int neuron_index, const BGSIZE iSyn);
+   virtual void eraseSynapse(const int neuronIndex, const BGSIZE iSyn);
 
 #endif // !defined(USE_GPU)
 public:

--- a/Simulation/Edges/IAllSynapses.h
+++ b/Simulation/Edges/IAllSynapses.h
@@ -12,13 +12,6 @@
 
 class IAllNeurons;
 
-//typedef void (*fpCreateSynapse_t)(void *, const int, const int, int, int, BGFLOAT *, const BGFLOAT, synapseType);
-
-// enumerate all non-abstract synapse classes.
-enum enumClassSynapses {
-   classAllSpikingSynapses, classAllDSSynapses, classAllSTDPSynapses, classAllDynamicSTDPSynapses, undefClassSynapses
-};
-
 class IAllSynapses {
 public:
    virtual ~IAllSynapses() {};
@@ -26,7 +19,6 @@ public:
    /**
     *  Setup the internal structure of the class (allocate memories and initialize them).
     *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupSynapses() = 0;
 
@@ -50,7 +42,8 @@ public:
    virtual void loadParameters() = 0;
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const = 0;
 
@@ -59,34 +52,31 @@ public:
     *
     *  @param  iSyn        Index of the synapse to be added.
     *  @param  type        The type of the Synapse to add.
-    *  @param  src_neuron  The Neuron that sends to this Synapse.
-    *  @param  dest_neuron The Neuron that receives from the Synapse.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron  The Neuron that sends to this Synapse.
+    *  @param  destNeuron The Neuron that receives from the Synapse.
+    *  @param  sumPoint   Summation point address.
     *  @param  deltaT      Inner simulation step duration
     */
    virtual void
-   addSynapse(BGSIZE &iSyn, synapseType type, const int src_neuron, const int dest_neuron, BGFLOAT *sum_point,
+   addSynapse(BGSIZE &iSyn, synapseType type, const int srcNeuron, const int destNeuron, BGFLOAT *sumPoint,
               const BGFLOAT deltaT) = 0;
 
    /**
     *  Create a Synapse and connect it to the model.
     *
-    *  @param  synapses    The synapse list to reference.
     *  @param  iSyn        Index of the synapse to set.
-    *  @param  source      Coordinates of the source Neuron.
-    *  @param  dest        Coordinates of the destination Neuron.
-    *  @param  sum_point   Summation point address.
+    *  @param  srcNeuron      Coordinates of the source Neuron.
+    *  @param  destNeuron        Coordinates of the destination Neuron.
+    *  @param  sumPoint   Summation point address.
     *  @param  deltaT      Inner simulation step duration.
     *  @param  type        Type of the Synapse to create.
     */
-   virtual void createSynapse(const BGSIZE iSyn, int source_index, int dest_index, BGFLOAT *sp, const BGFLOAT deltaT,
+   virtual void createSynapse(const BGSIZE iSyn, int srcNeuron, int destNeuron, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               synapseType type) = 0;
 
    /**
     *  Create a synapse index map.
     *
-    *  @param  synapseIndexMap   Reference to thw pointer to SynapseIndexMap structure.
-    *  @param  sim_info          Pointer to the simulation information.
     */
    virtual SynapseIndexMap *createSynapseIndexMap() = 0;
 
@@ -99,7 +89,7 @@ public:
    virtual int synSign(const synapseType type) = 0;
 
    /**
-    *  Prints SynapsesProps data.
+    *  Prints SynapsesProps data to console.
     */
    virtual void printSynapsesProps() const = 0;
 
@@ -110,7 +100,6 @@ public:
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
        virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, const SimulationInfo *sim_info ) = 0;
 
@@ -119,16 +108,15 @@ public:
         *  and copy them from host to GPU memory.
         *
         *  @param  allSynapsesDevice     Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons           Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron ) = 0;
+       virtual void allocSynapseDeviceStruct( void** allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron ) = 0;
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
        virtual void deleteSynapseDeviceStruct( void* allSynapsesDevice ) = 0;
 
@@ -136,42 +124,38 @@ public:
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, const SimulationInfo *sim_info ) = 0;
+       virtual void copySynapseHostToDevice(void* allSynapsesDevice) = 0;
 
        /**
         *  Copy all synapses' data from host to device.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  num_neurons           Number of neurons.
+        *  @param  numNeurons           Number of neurons.
         *  @param  maxSynapsesPerNeuron  Maximum number of synapses per neuron.
         */
-       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int num_neurons, int maxSynapsesPerNeuron ) = 0;
+       virtual void copySynapseHostToDevice( void* allSynapsesDevice, int numNeurons, int maxSynapsesPerNeuron ) = 0;
 
        /**
         *  Copy all synapses' data from device to host.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copySynapseDeviceToHost( void* allSynapsesDevice, const SimulationInfo *sim_info ) = 0;
+       virtual void copySynapseDeviceToHost( void* allSynapsesDevice) = 0;
 
        /**
         *  Get synapse_counts in AllSynapses struct on device memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyDeviceSynapseCountsToHost(void* allSynapsesDevice, const SimulationInfo *sim_info) = 0;
+       virtual void copyDeviceSynapseCountsToHost(void* allSynapsesDevice) = 0;
 
        /**
         *  Get summationCoord and in_use in AllSynapses struct on device memory.
         *
         *  @param  allSynapsesDevice  Reference to the allSynapses struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyDeviceSynapseSumIdxToHost(void* allSynapsesDevice, const SimulationInfo *sim_info) = 0;
+       virtual void copyDeviceSynapseSumIdxToHost(void* allSynapsesDevice) = 0;
 
        /**
         *  Advance all the Synapses in the simulation.
@@ -180,9 +164,8 @@ public:
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
-        *  @param  sim_info               SimulationInfo class to read information from.
         */
-       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice, const SimulationInfo *sim_info) = 0;
+       virtual void advanceSynapses(void* allSynapsesDevice, void* allNeuronsDevice, void* synapseIndexMapDevice) = 0;
 
        /**
         *  Set some parameters used for advanceSynapsesDevice.
@@ -214,7 +197,6 @@ public:
     *  Advance all the Synapses in the simulation.
     *  Update the state of all synapses for a time step.
     *
-    *  @param  sim_info  SimulationInfo class to read information from.
     *  @param  neurons   The Neuron list to search from.
     *  @param  synapseIndexMap   Pointer to SynapseIndexMap structure.
     */
@@ -224,7 +206,6 @@ public:
     *  Advance one specific Synapse.
     *
     *  @param  iSyn      Index of the Synapse to connect to.
-    *  @param  sim_info  SimulationInfo class to read information from.
     *  @param  neurons   The Neuron list to search from.
     */
    virtual void advanceSynapse(const BGSIZE iSyn, IAllNeurons *neurons) = 0;
@@ -232,10 +213,10 @@ public:
    /**
     *  Remove a synapse from the network.
     *
-    *  @param  neuron_index   Index of a neuron to remove from.
+    *  @param  neuronIndex   Index of a neuron to remove from.
     *  @param  iSyn           Index of a synapse to remove.
     */
-   virtual void eraseSynapse(const int neuron_index, const BGSIZE iSyn) = 0;
+   virtual void eraseSynapse(const int neuronIndex, const BGSIZE iSyn) = 0;
 
 #endif // defined(USE_GPU)
 };

--- a/Simulation/Layouts/DynamicLayout.cpp
+++ b/Simulation/Layouts/DynamicLayout.cpp
@@ -8,85 +8,87 @@ DynamicLayout::DynamicLayout() : Layout() {
 DynamicLayout::~DynamicLayout() {
 }
 
-/*
- *  Prints out all parameters of the layout to console.
+/**
+ *  Prints out all parameters to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void DynamicLayout::printParameters() const {
    Layout::printParameters();
-   cout << "\tLayout type: Dynamic Layout" << endl;
-
-   cout << "\tfrac_EXC:" << m_frac_excitatory_neurons << endl;
-   cout << "\tStarter neurons:" << m_frac_starter_neurons << endl << endl;
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: Dynamic Layout" << endl
+                                       << "\tfrac_EXC:" << m_frac_excitatory_neurons << endl
+                                       << "\tStarter neurons:" << m_frac_starter_neurons << endl << endl);
 }
 
 /*
  *  Creates a randomly ordered distribution with the specified numbers of neuron types.
  *
- *  @param  num_neurons number of the neurons to have in the type map.
+ *  @param  numNeurons number of the neurons to have in the type map.
  */
-void DynamicLayout::generateNeuronTypeMap(int num_neurons) {
-   Layout::generateNeuronTypeMap(num_neurons);
+void DynamicLayout::generateNeuronTypeMap(int numNeurons) {
+   Layout::generateNeuronTypeMap(numNeurons);
 
-   int num_excititory_neurons = (int) (m_frac_excitatory_neurons * num_neurons + 0.5);
-   int num_inhibitory_neurons = num_neurons - num_excititory_neurons;
+   int numExcititoryNeurons = (int) (m_frac_excitatory_neurons * numNeurons + 0.5);
+   int numInhibitoryNeurons = numNeurons - numExcititoryNeurons;
 
-   DEBUG(cout << "Total neurons: " << num_neurons << endl;)
-   DEBUG(cout << "Inhibitory Neurons: " << num_inhibitory_neurons << endl;)
-   DEBUG(cout << "Excitatory Neurons: " << num_excititory_neurons << endl;)
+   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON TYPE MAP" << endl
+                                                    << "\tTotal neurons: " << numNeurons << endl
+                                                    << "\tInhibitory Neurons: " << numInhibitoryNeurons << endl
+                                                    << "\tExcitatory Neurons: " << numExcititoryNeurons << endl);
 
-   DEBUG(cout << endl << "Randomly selecting inhibitory neurons..." << endl;)
+   LOG4CPLUS_INFO(fileLogger_, "Randomly selecting inhibitory neurons...");
 
-   int *rg_inhibitory_layout = new int[num_inhibitory_neurons];
+   int *rgInhibitoryLayout = new int[numInhibitoryNeurons];
 
-   for (int i = 0; i < num_inhibitory_neurons; i++) {
-      rg_inhibitory_layout[i] = i;
+   for (int i = 0; i < numInhibitoryNeurons; i++) {
+      rgInhibitoryLayout[i] = i;
    }
 
-   for (int i = num_inhibitory_neurons; i < num_neurons; i++) {
-      int j = static_cast<int>(rng() * num_neurons);
-      if (j < num_inhibitory_neurons) {
-         rg_inhibitory_layout[j] = i;
+   for (int i = numInhibitoryNeurons; i < numNeurons; i++) {
+      int j = static_cast<int>(rng() * numNeurons);
+      if (j < numInhibitoryNeurons) {
+         rgInhibitoryLayout[j] = i;
       }
    }
 
-   for (int i = 0; i < num_inhibitory_neurons; i++) {
-      neuronTypeMap_[rg_inhibitory_layout[i]] = INH;
+   for (int i = 0; i < numInhibitoryNeurons; i++) {
+      neuronTypeMap_[rgInhibitoryLayout[i]] = INH;
    }
-   delete[] rg_inhibitory_layout;
+   delete[] rgInhibitoryLayout;
 
-   DEBUG(cout << "Done initializing neuron type map" << endl;);
+   LOG4CPLUS_INFO(fileLogger_, "Done initializing neuron type map");
 }
 
 /*
  *  Populates the starter map.
- *  Selects num_endogenously_active_neurons excitory neurons 
+ *  Selects numEndogenouslyActiveNeurons_ excitatory neurons
  *  and converts them into starter neurons.
  *
- *  @param  num_neurons number of neurons to have in the map.
+ *  @param  numNeurons number of neurons to have in the map.
  */
-void DynamicLayout::initStarterMap(const int num_neurons) {
-   Layout::initStarterMap(num_neurons);
+void DynamicLayout::initStarterMap(const int numNeurons) {
+   Layout::initStarterMap(numNeurons);
 
-   numEndogenouslyActiveNeurons_ = (BGSIZE) (m_frac_starter_neurons * num_neurons + 0.5);
-   BGSIZE starters_allocated = 0;
+   numEndogenouslyActiveNeurons_ = (BGSIZE) (m_frac_starter_neurons * numNeurons + 0.5);
+   BGSIZE startersAllocated = 0;
 
-   DEBUG(cout << "\nRandomly initializing starter map\n";);
-   DEBUG(cout << "Total neurons: " << num_neurons << endl;)
-   DEBUG(cout << "Starter neurons: " << numEndogenouslyActiveNeurons_ << endl;)
+   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << endl
+                                                       << "\tTotal Neurons: " << numNeurons << endl
+                                                       << "\tStarter Neurons: " << numEndogenouslyActiveNeurons_
+                                                       << endl);
 
    // randomly set neurons as starters until we've created enough
-   while (starters_allocated < numEndogenouslyActiveNeurons_) {
+   while (startersAllocated < numEndogenouslyActiveNeurons_) {
       // Get a random integer
-      int i = static_cast<int>(rng.inRange(0, num_neurons));
+      int i = static_cast<int>(rng.inRange(0, numNeurons));
 
       // If the neuron at that index is excitatory and a starter map
       // entry does not already exist, add an entry.
       if (neuronTypeMap_[i] == EXC && starterMap_[i] == false) {
          starterMap_[i] = true;
-         starters_allocated++;
-         DEBUG_MID(cout << "allocated EA neuron at random index [" << i << "]" << endl;);
+         startersAllocated++;
+         LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << endl;);
       }
    }
 
-   DEBUG(cout << "Done randomly initializing starter map\n\n";)
+   LOG4CPLUS_INFO(fileLogger_, "Done randomly initializing starter map");
 }

--- a/Simulation/Layouts/DynamicLayout.h
+++ b/Simulation/Layouts/DynamicLayout.h
@@ -34,25 +34,26 @@ public:
    static Layout *Create() { return new DynamicLayout(); }
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Creates a randomly ordered distribution with the specified numbers of neuron types.
     *
-    *  @param  num_neurons number of the neurons to have in the type map.
+    *  @param  numNeurons number of the neurons to have in the type map.
     */
-   virtual void generateNeuronTypeMap(int num_neurons);
+   virtual void generateNeuronTypeMap(int numNeurons);
 
    /**
     *  Populates the starter map.
     *  Selects num_endogenously_active_neurons excitory neurons
     *  and converts them into starter neurons.
     *
-    *  @param  num_neurons number of neurons to have in the map.
+    *  @param  numNeurons number of neurons to have in the map.
     */
-   virtual void initStarterMap(const int num_neurons);
+   virtual void initStarterMap(const int numNeurons);
 
 private:
    //! Fraction of endogenously active neurons.

--- a/Simulation/Layouts/FixedLayout.cpp
+++ b/Simulation/Layouts/FixedLayout.cpp
@@ -8,36 +8,39 @@ FixedLayout::FixedLayout() : Layout() {
 FixedLayout::~FixedLayout() {
 }
 
-/*
- *  Prints out all parameters of the layout to console.
+/**
+ *  Prints out all parameters to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void FixedLayout::printParameters() const {
    Layout::printParameters();
 
-   cout << "\tLayout type: FixedLayout" << endl << endl;
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: FixedLayout" << endl << endl);
 }
 
 /*
  *  Creates a randomly ordered distribution with the specified numbers of neuron types.
- *  @param  num_neurons number of the neurons to have in the type map.
- *  @return a flat vector (to map to 2-d [x,y] = [i % m_width, i / m_width])
+ *
+ *  @param  numNeurons number of the neurons to have in the type map.
+ *
  */
-void FixedLayout::generateNeuronTypeMap(int num_neurons) {
-   Layout::generateNeuronTypeMap(num_neurons);
+void FixedLayout::generateNeuronTypeMap(int numNeurons) {
+   Layout::generateNeuronTypeMap(numNeurons);
 
-   int num_inhibitory_neurons = inhibitoryNeuronLayout_.size();
-   int num_excititory_neurons = num_neurons - num_inhibitory_neurons;
+   int numInhibitoryNeurons = inhibitoryNeuronLayout_.size();
+   int numExcititoryNeurons = numNeurons - numInhibitoryNeurons;
 
-   DEBUG(cout << "Total neurons: " << num_neurons << endl;)
-   DEBUG(cout << "Inhibitory Neurons: " << num_inhibitory_neurons << endl;)
-   DEBUG(cout << "Excitatory Neurons: " << num_excititory_neurons << endl;)
+   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON TYPE MAP" << endl
+   << "\tTotal neurons: " << numNeurons << endl
+   << "\tInhibitory Neurons: " << numInhibitoryNeurons << endl
+   << "\tExcitatory Neurons: " << numExcititoryNeurons << endl);
 
-   for (int i = 0; i < num_inhibitory_neurons; i++) {
-      assert(inhibitoryNeuronLayout_.at(i) < num_neurons);
+   for (int i = 0; i < numInhibitoryNeurons; i++) {
+      assert(inhibitoryNeuronLayout_.at(i) < numNeurons);
       neuronTypeMap_[inhibitoryNeuronLayout_.at(i)] = INH;
    }
 
-   DEBUG(cout << "Done initializing neuron type map" << endl;);
+   LOG4CPLUS_INFO(fileLogger_, "Finished initializing neuron type map");
 }
 
 /*
@@ -45,11 +48,11 @@ void FixedLayout::generateNeuronTypeMap(int num_neurons) {
  *  Selects \e numStarter excitory neurons and converts them into starter neurons.
  *  @param  num_neurons number of neurons to have in the map.
  */
-void FixedLayout::initStarterMap(const int num_neurons) {
-   Layout::initStarterMap(num_neurons);
+void FixedLayout::initStarterMap(const int numNeurons) {
+   Layout::initStarterMap(numNeurons);
 
    for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) {
-      assert(endogenouslyActiveNeuronList_.at(i) < num_neurons);
+      assert(endogenouslyActiveNeuronList_.at(i) < numNeurons);
       starterMap_[endogenouslyActiveNeuronList_.at(i)] = true;
    }
 }

--- a/Simulation/Layouts/FixedLayout.h
+++ b/Simulation/Layouts/FixedLayout.h
@@ -35,26 +35,25 @@ public:
    static Layout *Create() { return new FixedLayout(); }
 
    /**
-    *  Prints out all parameters of the neurons to ostream.
-    *
-    *  @param  output  ostream to send output to.
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Creates a neurons type map.
     *
-    *  @param  num_neurons number of the neurons to have in the type map.
+    *  @param  numNeurons number of the neurons to have in the type map.
     */
-   virtual void generateNeuronTypeMap(int num_neurons);
+   virtual void generateNeuronTypeMap(int numNeurons);
 
    /**
     *  Populates the starter map.
     *  Selects num_endogenously_active_neurons excitory neurons
     *  and converts them into starter neurons.
     *
-    *  @param  num_neurons number of neurons to have in the map.
+    *  @param  numNeurons number of neurons to have in the map.
     */
-   virtual void initStarterMap(const int num_neurons);
+   virtual void initStarterMap(const int numNeurons);
 };
 

--- a/Simulation/Layouts/Layout.h
+++ b/Simulation/Layouts/Layout.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <vector>
 
+#include <log4cplus/loggingmacros.h>
+
 #include "Utils/Global.h"
 #include "IAllNeurons.h"
 
@@ -41,29 +43,28 @@ public:
    /// Allocate memories to store all layout state.
    virtual void setupLayout();
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
+   /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
    virtual void loadParameters();
 
-   /// Prints out all parameters of the neurons to ostream.
-   /// @param  output  ostream to send output to.
+   /// Prints out all parameters to logging file. Registered to OperationManager as Operation::printParameters
    virtual void printParameters() const;
 
    /// Creates a neurons type map.
-   /// @param  num_neurons number of the neurons to have in the type map.
-   virtual void generateNeuronTypeMap(int num_neurons);
+   /// @param  numNeurons number of the neurons to have in the type map.
+   virtual void generateNeuronTypeMap(int numNeurons);
 
    /// Populates the starter map.
    /// Selects num_endogenously_active_neurons excitory neurons
    /// and converts them into starter neurons.
-   /// @param  num_neurons number of neurons to have in the map.
-   virtual void initStarterMap(const int num_neurons);
+   /// @param  numNeurons number of neurons to have in the map.
+   virtual void initStarterMap(const int numNeurons);
 
 
    /// Returns the type of synapse at the given coordinates
-   /// @param    src_neuron  integer that points to a Neuron in the type map as a source.
-   /// @param    dest_neuron integer that points to a Neuron in the type map as a destination.
+   /// @param    srcNeuron  integer that points to a Neuron in the type map as a source.
+   /// @param    destNeuron integer that points to a Neuron in the type map as a destination.
    /// @return type of the synapse.
-   synapseType synType(const int src_neuron, const int dest_neuron);
+   synapseType synType(const int srcNeuron, const int destNeuron);
 
    VectorMatrix *xloc_;  ///< Store neuron i's x location.
 
@@ -73,7 +74,7 @@ public:
 
    CompleteMatrix *dist_;    ///< The true inter-neuron distance.
 
-   vector<int> probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project
+   vector<int> probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
 
    neuronType *neuronTypeMap_;    ///< The neuron type map (INH, EXC).
 
@@ -87,6 +88,8 @@ protected:
    vector<int> endogenouslyActiveNeuronList_;    ///< Endogenously active neurons list.
 
    vector<int> inhibitoryNeuronLayout_;    ///< Inhibitory neurons list.
+
+   log4cplus::Logger fileLogger_;
 
 private:
    /// initialize the location maps (xloc and yloc).

--- a/Simulation/Recorders/IRecorder.h
+++ b/Simulation/Recorders/IRecorder.h
@@ -27,6 +27,8 @@
 
 #include <string>
 
+#include <log4cplus/loggingmacros.h>
+
 #include "Global.h"
 #include "Model.h"
 #include "Core/Simulator.h"
@@ -56,7 +58,7 @@ public:
    virtual void initValues() = 0;
 
    /**
-    * Get the current radii and rates vlaues
+    * Get the current radii and rates values
     */
    virtual void getValues() = 0;
 
@@ -79,7 +81,15 @@ public:
     **/
    virtual void saveSimData(const IAllNeurons &neurons) = 0;
 
+   /*
+    * Prints loaded parameters to logging file.
+    */
+   virtual void printParameters() = 0;
+
 protected:
-   // File path to the file that the results will be printed to.
+   /// File path to the file that the results will be printed to.
    string resultFileName_;
+
+   /// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
+   log4cplus::Logger fileLogger_;
 };

--- a/Simulation/Recorders/XmlGrowthRecorder.cpp
+++ b/Simulation/Recorders/XmlGrowthRecorder.cpp
@@ -14,10 +14,10 @@
 //! THe constructor and destructor
 XmlGrowthRecorder::XmlGrowthRecorder() :
       XmlRecorder(),
-      ratesHistory(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
-                   Simulator::getInstance().getTotalNeurons()),
-      radiiHistory(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
-                   Simulator::getInstance().getTotalNeurons()) {
+      ratesHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+                    Simulator::getInstance().getTotalNeurons()),
+      radiiHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+                    Simulator::getInstance().getTotalNeurons()) {
 }
 
 XmlGrowthRecorder::~XmlGrowthRecorder() {
@@ -31,8 +31,8 @@ void XmlGrowthRecorder::initDefaultValues() {
    BGFLOAT startRadius = dynamic_cast<ConnGrowth *>(conns.get())->growthParams_.startRadius;
 
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
-      radiiHistory(0, i) = startRadius;
-      ratesHistory(0, i) = 0;
+      radiiHistory_(0, i) = startRadius;
+      ratesHistory_(0, i) = 0;
    }
 }
 
@@ -43,8 +43,8 @@ void XmlGrowthRecorder::initValues() {
    shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
-      radiiHistory(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->radii_)[i];
-      ratesHistory(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->rates_)[i];
+      radiiHistory_(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->radii_)[i];
+      ratesHistory_(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->rates_)[i];
    }
 }
 
@@ -55,8 +55,8 @@ void XmlGrowthRecorder::getValues() {
    Connections *conns = Simulator::getInstance().getModel()->getConnections().get();
 
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
-      (*dynamic_cast<ConnGrowth *>(conns)->radii_)[i] = radiiHistory(Simulator::getInstance().getCurrentStep(), i);
-      (*dynamic_cast<ConnGrowth *>(conns)->rates_)[i] = ratesHistory(Simulator::getInstance().getCurrentStep(), i);
+      (*dynamic_cast<ConnGrowth *>(conns)->radii_)[i] = radiiHistory_(Simulator::getInstance().getCurrentStep(), i);
+      (*dynamic_cast<ConnGrowth *>(conns)->rates_)[i] = ratesHistory_(Simulator::getInstance().getCurrentStep(), i);
    }
 }
 
@@ -76,7 +76,7 @@ void XmlGrowthRecorder::compileHistories(IAllNeurons &neurons) {
 
    for (int iNeuron = 0; iNeuron < Simulator::getInstance().getTotalNeurons(); iNeuron++) {
       // record firing rate to history matrix
-      ratesHistory(Simulator::getInstance().getCurrentStep(), iNeuron) = rates[iNeuron];
+      ratesHistory_(Simulator::getInstance().getCurrentStep(), iNeuron) = rates[iNeuron];
 
       // Cap minimum radius size and record radii to history matrix
       // TODO: find out why we cap this here.
@@ -84,9 +84,7 @@ void XmlGrowthRecorder::compileHistories(IAllNeurons &neurons) {
          radii[iNeuron] = minRadius;
 
       // record radius to history matrix
-      radiiHistory(Simulator::getInstance().getCurrentStep(), iNeuron) = radii[iNeuron];
-
-      DEBUG_MID(cout << "radii[" << iNeuron << ":" << radii[iNeuron] << "]" << endl;)
+      radiiHistory_(Simulator::getInstance().getCurrentStep(), iNeuron) = radii[iNeuron];
    }
 }
 
@@ -109,41 +107,52 @@ void XmlGrowthRecorder::saveSimData(const IAllNeurons &neurons) {
    }
 
    // Write XML header information:
-   stateOut << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
-            << "<!-- State output file for the DCT growth modeling-->\n";
+   stateOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
+             << "<!-- State output file for the DCT growth modeling-->\n";
    //stateOut << version; TODO: version
 
    // Write the core state information:
-   stateOut << "<SimState>\n";
-   stateOut << "   " << radiiHistory.toXML("radiiHistory") << endl;
-   stateOut << "   " << ratesHistory.toXML("ratesHistory") << endl;
-   stateOut << "   " << burstinessHist.toXML("burstinessHist") << endl;
-   stateOut << "   " << spikesHistory.toXML("spikesHistory") << endl;
-   stateOut << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << endl;
-   stateOut << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << endl;
-   stateOut << "   " << neuronTypes.toXML("neuronTypes") << endl;
+   stateOut_ << "<SimState>\n";
+   stateOut_ << "   " << radiiHistory_.toXML("radiiHistory") << endl;
+   stateOut_ << "   " << ratesHistory_.toXML("ratesHistory") << endl;
+   stateOut_ << "   " << burstinessHist_.toXML("burstinessHist") << endl;
+   stateOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
+   stateOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << endl;
+   stateOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << endl;
+   stateOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter nuerons matrix
    int num_starter_neurons = static_cast<int>(Simulator::getInstance().getModel()->getLayout()->numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons, Simulator::getInstance().getModel()->getLayout()->starterMap_);
-      stateOut << "   " << starterNeurons.toXML("starterNeurons") << endl;
+      stateOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 
    // Write neuron thresold
-   stateOut << "   " << neuronThresh.toXML("neuronThresh") << endl;
+   stateOut_ << "   " << neuronThresh.toXML("neuronThresh") << endl;
 
    // write time between growth cycles
-   stateOut << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
-   stateOut << "   " << Simulator::getInstance().getEpochDuration() << endl;
-   stateOut << "</Matrix>" << endl;
+   stateOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
+   stateOut_ << "   " << Simulator::getInstance().getEpochDuration() << endl;
+   stateOut_ << "</Matrix>" << endl;
 
    // write simulation end time
-   stateOut << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-            << endl;
-   stateOut << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << endl;
-   stateOut << "</Matrix>" << endl;
-   stateOut << "</SimState>" << endl;
+   stateOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
+             << endl;
+   stateOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << endl;
+   stateOut_ << "</Matrix>" << endl;
+   stateOut_ << "</SimState>" << endl;
+}
+
+/**
+ *  Prints out all parameters to logging file.
+ *  Registered to OperationManager as Operation::printParameters
+ */
+void XmlGrowthRecorder::printParameters() {
+   XmlRecorder::printParameters();
+
+   LOG4CPLUS_DEBUG(fileLogger_, "\n---XmlGrowthRecorder Parameters---" << endl
+                                      << "\tRecorder type: XmlGrowthRecorder" << endl);
 }
 

--- a/Simulation/Recorders/XmlGrowthRecorder.h
+++ b/Simulation/Recorders/XmlGrowthRecorder.h
@@ -74,11 +74,17 @@ public:
     **/
    virtual void saveSimData(const IAllNeurons &neurons);
 
+   /**
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
+    */
+   virtual void printParameters();
+
 private:
    // track firing rate
-   CompleteMatrix ratesHistory;
+   CompleteMatrix ratesHistory_;
 
    // track radii
-   CompleteMatrix radiiHistory;
+   CompleteMatrix radiiHistory_;
 };
 

--- a/Simulation/Recorders/XmlRecorder.h
+++ b/Simulation/Recorders/XmlRecorder.h
@@ -84,16 +84,22 @@ public:
     **/
    virtual void saveSimData(const IAllNeurons &neurons);
 
+   /**
+    *  Prints out all parameters to logging file.
+    *  Registered to OperationManager as Operation::printParameters
+    */
+   virtual void printParameters();
+
 protected:
-   void getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starter_map);
+   void getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starterMap);
 
    // a file stream for xml output
-   ofstream stateOut;
+   ofstream stateOut_;
 
    // burstiness Histogram goes through the
-   VectorMatrix burstinessHist;
+   VectorMatrix burstinessHist_;
 
    // spikes history - history of accumulated spikes count of all neurons (10 ms bin)
-   VectorMatrix spikesHistory;
+   VectorMatrix spikesHistory_;
 };
 

--- a/Simulation/Vertices/AllIFNeurons.cpp
+++ b/Simulation/Vertices/AllIFNeurons.cpp
@@ -32,8 +32,6 @@ AllIFNeurons::~AllIFNeurons() {
 
 /*
  *  Setup the internal structure of the class (allocate memories).
- *
- *  @param  sim_info  SimulationInfo class to read information from.
  */
 void AllIFNeurons::setupNeurons() {
    AllSpikingNeurons::setupNeurons();
@@ -140,42 +138,43 @@ void AllIFNeurons::loadParameters() {
    ParameterManager::getInstance().getBGFloatByXpath("//starter_vreset/max/text()", starterVresetRange_[1]);
 }
 
-/*
- *  Prints out all parameters of the neurons to ostream.
- * 
- *  @param  output  ostream to send output to.
+/**
+ *  Prints out all parameters of the neurons to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void AllIFNeurons::printParameters() const {
-   cout << "\tInterval of constant injected current: ["
-          << IinjectRange_[0] << ", " << IinjectRange_[1] << "]"
-          << endl;
-   cout << "\tInterval of STD of (gaussian) noise current: ["
-          << InoiseRange_[0] << ", " << InoiseRange_[1] << "]"
-          << endl;
-   cout << "\tInterval of firing threshold: ["
-          << VthreshRange_[0] << ", " << VthreshRange_[1] << "]"
-          << endl;
-   cout << "\tInterval of asymptotic voltage (Vresting): [" << VrestingRange_[0]
-          << ", " << VrestingRange_[1] << "]"
-          << endl;
-   cout << "\tInterval of reset voltage: [" << VresetRange_[0]
-          << ", " << VresetRange_[1] << "]"
-          << endl;
-   cout << "\tInterval of initial membrance voltage: [" << VinitRange_[0]
-          << ", " << VinitRange_[1] << "]"
-          << endl;
-   cout << "\tStarter firing threshold: [" << starterVthreshRange_[0]
-        << ", " << starterVthreshRange_[1] << "]"
-          << endl;
-   cout << "\tStarter reset threshold: [" << starterVresetRange_[0]
-        << ", " << starterVresetRange_[1] << "]"
-          << endl << endl;
+   AllNeurons::printParameters();
+
+   LOG4CPLUS_DEBUG(fileLogger_,
+                   "\n\tInterval of constant injected current: ["
+                         << IinjectRange_[0] << ", " << IinjectRange_[1] << "]"
+                         << endl
+                         << "\tInterval of STD of (gaussian) noise current: ["
+                         << InoiseRange_[0] << ", " << InoiseRange_[1] << "]"
+                         << endl
+                         << "\tInterval of firing threshold: ["
+                         << VthreshRange_[0] << ", " << VthreshRange_[1] << "]"
+                         << endl
+                         << "\tInterval of asymptotic voltage (Vresting): [" << VrestingRange_[0]
+                         << ", " << VrestingRange_[1] << "]"
+                         << endl
+                         << "\tInterval of reset voltage: [" << VresetRange_[0]
+                         << ", " << VresetRange_[1] << "]"
+                         << endl
+                         << "\tInterval of initial membrance voltage: [" << VinitRange_[0]
+                         << ", " << VinitRange_[1] << "]"
+                         << endl
+                         << "\tStarter firing threshold: [" << starterVthreshRange_[0]
+                         << ", " << starterVthreshRange_[1] << "]"
+                         << endl
+                         << "\tStarter reset threshold: [" << starterVresetRange_[0]
+                         << ", " << starterVresetRange_[1] << "]"
+                         << endl << endl);
 }
 
 /*
  *  Creates all the Neurons and generates data for them.
  *
- *  @param  sim_info    SimulationInfo class to read information from.
  *  @param  layout      Layout information of the neunal network.
  */
 void AllIFNeurons::createAllNeurons(Layout *layout) {
@@ -191,68 +190,70 @@ void AllIFNeurons::createAllNeurons(Layout *layout) {
 /*
  *  Creates a single Neuron and generates data for it.
  *
- *  @param  sim_info     SimulationInfo class to read information from.
- *  @param  neuron_index Index of the neuron to create.
+ *  @param  neuronIndex Index of the neuron to create.
  *  @param  layout       Layout information of the neunal network.
  */
-void AllIFNeurons::createNeuron(int neuron_index, Layout *layout) {
+void AllIFNeurons::createNeuron(int neuronIndex, Layout *layout) {
    // set the neuron info for neurons
-   Iinject_[neuron_index] = rng.inRange(IinjectRange_[0], IinjectRange_[1]);
-   Inoise_[neuron_index] = rng.inRange(InoiseRange_[0], InoiseRange_[1]);
-   Vthresh_[neuron_index] = rng.inRange(VthreshRange_[0], VthreshRange_[1]);
-   Vrest_[neuron_index] = rng.inRange(VrestingRange_[0], VrestingRange_[1]);
-   Vreset_[neuron_index] = rng.inRange(VresetRange_[0], VresetRange_[1]);
-   Vinit_[neuron_index] = rng.inRange(VinitRange_[0], VinitRange_[1]);
-   Vm_[neuron_index] = Vinit_[neuron_index];
+   Iinject_[neuronIndex] = rng.inRange(IinjectRange_[0], IinjectRange_[1]);
+   Inoise_[neuronIndex] = rng.inRange(InoiseRange_[0], InoiseRange_[1]);
+   Vthresh_[neuronIndex] = rng.inRange(VthreshRange_[0], VthreshRange_[1]);
+   Vrest_[neuronIndex] = rng.inRange(VrestingRange_[0], VrestingRange_[1]);
+   Vreset_[neuronIndex] = rng.inRange(VresetRange_[0], VresetRange_[1]);
+   Vinit_[neuronIndex] = rng.inRange(VinitRange_[0], VinitRange_[1]);
+   Vm_[neuronIndex] = Vinit_[neuronIndex];
 
-   initNeuronConstsFromParamValues(neuron_index, Simulator::getInstance().getDeltaT());
+   initNeuronConstsFromParamValues(neuronIndex, Simulator::getInstance().getDeltaT());
 
-   int max_spikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
-   spikeHistory_[neuron_index] = new uint64_t[max_spikes];
-   for (int j = 0; j < max_spikes; ++j) {
-      spikeHistory_[neuron_index][j] = ULONG_MAX;
+   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+   spikeHistory_[neuronIndex] = new uint64_t[maxSpikes];
+   for (int j = 0; j < maxSpikes; ++j) {
+      spikeHistory_[neuronIndex][j] = ULONG_MAX;
    }
 
-   switch (layout->neuronTypeMap_[neuron_index]) {
-      case INH: DEBUG_MID(cout << "setting inhibitory neuron: " << neuron_index << endl;)
+   switch (layout->neuronTypeMap_[neuronIndex]) {
+      case INH:
+         LOG4CPLUS_DEBUG(neuronLogger_, "Setting inhibitory neuron: " << neuronIndex);
          // set inhibitory absolute refractory period
-         Trefract_[neuron_index] = DEFAULT_InhibTrefract;// TODO(derek): move defaults inside model.
+         Trefract_[neuronIndex] = DEFAULT_InhibTrefract;// TODO(derek): move defaults inside model.
          break;
 
-      case EXC: DEBUG_MID(cout << "setting exitory neuron: " << neuron_index << endl;)
-         // set excitory absolute refractory period
-         Trefract_[neuron_index] = DEFAULT_ExcitTrefract;
+      case EXC:
+         LOG4CPLUS_DEBUG(neuronLogger_, "Setting excitatory neuron: " << neuronIndex);
+         // set excitatory absolute refractory period
+         Trefract_[neuronIndex] = DEFAULT_ExcitTrefract;
          break;
 
-      default: DEBUG_MID(
-            cout << "ERROR: unknown neuron type: " << layout->neuronTypeMap_[neuron_index] << "@" << neuron_index
-                 << endl;)
+      default:
+         LOG4CPLUS_DEBUG(neuronLogger_, "ERROR: unknown neuron type: "
+               << layout->neuronTypeMap_[neuronIndex] << "@" << neuronIndex);
          assert(false);
          break;
    }
    // endogenously_active_neuron_map -> Model State
-   if (layout->starterMap_[neuron_index]) {
+   if (layout->starterMap_[neuronIndex]) {
       // set endogenously active threshold voltage, reset voltage, and refractory period
-      Vthresh_[neuron_index] = rng.inRange(starterVthreshRange_[0], starterVthreshRange_[1]);
-      Vreset_[neuron_index] = rng.inRange(starterVresetRange_[0], starterVresetRange_[1]);
-      Trefract_[neuron_index] = DEFAULT_ExcitTrefract; // TODO(derek): move defaults inside model.
+      Vthresh_[neuronIndex] = rng.inRange(starterVthreshRange_[0], starterVthreshRange_[1]);
+      Vreset_[neuronIndex] = rng.inRange(starterVresetRange_[0], starterVresetRange_[1]);
+      Trefract_[neuronIndex] = DEFAULT_ExcitTrefract; // TODO(derek): move defaults inside model.
    }
 
-   DEBUG_HI(cout << "CREATE NEURON[" << neuron_index << "] {" << endl
-                 << "\tVm = " << Vm_[neuron_index] << endl
-                 << "\tVthresh = " << Vthresh_[neuron_index] << endl
-                 << "\tI0 = " << I0_[neuron_index] << endl
-                 << "\tInoise = " << Inoise_[neuron_index] << "from : (" << InoiseRange_[0] << "," << InoiseRange_[1] << ")"
+   LOG4CPLUS_DEBUG(neuronLogger_, "\nCREATE NEURON[" << neuronIndex << "] {" << endl
+                 << "\tVm = " << Vm_[neuronIndex] << endl
+                 << "\tVthresh = " << Vthresh_[neuronIndex] << endl
+                 << "\tI0 = " << I0_[neuronIndex] << endl
+                 << "\tInoise = " << Inoise_[neuronIndex] << " from : (" << InoiseRange_[0] << "," << InoiseRange_[1]
+                 << ")"
                  << endl
-                 << "\tC1 = " << C1_[neuron_index] << endl
-                 << "\tC2 = " << C2_[neuron_index] << endl
-                 << "}" << endl;)
+                 << "\tC1 = " << C1_[neuronIndex] << endl
+                 << "\tC2 = " << C2_[neuronIndex] << endl
+                 << "}" << endl);
 }
 
 /*
  *  Set the Neuron at the indexed location to default values.
  *
- *  @param  neuron_index    Index of the Neuron that the synapse belongs to.
+ *  @param  index    Index of the Neuron that the synapse belongs to.
  */
 void AllIFNeurons::setNeuronDefaults(const int index) {
    Cm_[index] = DEFAULT_Cm;
@@ -270,17 +271,17 @@ void AllIFNeurons::setNeuronDefaults(const int index) {
 /*
  *  Initializes the Neuron constants at the indexed location.
  *
- *  @param  neuron_index    Index of the Neuron.
+ *  @param  neuronIndex    Index of the Neuron.
  *  @param  deltaT          Inner simulation step duration
  */
-void AllIFNeurons::initNeuronConstsFromParamValues(int neuron_index, const BGFLOAT deltaT) {
-   BGFLOAT &Tau = this->Tau_[neuron_index];
-   BGFLOAT &C1 = this->C1_[neuron_index];
-   BGFLOAT &C2 = this->C2_[neuron_index];
-   BGFLOAT &Rm = this->Rm_[neuron_index];
-   BGFLOAT &I0 = this->I0_[neuron_index];
-   BGFLOAT &Iinject = this->Iinject_[neuron_index];
-   BGFLOAT &Vrest = this->Vrest_[neuron_index];
+void AllIFNeurons::initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT) {
+   BGFLOAT &Tau = this->Tau_[neuronIndex];
+   BGFLOAT &C1 = this->C1_[neuronIndex];
+   BGFLOAT &C2 = this->C2_[neuronIndex];
+   BGFLOAT &Rm = this->Rm_[neuronIndex];
+   BGFLOAT &I0 = this->I0_[neuronIndex];
+   BGFLOAT &Iinject = this->Iinject_[neuronIndex];
+   BGFLOAT &Vrest = this->Vrest_[neuronIndex];
 
    /* init consts C1,C2 for exponential Euler integration */
    if (Tau > 0) {
@@ -301,26 +302,27 @@ void AllIFNeurons::initNeuronConstsFromParamValues(int neuron_index, const BGFLO
 /*
  *  Outputs state of the neuron chosen as a string.
  *
- *  @param  i   index of the neuron (in neurons) to output info from.
+ *  @param  index  index of the neuron (in neurons) to output info from.
  *  @return the complete state of the neuron.
  */
-string AllIFNeurons::toString(const int i) const {
+string AllIFNeurons::toString(const int index) const {
    stringstream ss;
-   ss << "Cm: " << Cm_[i] << " "; // membrane capacitance
-   ss << "Rm: " << Rm_[i] << " "; // membrane resistance
-   ss << "Vthresh: " << Vthresh_[i] << " "; // if Vm exceeds, Vthresh, a spike is emitted
-   ss << "Vrest: " << Vrest_[i] << " "; // the resting membrane voltage
-   ss << "Vreset: " << Vreset_[i] << " "; // The voltage to reset Vm to after a spike
-   ss << "Vinit: " << Vinit_[i] << endl; // The initial condition for V_m at t=0
-   ss << "Trefract: " << Trefract_[i] << " "; // the number of steps in the refractory period
-   ss << "Inoise: " << Inoise_[i] << " "; // the stdev of the noise to be added each delta_t
-   ss << "Iinject: " << Iinject_[i] << " "; // A constant current to be injected into the LIF neuron
-   ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[i] << endl; // the number of steps left in the refractory period
-   ss << "Vm: " << Vm_[i] << " "; // the membrane voltage
-   ss << "hasFired: " << hasFired_[i] << " "; // it done fired?
-   ss << "C1: " << C1_[i] << " ";
-   ss << "C2: " << C2_[i] << " ";
-   ss << "I0: " << I0_[i] << " ";
+   ss << "Cm: " << Cm_[index] << " "; // membrane capacitance
+   ss << "Rm: " << Rm_[index] << " "; // membrane resistance
+   ss << "Vthresh: " << Vthresh_[index] << " "; // if Vm exceeds, Vthresh, a spike is emitted
+   ss << "Vrest: " << Vrest_[index] << " "; // the resting membrane voltage
+   ss << "Vreset: " << Vreset_[index] << " "; // The voltage to reset Vm to after a spike
+   ss << "Vinit: " << Vinit_[index] << endl; // The initial condition for V_m at t=0
+   ss << "Trefract: " << Trefract_[index] << " "; // the number of steps in the refractory period
+   ss << "Inoise: " << Inoise_[index] << " "; // the stdev of the noise to be added each delta_t
+   ss << "Iinject: " << Iinject_[index] << " "; // A constant current to be injected into the LIF neuron
+   ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
+      << endl; // the number of steps left in the refractory period
+   ss << "Vm: " << Vm_[index] << " "; // the membrane voltage
+   ss << "hasFired: " << hasFired_[index] << " "; // it done fired?
+   ss << "C1: " << C1_[index] << " ";
+   ss << "C2: " << C2_[index] << " ";
+   ss << "I0: " << I0_[index] << " ";
    return ss.str();
 }
 
@@ -328,7 +330,6 @@ string AllIFNeurons::toString(const int i) const {
  *  Sets the data for Neurons to input's data.
  *
  *  @param  input       istream to read from.
- *  @param  sim_info    used as a reference to set info for neuronss.
  */
 void AllIFNeurons::deserialize(istream &input) {
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
@@ -340,7 +341,6 @@ void AllIFNeurons::deserialize(istream &input) {
  *  Sets the data for Neuron #index to input's data.
  *
  *  @param  input       istream to read from.
- *  @param  sim_info    used as a reference to set info for neurons.
  *  @param  i           index of the neuron (in neurons).
  */
 void AllIFNeurons::readNeuron(istream &input, int i) {
@@ -385,7 +385,6 @@ void AllIFNeurons::readNeuron(istream &input, int i) {
  *  Writes out the data in Neurons.
  *
  *  @param  output      stream to write out to.
- *  @param  sim_info    used as a reference to set info for neuronss.
  */
 void AllIFNeurons::serialize(ostream &output) const {
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
@@ -397,7 +396,6 @@ void AllIFNeurons::serialize(ostream &output) const {
  *  Writes out the data in the selected Neuron.
  *
  *  @param  output      stream to write out to.
- *  @param  sim_info    used as a reference to set info for neuronss.
  *  @param  i           index of the neuron (in neurons).
  */
 void AllIFNeurons::writeNeuron(ostream &output, int i) const {

--- a/Simulation/Vertices/AllIFNeurons.h
+++ b/Simulation/Vertices/AllIFNeurons.h
@@ -51,8 +51,6 @@ public:
    /**
     *  Setup the internal structure of the class.
     *  Allocate memories to store all neurons' state.
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupNeurons();
 
@@ -62,18 +60,21 @@ public:
     */
    virtual void cleanupNeurons();
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
+   /*
+    *  Load member variables from configuration file.
+    *  Registered to OperationManager as Operation::loadParameters
+    */
    virtual void loadParameters();
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters of the neurons to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Creates all the Neurons and assigns initial data for them.
     *
-    *  @param  sim_info    SimulationInfo class to read information from.
     *  @param  layout      Layout information of the neunal network.
     */
    virtual void createAllNeurons(Layout *layout);
@@ -81,24 +82,22 @@ public:
    /**
     *  Outputs state of the neuron chosen as a string.
     *
-    *  @param  i   index of the neuron (in neurons) to output info from.
+    *  @param  index   index of the neuron (in neurons) to output info from.
     *  @return the complete state of the neuron.
     */
-   virtual string toString(const int i) const;
+   virtual string toString(const int index) const;
 
    /**
     *  Reads and sets the data for all neurons from input stream.
     *
     *  @param  input       istream to read from.
-    *  @param  sim_info    used as a reference to set info for neuronss.
     */
    virtual void deserialize(istream &input);
 
    /**
     *  Writes out the data in all neurons to output stream.
     *
-    *  @param  output      stream to write out to.
-    *  @param  sim_info    used as a reference to set info for neuronss.
+    *  @param  output      stream to write out to.ss.
     */
    virtual void serialize(ostream &output) const;
 
@@ -111,68 +110,60 @@ public:
         *  @param  synapses               Reference to the allSynapses struct on host memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
-        *  @param  sim_info               SimulationInfo to refer from.
         *  @param  randNoise              Reference to the random noise array.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
         */
-       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, const SimulationInfo *sim_info, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
+       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
 
        /**
         *  Allocate GPU memories to store all neurons' states,
         *  and copy them from host to GPU memory.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void allocNeuronDeviceStruct( void** allNeuronsDevice, SimulationInfo *sim_info );
+       virtual void allocNeuronDeviceStruct( void** allNeuronsDevice);
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void deleteNeuronDeviceStruct( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void deleteNeuronDeviceStruct( void* allNeuronsDevice);
 
        /**
         *  Copy all neurons' data from host to device.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronHostToDevice( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronHostToDevice( void* allNeuronsDevice);
 
        /**
         *  Copy all neurons' data from device to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceToHost( void* allNeuronsDevice);
 
        /**
         *  Copy spike history data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice);
 
        /**
         *  Copy spike counts data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice);
 
        /**
         *  Clear the spike counts out of all neurons.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice);
 
    protected:
        /**
@@ -180,36 +171,32 @@ public:
         *  (Helper function of allocNeuronDeviceStruct)
         *
         *  @param  allNeurons         Reference to the AllIFNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void allocDeviceStruct( AllIFNeuronsDeviceProperties &allNeurons, SimulationInfo *sim_info );
+       void allocDeviceStruct( AllIFNeuronsDeviceProperties &allNeurons);
 
        /**
         *  Delete GPU memories.
         *  (Helper function of deleteNeuronDeviceStruct)
         *
         *  @param  allNeurons         Reference to the AllIFNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void deleteDeviceStruct( AllIFNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void deleteDeviceStruct( AllIFNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Copy all neurons' data from host to device.
         *  (Helper function of copyNeuronHostToDevice)
         *
         *  @param  allNeurons         Reference to the AllIFNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-  void copyHostToDevice( AllIFNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+  void copyHostToDevice( AllIFNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Copy all neurons' data from device to host.
         *  (Helper function of copyNeuronDeviceToHost)
         *
         *  @param  allNeurons         Reference to the AllIFNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-  void copyDeviceToHost( AllIFNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+  void copyDeviceToHost( AllIFNeuronsDeviceProperties& allNeurons);
 
 #endif // defined(USE_GPU)
 
@@ -217,32 +204,30 @@ protected:
    /**
     *  Creates a single Neuron and generates data for it.
     *
-    *  @param  sim_info     SimulationInfo class to read information from.
-    *  @param  neuron_index Index of the neuron to create.
+    *  @param  neuronIndex Index of the neuron to create.
     *  @param  layout       Layout information of the neunal network.
     */
-   void createNeuron(int neuron_index, Layout *layout);
+   void createNeuron(int neuronIndex, Layout *layout);
 
    /**
     *  Set the Neuron at the indexed location to default values.
     *
-    *  @param  neuron_index    Index of the Neuron that the synapse belongs to.
+    *  @param  index    Index of the Neuron that the synapse belongs to.
     */
    void setNeuronDefaults(const int index);
 
    /**
     *  Initializes the Neuron constants at the indexed location.
     *
-    *  @param  neuron_index    Index of the Neuron.
+    *  @param  neuronIndex    Index of the Neuron.
     *  @param  deltaT          Inner simulation step duration
     */
-   virtual void initNeuronConstsFromParamValues(int neuron_index, const BGFLOAT deltaT);
+   virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT);
 
    /**
     *  Sets the data for Neuron #index to input's data.
     *
     *  @param  input       istream to read from.
-    *  @param  sim_info    used as a reference to set info for neurons.
     *  @param  i           index of the neuron (in neurons).
     */
    void readNeuron(istream &input, int i);
@@ -251,7 +236,6 @@ protected:
     *  Writes out the data in the selected Neuron.
     *
     *  @param  output      stream to write out to.
-    *  @param  sim_info    used as a reference to set info for neuronss.
     *  @param  i           index of the neuron (in neurons).
     */
    void writeNeuron(ostream &output, int i) const;

--- a/Simulation/Vertices/AllIZHNeurons.cpp
+++ b/Simulation/Vertices/AllIZHNeurons.cpp
@@ -22,8 +22,6 @@ AllIZHNeurons::~AllIZHNeurons() {
 
 /*
  *  Setup the internal structure of the class (allocate memories).
- *
- *  @param  sim_info  SimulationInfo class to read information from.
  */
 void AllIZHNeurons::setupNeurons() {
    AllIFNeurons::setupNeurons();
@@ -65,102 +63,97 @@ void AllIZHNeurons::freeResources() {
    C3_ = NULL;
 }
 
-/*
- *  Prints out all parameters of the neurons to ostream.
- *
- *  @param  output  ostream to send output to.
+/**
+ *  Prints out all parameters of the neurons to logging file.
+ *  Registered to OperationManager as Operation::printParameters
  */
 void AllIZHNeurons::printParameters() const {
-   AllNeurons::printParameters();
-
-   cout << "\tVertices type: AllIZHNeurons" << endl;
-
    AllIFNeurons::printParameters();
 
-   cout << "\tInterval of A constant for excitatory neurons: ["
-          << excAconst_[0] << ", " << excAconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of A constant for inhibitory neurons: ["
-          << inhAconst_[0] << ", " << inhAconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of B constant for excitatory neurons: ["
-          << excBconst_[0] << ", " << excBconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of B constant for inhibitory neurons: ["
-          << inhBconst_[0] << ", " << inhBconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of C constant for excitatory neurons: ["
-          << excCconst_[0] << ", " << excCconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of C constant for inhibitory neurons: ["
-          << inhCconst_[0] << ", " << inhCconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of D constant for excitatory neurons: ["
-          << excDconst_[0] << ", " << excDconst_[1] << "]"
-          << endl;
-   cout << "\tInterval of D constant for inhibitory neurons: ["
-          << inhDconst_[0] << ", " << inhDconst_[1] << "]"
-          << endl << endl;
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices type: AllIZHNeurons" << endl
+             << "\tInterval of A constant for excitatory neurons: ["
+             << excAconst_[0] << ", " << excAconst_[1] << "]"
+             << endl
+             << "\tInterval of A constant for inhibitory neurons: ["
+             << inhAconst_[0] << ", " << inhAconst_[1] << "]"
+             << endl
+             << "\tInterval of B constant for excitatory neurons: ["
+             << excBconst_[0] << ", " << excBconst_[1] << "]"
+             << endl
+             << "\tInterval of B constant for inhibitory neurons: ["
+             << inhBconst_[0] << ", " << inhBconst_[1] << "]"
+             << endl
+             << "\tInterval of C constant for excitatory neurons: ["
+             << excCconst_[0] << ", " << excCconst_[1] << "]"
+             << endl
+             << "\tInterval of C constant for inhibitory neurons: ["
+             << inhCconst_[0] << ", " << inhCconst_[1] << "]"
+             << endl
+             << "\tInterval of D constant for excitatory neurons: ["
+             << excDconst_[0] << ", " << excDconst_[1] << "]"
+             << endl
+             << "\tInterval of D constant for inhibitory neurons: ["
+             << inhDconst_[0] << ", " << inhDconst_[1] << "]"
+             << endl << endl);
+
 }
 
 /*
  *  Creates all the Neurons and generates data for them.
  *
- *  @param  sim_info    SimulationInfo class to read information from.
  *  @param  layout      Layout information of the neunal network.
  */
 void AllIZHNeurons::createAllNeurons(Layout *layout) {
    /* set their specific types */
-   for (int neuron_index = 0; neuron_index < Simulator::getInstance().getTotalNeurons(); neuron_index++) {
-      setNeuronDefaults(neuron_index);
+   for (int neuronIndex = 0; neuronIndex < Simulator::getInstance().getTotalNeurons(); neuronIndex++) {
+      setNeuronDefaults(neuronIndex);
 
       // set the neuron info for neurons
-      createNeuron(neuron_index, layout);
+      createNeuron(neuronIndex, layout);
    }
 }
 
 /*
  *  Creates a single Neuron and generates data for it.
  *
- *  @param  sim_info     SimulationInfo class to read information from.
- *  @param  neuron_index Index of the neuron to create.
+ *  @param  neuronIndex Index of the neuron to create.
  *  @param  layout       Layout information of the neunal network.
  */
-void AllIZHNeurons::createNeuron(int neuron_index, Layout *layout) {
+void AllIZHNeurons::createNeuron(int neuronIndex, Layout *layout) {
    // set the neuron info for neurons
-   AllIFNeurons::createNeuron(neuron_index, layout);
+   AllIFNeurons::createNeuron(neuronIndex, layout);
 
    // TODO: we may need another distribution mode besides flat distribution
-   if (layout->neuronTypeMap_[neuron_index] == EXC) {
+   if (layout->neuronTypeMap_[neuronIndex] == EXC) {
       // excitatory neuron
-      Aconst_[neuron_index] = rng.inRange(excAconst_[0], excAconst_[1]);
-      Bconst_[neuron_index] = rng.inRange(excBconst_[0], excBconst_[1]);
-      Cconst_[neuron_index] = rng.inRange(excCconst_[0], excCconst_[1]);
-      Dconst_[neuron_index] = rng.inRange(excDconst_[0], excDconst_[1]);
+      Aconst_[neuronIndex] = rng.inRange(excAconst_[0], excAconst_[1]);
+      Bconst_[neuronIndex] = rng.inRange(excBconst_[0], excBconst_[1]);
+      Cconst_[neuronIndex] = rng.inRange(excCconst_[0], excCconst_[1]);
+      Dconst_[neuronIndex] = rng.inRange(excDconst_[0], excDconst_[1]);
    } else {
       // inhibitory neuron
-      Aconst_[neuron_index] = rng.inRange(inhAconst_[0], inhAconst_[1]);
-      Bconst_[neuron_index] = rng.inRange(inhBconst_[0], inhBconst_[1]);
-      Cconst_[neuron_index] = rng.inRange(inhCconst_[0], inhCconst_[1]);
-      Dconst_[neuron_index] = rng.inRange(inhDconst_[0], inhDconst_[1]);
+      Aconst_[neuronIndex] = rng.inRange(inhAconst_[0], inhAconst_[1]);
+      Bconst_[neuronIndex] = rng.inRange(inhBconst_[0], inhBconst_[1]);
+      Cconst_[neuronIndex] = rng.inRange(inhCconst_[0], inhCconst_[1]);
+      Dconst_[neuronIndex] = rng.inRange(inhDconst_[0], inhDconst_[1]);
    }
 
-   u_[neuron_index] = 0;
+   u_[neuronIndex] = 0;
 
-   DEBUG_HI(cout << "CREATE NEURON[" << neuron_index << "] {" << endl
-                 << "\tAconst = " << Aconst_[neuron_index] << endl
-                 << "\tBconst = " << Bconst_[neuron_index] << endl
-                 << "\tCconst = " << Cconst_[neuron_index] << endl
-                 << "\tDconst = " << Dconst_[neuron_index] << endl
-                 << "\tC3 = " << C3_[neuron_index] << endl
-                 << "}" << endl;)
+   LOG4CPLUS_DEBUG(fileLogger_, "\nCREATE NEURON[" << neuronIndex << "] {" << endl
+                 << "\tAconst = " << Aconst_[neuronIndex] << endl
+                 << "\tBconst = " << Bconst_[neuronIndex] << endl
+                 << "\tCconst = " << Cconst_[neuronIndex] << endl
+                 << "\tDconst = " << Dconst_[neuronIndex] << endl
+                 << "\tC3 = " << C3_[neuronIndex] << endl
+                 << "}" << endl);
 
 }
 
 /*
  *  Set the Neuron at the indexed location to default values.
  *
- *  @param  neuron_index    Index of the Neuron to refer.
+ *  @param  neuronIndex    Index of the Neuron to refer.
  */
 void AllIZHNeurons::setNeuronDefaults(const int index) {
    AllIFNeurons::setNeuronDefaults(index);
@@ -177,33 +170,33 @@ void AllIZHNeurons::setNeuronDefaults(const int index) {
 /*
  *  Initializes the Neuron constants at the indexed location.
  *
- *  @param  neuron_index    Index of the Neuron.
+ *  @param  neuronIndex    Index of the Neuron.
  *  @param  deltaT          Inner simulation step duration
  */
-void AllIZHNeurons::initNeuronConstsFromParamValues(int neuron_index, const BGFLOAT deltaT) {
-   AllIFNeurons::initNeuronConstsFromParamValues(neuron_index, deltaT);
+void AllIZHNeurons::initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT) {
+   AllIFNeurons::initNeuronConstsFromParamValues(neuronIndex, deltaT);
 
-   BGFLOAT &C3 = this->C3_[neuron_index];
+   BGFLOAT &C3 = this->C3_[neuronIndex];
    C3 = deltaT * 1000;
 }
 
 /*
  *  Outputs state of the neuron chosen as a string.
  *
- *  @param  i   index of the neuron (in neurons) to output info from.
+ *  @param  index index of the neuron (in neurons) to output info from.
  *  @return the complete state of the neuron.
  */
-string AllIZHNeurons::toString(const int i) const {
+string AllIZHNeurons::toString(const int index) const {
    stringstream ss;
 
-   ss << AllIFNeurons::toString(i);
+   ss << AllIFNeurons::toString(index);
 
-   ss << "Aconst: " << Aconst_[i] << " ";
-   ss << "Bconst: " << Bconst_[i] << " ";
-   ss << "Cconst: " << Cconst_[i] << " ";
-   ss << "Dconst: " << Dconst_[i] << " ";
-   ss << "u: " << u_[i] << " ";
-   ss << "C3: " << C3_[i] << " ";
+   ss << "Aconst: " << Aconst_[index] << " ";
+   ss << "Bconst: " << Bconst_[index] << " ";
+   ss << "Cconst: " << Cconst_[index] << " ";
+   ss << "Dconst: " << Dconst_[index] << " ";
+   ss << "u: " << u_[index] << " ";
+   ss << "C3: " << C3_[index] << " ";
    return ss.str();
 }
 
@@ -211,7 +204,6 @@ string AllIZHNeurons::toString(const int i) const {
  *  Sets the data for Neurons to input's data.
  *
  *  @param  input       istream to read from.
- *  @param  sim_info    used as a reference to set info for neurons.
  */
 void AllIZHNeurons::deserialize(istream &input) {
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
@@ -223,23 +215,22 @@ void AllIZHNeurons::deserialize(istream &input) {
  *  Sets the data for Neuron #index to input's data.
  *
  *  @param  input       istream to read from.
- *  @param  sim_info    used as a reference to set info for neurons.
- *  @param  i           index of the neuron (in neurons).
+ *  @param  index           index of the neuron (in neurons).
  */
-void AllIZHNeurons::readNeuron(istream &input, int i) {
-   AllIFNeurons::readNeuron(input, i);
+void AllIZHNeurons::readNeuron(istream &input, int index) {
+   AllIFNeurons::readNeuron(input, index);
 
-   input >> Aconst_[i];
+   input >> Aconst_[index];
    input.ignore();
-   input >> Bconst_[i];
+   input >> Bconst_[index];
    input.ignore();
-   input >> Cconst_[i];
+   input >> Cconst_[index];
    input.ignore();
-   input >> Dconst_[i];
+   input >> Dconst_[index];
    input.ignore();
-   input >> u_[i];
+   input >> u_[index];
    input.ignore();
-   input >> C3_[i];
+   input >> C3_[index];
    input.ignore();
 }
 
@@ -247,7 +238,6 @@ void AllIZHNeurons::readNeuron(istream &input, int i) {
  *  Writes out the data in Neurons.
  *
  *  @param  output      stream to write out to.
- *  @param  sim_info    used as a reference to set info for neuronss.
  */
 void AllIZHNeurons::serialize(ostream &output) const {
    for (int i = 0; i < Simulator::getInstance().getTotalNeurons(); i++) {
@@ -259,18 +249,17 @@ void AllIZHNeurons::serialize(ostream &output) const {
  *  Writes out the data in the selected Neuron.
  *
  *  @param  output      stream to write out to.
- *  @param  sim_info    used as a reference to set info for neuronss.
- *  @param  i           index of the neuron (in neurons).
+ *  @param  index       index of the neuron (in neurons).
  */
-void AllIZHNeurons::writeNeuron(ostream &output, int i) const {
-   AllIFNeurons::writeNeuron(output, i);
+void AllIZHNeurons::writeNeuron(ostream &output, int index) const {
+   AllIFNeurons::writeNeuron(output, index);
 
-   output << Aconst_[i] << ends;
-   output << Bconst_[i] << ends;
-   output << Cconst_[i] << ends;
-   output << Dconst_[i] << ends;
-   output << u_[i] << ends;
-   output << C3_[i] << ends;
+   output << Aconst_[index] << ends;
+   output << Bconst_[index] << ends;
+   output << Cconst_[index] << ends;
+   output << Dconst_[index] << ends;
+   output << u_[index] << ends;
+   output << C3_[index] << ends;
 }
 
 #if !defined(USE_GPU)
@@ -279,7 +268,6 @@ void AllIZHNeurons::writeNeuron(ostream &output, int i) const {
  *  Update internal state of the indexed Neuron (called by every simulation step).
  *
  *  @param  index       Index of the Neuron to update.
- *  @param  sim_info    SimulationInfo class to read information from.
  */
 void AllIZHNeurons::advanceNeuron(const int index) {
    BGFLOAT &Vm = this->Vm_[index];
@@ -306,7 +294,8 @@ void AllIZHNeurons::advanceNeuron(const int index) {
       summationPoint += I0; // add IO
       // add noise
       BGFLOAT noise = (*rgNormrnd[0])();
-      DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << endl;)
+      // Happens really often, causes drastic slow down
+      // DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << endl;)
       summationPoint += noise * Inoise; // add noise
 
       BGFLOAT Vint = Vm * 1000;
@@ -318,22 +307,23 @@ void AllIZHNeurons::advanceNeuron(const int index) {
       Vm = Vb * 0.001 + C2 * summationPoint;  // add inputs
    }
 
-   DEBUG_MID(cout << index << " " << Vm << endl;)
-   DEBUG_MID(cout << "NEURON[" << index << "] {" << endl
-                  << "\tVm = " << Vm << endl
-                  << "\ta = " << a << endl
-                  << "\tb = " << b << endl
-                  << "\tc = " << Cconst_[index] << endl
-                  << "\td = " << Dconst_[index] << endl
-                  << "\tu = " << u << endl
-                  << "\tVthresh = " << Vthresh << endl
-                  << "\tsummationPoint = " << summationPoint << endl
-                  << "\tI0 = " << I0 << endl
-                  << "\tInoise = " << Inoise << endl
-                  << "\tC1 = " << C1 << endl
-                  << "\tC2 = " << C2 << endl
-                  << "\tC3 = " << C3 << endl
-                  << "}" << endl;)
+   // Happens really often, causes drastic slow down
+//   DEBUG_MID(cout << index << " " << Vm << endl;)
+//   DEBUG_MID(cout << "NEURON[" << index << "] {" << endl
+//                  << "\tVm = " << Vm << endl
+//                  << "\ta = " << a << endl
+//                  << "\tb = " << b << endl
+//                  << "\tc = " << Cconst_[index] << endl
+//                  << "\td = " << Dconst_[index] << endl
+//                  << "\tu = " << u << endl
+//                  << "\tVthresh = " << Vthresh << endl
+//                  << "\tsummationPoint = " << summationPoint << endl
+//                  << "\tI0 = " << I0 << endl
+//                  << "\tInoise = " << Inoise << endl
+//                  << "\tC1 = " << C1 << endl
+//                  << "\tC2 = " << C2 << endl
+//                  << "\tC3 = " << C3 << endl
+//                  << "}" << endl;)
 
    // clear synaptic input for next time step
    summationPoint = 0;
@@ -343,7 +333,6 @@ void AllIZHNeurons::advanceNeuron(const int index) {
  *  Fire the selected Neuron and calculate the result.
  *
  *  @param  index       Index of the Neuron to update.
- *  @param  sim_info    SimulationInfo class to read information from.
  */
 void AllIZHNeurons::fire(const int index) const {
    const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();

--- a/Simulation/Vertices/AllIZHNeurons.h
+++ b/Simulation/Vertices/AllIZHNeurons.h
@@ -99,8 +99,6 @@ public:
    /**
     *  Setup the internal structure of the class.
     *  Allocate memories to store all neurons' state.
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupNeurons();
 
@@ -111,14 +109,14 @@ public:
    virtual void cleanupNeurons();
 
    /**
-    *  Prints out all parameters of the neurons to console.
+    *  Prints out all parameters of the neurons to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const;
 
    /**
     *  Creates all the Neurons and assigns initial data for them.
     *
-    *  @param  sim_info    SimulationInfo class to read information from.
     *  @param  layout      Layout information of the neunal network.
     */
    virtual void createAllNeurons(Layout *layout);
@@ -126,16 +124,15 @@ public:
    /**
     *  Outputs state of the neuron chosen as a string.
     *
-    *  @param  i   index of the neuron (in neurons) to output info from.
+    *  @param  index   index of the neuron (in neurons) to output info from.
     *  @return the complete state of the neuron.
     */
-   virtual string toString(const int i) const;
+   virtual string toString(const int index) const;
 
    /**
     *  Reads and sets the data for all neurons from input stream.
     *
     *  @param  input       istream to read from.
-    *  @param  sim_info    used as a reference to set info for neuronss.
     */
    virtual void deserialize(istream &input);
 
@@ -143,7 +140,6 @@ public:
     *  Writes out the data in all neurons to output stream.
     *
     *  @param  output      stream to write out to.
-    *  @param  sim_info    used as a reference to set info for neuronss.
     */
    virtual void serialize(ostream &output) const;
 
@@ -156,68 +152,60 @@ public:
         *  @param  synapses               Reference to the allSynapses struct on host memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
-        *  @param  sim_info               SimulationInfo to refer from.
         *  @param  randNoise              Reference to the random noise array.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
         */
-       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, const SimulationInfo *sim_info, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
+       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
 
        /**
         *  Allocate GPU memories to store all neurons' states,
         *  and copy them from host to GPU memory.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void allocNeuronDeviceStruct( void** allNeuronsDevice, SimulationInfo *sim_info );
+       virtual void allocNeuronDeviceStruct( void** allNeuronsDevice);
 
        /**
         *  Delete GPU memories.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void deleteNeuronDeviceStruct( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void deleteNeuronDeviceStruct( void* allNeuronsDevice);
 
        /**
         *  Copy all neurons' data from host to device.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronHostToDevice( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronHostToDevice( void* allNeuronsDevice);
 
        /**
         *  Copy all neurons' data from device to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceToHost( void* allNeuronsDevice,);
 
        /**
         *  Copy spike history data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice);
 
        /**
         *  Copy spike counts data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice);
 
        /**
         *  Clear the spike counts out of all neurons.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice, const SimulationInfo *sim_info );
+       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice);
 
 
    protected:
@@ -226,36 +214,32 @@ public:
         *  (Helper function of allocNeuronDeviceStruct)
         *
         *  @param  allNeurons         Reference to the AllIZHNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void allocDeviceStruct( AllIZHNeuronsDeviceProperties &allNeurons, SimulationInfo *sim_info );
+       void allocDeviceStruct( AllIZHNeuronsDeviceProperties &allNeurons);
 
        /**
         *  Delete GPU memories.
         *  (Helper function of deleteNeuronDeviceStruct)
         *
         *  @param  allNeurons         Reference to the AllIZHNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void deleteDeviceStruct( AllIZHNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void deleteDeviceStruct( AllIZHNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Copy all neurons' data from host to device.
         *  (Helper function of copyNeuronHostToDevice)
         *
         *  @param  allNeurons         Reference to the AllIZHNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void copyHostToDevice( AllIZHNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void copyHostToDevice( AllIZHNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Copy all neurons' data from device to host.
         *  (Helper function of copyNeuronDeviceToHost)
         *
         *  @param  allNeurons         Reference to the AllIZHNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void copyDeviceToHost( AllIZHNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void copyDeviceToHost( AllIZHNeuronsDeviceProperties& allNeurons);
 
 #else  // !defined(USE_GPU)
 
@@ -264,7 +248,6 @@ protected:
     *  Helper for #advanceNeuron. Updates state of a single neuron.
     *
     *  @param  index            Index of the neuron to update.
-    *  @param  sim_info         SimulationInfo class to read information from.
     */
    virtual void advanceNeuron(const int index);
 
@@ -272,7 +255,6 @@ protected:
     *  Initiates a firing of a neuron to connected neurons.
     *
     *  @param  index            Index of the neuron to fire.
-    *  @param  sim_info         SimulationInfo class to read information from.
     */
    virtual void fire(const int index) const;
 
@@ -282,44 +264,41 @@ protected:
    /**
     *  Creates a single Neuron and generates data for it.
     *
-    *  @param  sim_info     SimulationInfo class to read information from.
-    *  @param  neuron_index Index of the neuron to create.
+    *  @param  neuronIndex Index of the neuron to create.
     *  @param  layout       Layout information of the neunal network.
     */
-   void createNeuron(int neuron_index, Layout *layout);
+   void createNeuron(int neuronIndex, Layout *layout);
 
    /**
     *  Set the Neuron at the indexed location to default values.
     *
-    *  @param  neuron_index    Index of the Neuron that the synapse belongs to.
+    *  @param  index    Index of the Neuron that the synapse belongs to.
     */
    void setNeuronDefaults(const int index);
 
    /**
     *  Initializes the Neuron constants at the indexed location.
     *
-    *  @param  neuron_index    Index of the Neuron.
+    *  @param  neuronIndex    Index of the Neuron.
     *  @param  deltaT          Inner simulation step duration
     */
-   virtual void initNeuronConstsFromParamValues(int neuron_index, const BGFLOAT deltaT);
+   virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT);
 
    /**
     *  Sets the data for Neuron #index to input's data.
     *
     *  @param  input       istream to read from.
-    *  @param  sim_info    used as a reference to set info for neurons.
-    *  @param  i           index of the neuron (in neurons).
+    *  @param  index           index of the neuron (in neurons).
     */
-   void readNeuron(istream &input, int i);
+   void readNeuron(istream &input, int index);
 
    /**
     *  Writes out the data in the selected Neuron.
     *
     *  @param  output      stream to write out to.
-    *  @param  sim_info    used as a reference to set info for neuronss.
-    *  @param  i           index of the neuron (in neurons).
+    *  @param  index           index of the neuron (in neurons).
     */
-   void writeNeuron(ostream &output, int i) const;
+   void writeNeuron(ostream &output, int index) const;
 
 private:
    /**

--- a/Simulation/Vertices/AllLIFNeurons.cpp
+++ b/Simulation/Vertices/AllLIFNeurons.cpp
@@ -8,10 +8,13 @@ AllLIFNeurons::AllLIFNeurons() : AllIFNeurons() {
 AllLIFNeurons::~AllLIFNeurons() {
 }
 
+/**
+ *  Prints out all parameters of the neurons to logging file.
+ *  Registered to OperationManager as Operation::printParameters
+ */
 void AllLIFNeurons::printParameters() const {
-   AllNeurons::printParameters();
-   cout << "\tVertice Type: AllLIFNeurons" << endl;
    AllIFNeurons::printParameters();
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices Type: AllLIFNeurons" << endl);
 }
 
 #if !defined(USE_GPU)
@@ -20,7 +23,6 @@ void AllLIFNeurons::printParameters() const {
  *  Update internal state of the indexed Neuron (called by every simulation step).
  *
  *  @param  index       Index of the Neuron to update.
- *  @param  sim_info    SimulationInfo class to read information from.
  */
 void AllLIFNeurons::advanceNeuron(const int index) {
     BGFLOAT &Vm = this->Vm_[index];
@@ -42,30 +44,30 @@ void AllLIFNeurons::advanceNeuron(const int index) {
         summationPoint += I0; // add IO
         // add noise
         BGFLOAT noise = (*rgNormrnd[0])();
-        DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << endl;)
+        //LOG4CPLUS_DEBUG(neuronLogger_, "ADVANCE NEURON[" << index << "] :: Noise = " << noise);
         summationPoint += noise * Inoise; // add noise
         Vm = C1 * Vm + C2 * summationPoint; // decay Vm and add inputs
     }
     // clear synaptic input for next time step
     summationPoint = 0;
 
-    DEBUG_MID(cout << index << " " << Vm << endl;)
-    DEBUG_MID(cout << "NEURON[" << index << "] {" << endl
-                   << "\tVm = " << Vm << endl
-                   << "\tVthresh = " << Vthresh << endl
-                   << "\tsummationPoint = " << summationPoint << endl
-                   << "\tI0 = " << I0 << endl
-                   << "\tInoise = " << Inoise << endl
-                   << "\tC1 = " << C1 << endl
-                   << "\tC2 = " << C2 << endl
-                   << "}" << endl;)
+    // Causes a huge slowdown since it's printed so frequently
+//    LOG4CPLUS_DEBUG(neuronLogger_, "Index: " << index << " Vm: " << Vm);
+//    LOG4CPLUS_DEBUG(neuronLogger_, "NEURON[" << index << "] {" << endl
+//                   << "\tVm = " << Vm << endl
+//                   << "\tVthresh = " << Vthresh << endl
+//                   << "\tsummationPoint = " << summationPoint << endl
+//                   << "\tI0 = " << I0 << endl
+//                   << "\tInoise = " << Inoise << endl
+//                   << "\tC1 = " << C1 << endl
+//                   << "\tC2 = " << C2 << endl
+//                   << "}" << endl);
 }
 
 /*
  *  Fire the selected Neuron and calculate the result.
  *
  *  @param  index       Index of the Neuron to update.
- *  @param  sim_info    SimulationInfo class to read information from.
  */
 void AllLIFNeurons::fire(const int index) const {
     const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();

--- a/Simulation/Vertices/AllLIFNeurons.h
+++ b/Simulation/Vertices/AllLIFNeurons.h
@@ -109,8 +109,9 @@ public:
    static IAllNeurons *Create() { return new AllLIFNeurons(); }
 
    /**
- *  Prints out all parameters of the neurons to console.
- */
+    *  Prints out all parameters of the neurons to logging file.
+    *  Registered to OperationManager as Operation::printParameters
+    */
    virtual void printParameters() const;
 
 #if defined(USE_GPU)
@@ -123,11 +124,10 @@ public:
         *  @param  synapses               Reference to the allSynapses struct on host memory.
         *  @param  allNeuronsDevice       Reference to the allNeurons struct on device memory.
         *  @param  allSynapsesDevice      Reference to the allSynapses struct on device memory.
-        *  @param  sim_info               SimulationInfo to refer from.
         *  @param  randNoise              Reference to the random noise array.
         *  @param  synapseIndexMapDevice  Reference to the SynapseIndexMap on device memory.
         */
-       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, const SimulationInfo *sim_info, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
+       virtual void advanceNeurons(IAllSynapses &synapses, void* allNeuronsDevice, void* allSynapsesDevice, float* randNoise, SynapseIndexMap* synapseIndexMapDevice);
 
 #else  // !defined(USE_GPU)
 protected:
@@ -135,16 +135,14 @@ protected:
    /**
     *  Helper for #advanceNeuron. Updates state of a single neuron.
     *
-    *  @param  index            Index of the neuron to update.
-    *  @param  sim_info         SimulationInfo class to read information from.
+    *  @param  index Index of the neuron to update.
     */
    virtual void advanceNeuron(const int index);
 
    /**
     *  Initiates a firing of a neuron to connected neurons.
     *
-    *  @param  index            Index of the neuron to fire.
-    *  @param  sim_info         SimulationInfo class to read information from.
+    *  @param  index Index of the neuron to fire.
     */
    virtual void fire(const int index) const;
 

--- a/Simulation/Vertices/AllNeurons.cpp
+++ b/Simulation/Vertices/AllNeurons.cpp
@@ -3,8 +3,7 @@
 #include "OperationManager.h"
 
 // Default constructor
-AllNeurons::AllNeurons() :
-      size_(0) {
+AllNeurons::AllNeurons() : size_(0) {
    summationMap_ = NULL;
 
    // Register loadParameters function as a loadParameters operation in the Operation Manager
@@ -14,6 +13,10 @@ AllNeurons::AllNeurons() :
    // Register printParameters function as a printParameters operation in the OperationManager
    function<void()> printParametersFunc = bind(&IAllNeurons::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+
+   // Get a copy of the file and neuron logger to use log4cplus macros to print to debug files
+   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+   neuronLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("neuron"));
 }
 
 AllNeurons::~AllNeurons() {
@@ -22,8 +25,6 @@ AllNeurons::~AllNeurons() {
 
 /*
  *  Setup the internal structure of the class (allocate memories).
- *
- *  @param  sim_info  SimulationInfo class to read information from.
  */
 void AllNeurons::setupNeurons() {
    size_ = Simulator::getInstance().getTotalNeurons();
@@ -56,6 +57,10 @@ void AllNeurons::freeResources() {
    size_ = 0;
 }
 
+/**
+ *  Prints out all parameters of the neurons to logging file.
+ *  Registered to OperationManager as Operation::printParameters
+ */
 void AllNeurons::printParameters() const {
-   cout << "VERTICE PARAMETERS" << endl;
+   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTICES PARAMETERS");
 }

--- a/Simulation/Vertices/AllNeurons.h
+++ b/Simulation/Vertices/AllNeurons.h
@@ -37,6 +37,8 @@
 
 using namespace std;
 
+#include <log4cplus/loggingmacros.h>
+
 #include "IAllNeurons.h"
 #include "BGTypes.h"
 
@@ -50,7 +52,6 @@ public:
     *  Setup the internal structure of the class.
     *  Allocate memories to store all neurons' state.
     *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupNeurons();
 
@@ -60,6 +61,10 @@ public:
     */
    virtual void cleanupNeurons();
 
+   /**
+    *  Prints out all parameters of the neurons to logging file.
+    *  Registered to OperationManager as Operation::printParameters
+    */
    virtual void printParameters() const;
 
    /**
@@ -76,6 +81,10 @@ protected:
     *  Total number of neurons.
     */
    int size_;
+
+   // Loggers used to print to using log4cplus logging macros
+   log4cplus::Logger fileLogger_; // Logs to Output/Debug/logging.txt
+   log4cplus::Logger neuronLogger_; // Logs to Output/Debug/neurons.txt
 
 private:
    /**

--- a/Simulation/Vertices/AllSpikingNeurons.h
+++ b/Simulation/Vertices/AllSpikingNeurons.h
@@ -53,8 +53,6 @@ public:
    /**
     *  Setup the internal structure of the class.
     *  Allocate memories to store all neurons' state.
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupNeurons();
 
@@ -66,8 +64,6 @@ public:
 
    /**
     *  Clear the spike counts out of all Neurons.
-    *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    void clearSpikeCounts();
 
@@ -84,25 +80,22 @@ public:
         *  Copy spike counts data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice, const SimulationInfo *sim_info ) = 0;
+       virtual void copyNeuronDeviceSpikeCountsToHost( void* allNeuronsDevice) = 0;
 
        /**
         *  Copy spike history data stored in device memory to host.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice, const SimulationInfo *sim_info ) = 0;
+       virtual void copyNeuronDeviceSpikeHistoryToHost( void* allNeuronsDevice) = 0;
 
        /**
         *  Clear the spike counts out of all neurons.
         *
         *  @param  allNeuronsDevice   Reference to the allNeurons struct on device memory.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice, const SimulationInfo *sim_info ) = 0;
+       virtual void clearNeuronSpikeCounts( void* allNeuronsDevice) = 0;
 
    protected:
        /**
@@ -110,27 +103,24 @@ public:
         *  (Helper function of copyNeuronDeviceSpikeHistoryToHost)
         *
         *  @param  allNeurons        Reference to the AllSpikingNeuronsDeviceProperties struct.
-        *  @param  sim_info          SimulationInfo to refer from.
         */
-       void copyDeviceSpikeHistoryToHost( AllSpikingNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void copyDeviceSpikeHistoryToHost( AllSpikingNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Copy spike counts data stored in device memory to host.
         *  (Helper function of copyNeuronDeviceSpikeCountsToHost)
         *
         *  @param  allNeurons         Reference to the AllSpikingNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void copyDeviceSpikeCountsToHost( AllSpikingNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void copyDeviceSpikeCountsToHost( AllSpikingNeuronsDeviceProperties& allNeurons);
 
        /**
         *  Clear the spike counts out of all neurons in device memory.
         *  (helper function of clearNeuronSpikeCounts)
         *
         *  @param  allNeurons         Reference to the AllSpikingNeuronsDeviceProperties struct.
-        *  @param  sim_info           SimulationInfo to refer from.
         */
-       void clearDeviceSpikeCounts( AllSpikingNeuronsDeviceProperties& allNeurons, const SimulationInfo *sim_info );
+       void clearDeviceSpikeCounts( AllSpikingNeuronsDeviceProperties& allNeurons);
 #else // !defined(USE_GPU)
 
 public:
@@ -139,7 +129,6 @@ public:
     *  Notify outgoing synapses if neuron has fired.
     *
     *  @param  synapses         The Synapse list to search from.
-    *  @param  sim_info         SimulationInfo class to read information from.
     *  @param  synapseIndexMap  Reference to the SynapseIndexMap.
     */
    virtual void advanceNeurons(IAllSynapses &synapses, const SynapseIndexMap *synapseIndexMap);
@@ -159,7 +148,6 @@ protected:
     *  Helper for #advanceNeuron. Updates state of a single neuron.
     *
     *  @param  index            Index of the neuron to update.
-    *  @param  sim_info         SimulationInfo class to read information from.
     */
    virtual void advanceNeuron(const int index) = 0;
 
@@ -167,7 +155,6 @@ protected:
     *  Initiates a firing of a neuron to connected neurons
     *
     *  @param  index            Index of the neuron to fire.
-    *  @param  sim_info         SimulationInfo class to read information from.
     */
    virtual void fire(const int index) const;
 

--- a/Simulation/Vertices/IAllNeurons.h
+++ b/Simulation/Vertices/IAllNeurons.h
@@ -24,7 +24,6 @@ public:
     *  Setup the internal structure of the class.
     *  Allocate memories to store all neurons' state.
     *
-    *  @param  sim_info  SimulationInfo class to read information from.
     */
    virtual void setupNeurons() = 0;
 
@@ -34,20 +33,22 @@ public:
     */
    virtual void cleanupNeurons() = 0;
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
+
+    /*
+     *  Load member variables from configuration file.
+     *  Registered to OperationManager as Operation::loadParameters
+     */
    virtual void loadParameters() = 0;
 
    /**
-    *  Prints out all parameters of the neurons to ostream.
-    *
-    *  @param  output  ostream to send output to.
+    *  Prints out all parameters of the neurons to logging file.
+    *  Registered to OperationManager as Operation::printParameters
     */
    virtual void printParameters() const = 0;
 
    /**
     *  Creates all the Neurons and assigns initial data for them.
     *
-    *  @param  sim_info    SimulationInfo class to read information from.
     *  @param  layout      Layout information of the neunal network.
     */
    virtual void createAllNeurons(Layout *layout) = 0;
@@ -121,7 +122,6 @@ public:
     *  Notify outgoing synapses if neuron has fired.
     *
     *  @param  synapses         The Synapse list to search from.
-    *  @param  sim_info         SimulationInfo class to read information from.
     *  @param  synapseIndexMap  Reference to the SynapseIndexMap.
     */
    virtual void advanceNeurons(IAllSynapses &synapses, const SynapseIndexMap *synapseIndexMap) = 0;

--- a/Testing/RunTests.cpp
+++ b/Testing/RunTests.cpp
@@ -25,9 +25,9 @@ int main() {
    ::log4cplus::initialize();
    ::log4cplus::PropertyConfigurator::doConfigure("RuntimeFiles/log4cplus_configure.ini");
 
-   // Get the instance of the main logger and begin tests
-   log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("main"));
-   LOG4CPLUS_INFO(logger, "Running Tests");
+   // Get the instance of the console logger and begin tests
+   log4cplus::Logger consoleLogger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
+   LOG4CPLUS_INFO(consoleLogger, "Running Tests");
 
    // Disabling cout and cerr so output and error messages won't interrupt test flow.
    std::cout.setstate(std::ios_base::failbit);

--- a/docs/RebuildNotes/RecordersNotes.md
+++ b/docs/RebuildNotes/RecordersNotes.md
@@ -49,8 +49,8 @@ in hdf5recorder.cpp
 
 // someo of this is specific to the hdf5 recorder stuff
 // hdf5 dataset name
-const H5std_string  nameBurstHist("burstinessHist");
-const H5std_string  nameSpikesHist("spikesHistory");
+const H5std_string  nameBurstHist("burstinessHist_");
+const H5std_string  nameSpikesHist("spikesHistory_");
 
 const H5std_string  nameXloc("xloc");
 const H5std_string  nameYloc("yloc");
@@ -78,7 +78,7 @@ void Hdf5Recorder::init(const string& stateOutputFileName)
     try
     {
         // create a new file using the default property lists
-        stateOut = new H5File( stateOutputFileName, H5F_ACC_TRUNC );
+        stateOut_ = new H5File( stateOutputFileName, H5F_ACC_TRUNC );
 
         initDataSet();
     }


### PR DESCRIPTION
- There are three loggers now, one for the console, one for logging file, and one for neuron related information.
- All simulator objects now have at least one logger as a member variable.
- All previous DEBUG macros replaced with log4cplus macros using the most relevant logger.
- Commenting cleanup throughout all simulation object files.
- Removed sim info from all USE_GPU sections.
- Went through all simulator object files and did naming cleanup to fit coding standards (camelCasing rather than underscores) and to add more consistently.

Closes #113 Closes #118 