### PR TITLE
Renamed all setup methods

### DIFF
--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -59,7 +59,7 @@ public:
    ///  @param  layout    Layout information of the neural network.
    ///  @param  neurons   The Neuron list to search from.
    ///  @param  synapses  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *synapses) = 0;
+   virtual void allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *synapses) = 0;
 
    /// Load member variables from configuration file.
    /// Registered to OperationManager as Operations::op::loadParameters

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -18,7 +18,7 @@ Connections911::~Connections911() {
 
 }
 
-void Connections911::setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *edges) {
+void Connections911::allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *edges) {
    int numVertices = Simulator::getInstance().getTotalVertices();
    vector<DistDestVertex> distDestVertices;
 

--- a/Simulator/Connections/NG911/Connections911.h
+++ b/Simulator/Connections/NG911/Connections911.h
@@ -34,7 +34,7 @@ public:
    ///  @param  layout    Layout information of the network.
    ///  @param  vertices   The Vertex list to search from.
    ///  @param  edges  The edge list to search from.
-   virtual void setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *edges);
+   virtual void allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *edges);
 
    /// Load member variables from configuration file.
    /// Registered to OperationManager as Operations::op::loadParameters

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -83,7 +83,7 @@ ConnGrowth::~ConnGrowth() {
 ///  @param  layout    Layout information of the neural network.
 ///  @param  vertices   The vertex list to search from.
 ///  @param  synapses  The Synapse list to search from.
-void ConnGrowth::setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *synapses) {
+void ConnGrowth::allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *synapses) {
    int numVertices = Simulator::getInstance().getTotalVertices();
    radiiSize_ = numVertices;
 

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -36,6 +36,7 @@
 #include "ConnGrowth.h"
 #include "ParseParamError.h"
 #include "AllEdges.h"
+#include "AllNeuroEdges.h"
 #include "XmlGrowthRecorder.h"
 #include "AllSpikingNeurons.h"
 #include "Matrix/CompleteMatrix.h"
@@ -241,7 +242,7 @@ void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout *layout) {
 void ConnGrowth::updateSynapsesWeights(const int numVertices, IAllVertices &ivertices, AllEdges &iedges,
                                        Layout *layout) {
    AllVertices &vertices = dynamic_cast<AllVertices &>(ivertices);
-   AllEdges &synapses = dynamic_cast<AllEdges &>(iedges);
+   AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(iedges);
 
    // For now, we just set the weights to equal the areas. We will later
    // scale it and set its sign (when we index and get its sign).

--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -91,7 +91,7 @@ public:
    ///  @param  layout    Layout information of the neural network.
    ///  @param  neurons   The Neuron list to search from.
    ///  @param  synapses  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, IAllVertices *neurons, AllEdges *synapses);
+   virtual void allocateMemory(Layout *layout, IAllVertices *neurons, AllEdges *synapses);
 
    /// Load member variables from configuration file.
    /// Registered to OperationManager as Operations::op::loadParameters

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -43,14 +43,14 @@ ConnStatic::~ConnStatic() {
 ///  @param  edges  The Synapse list to search from.
 void ConnStatic::setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *edges) {
    int numVertices = Simulator::getInstance().getTotalVertices();
-   vector<DistDestVertex> distDestVertices[numVertices];
+   vector<DistDestVertex> distDestVertices;
 
    int added = 0;
 
    LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
 
    for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
-      distDestVertices[srcVertex].clear();
+      distDestVertices.clear();
 
       // pick the connections shorter than threshConnsRadius
       for (int destVertex = 0; destVertex < numVertices; destVertex++) {
@@ -60,21 +60,21 @@ void ConnStatic::setupConnections(Layout *layout, IAllVertices *vertices, AllEdg
                DistDestVertex distDestVertex;
                distDestVertex.dist = dist;
                distDestVertex.destVertex = destVertex;
-               distDestVertices[srcVertex].push_back(distDestVertex);
+               distDestVertices.push_back(distDestVertex);
             }
          }
       }
 
       // sort ascendant
-      sort(distDestVertices[srcVertex].begin(), distDestVertices[srcVertex].end());
+      sort(distDestVertices.begin(), distDestVertices.end());
       // pick the shortest m_nConnsPerNeuron connections
-      for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && (int) i < connsPerVertex_; i++) {
-         int destVertex = distDestVertices[srcVertex][i].destVertex;
+      for (BGSIZE i = 0; i < distDestVertices.size() && (int) i < connsPerVertex_; i++) {
+         int destVertex = distDestVertices[i].destVertex;
          edgeType type = layout->edgType(srcVertex, destVertex);
          BGFLOAT *sumPoint = &(dynamic_cast<AllVertices *>(vertices)->summationMap_[destVertex]);
 
          LOG4CPLUS_DEBUG(fileLogger_, "Source: " << srcVertex << " Dest: " << destVertex << " Dist: "
-                                                 << distDestVertices[srcVertex][i].dist);
+                                                 << distDestVertices[i].dist);
 
          BGSIZE iEdg;
          edges->addEdge(iEdg, type, srcVertex, destVertex, sumPoint, Simulator::getInstance().getDeltaT());

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -41,7 +41,7 @@ ConnStatic::~ConnStatic() {
 ///  @param  layout    Layout information of the neural network.
 ///  @param  vertices   The Vertex list to search from.
 ///  @param  edges  The Synapse list to search from.
-void ConnStatic::setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *edges) {
+void ConnStatic::allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *edges) {
    int numVertices = Simulator::getInstance().getTotalVertices();
    vector<DistDestVertex> distDestVertices;
 

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -82,10 +82,13 @@ void ConnStatic::allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges
 
          // set edge weight
          // TODO: we need another synaptic weight distibution mode (normal distribution)
-         if (edges->edgSign(type) > 0) {
-            dynamic_cast<AllNeuroEdges *>(edges)->W_[iEdg] = rng.inRange(excWeight_[0], excWeight_[1]);
+
+         AllNeuroEdges *neuroEdges = dynamic_cast<AllNeuroEdges *>(edges);
+
+         if (neuroEdges->edgSign(type) > 0) {
+            neuroEdges->W_[iEdg] = rng.inRange(excWeight_[0], excWeight_[1]);
          } else {
-            dynamic_cast<AllNeuroEdges *>(edges)->W_[iEdg] = rng.inRange(inhWeight_[0], inhWeight_[1]);
+            neuroEdges->W_[iEdg] = rng.inRange(inhWeight_[0], inhWeight_[1]);
          }
       }
    }

--- a/Simulator/Connections/Neuro/ConnStatic.h
+++ b/Simulator/Connections/Neuro/ConnStatic.h
@@ -49,7 +49,7 @@ public:
    ///  @param  layout    Layout information of the neural network.
    ///  @param  vertices   The Neuron list to search from.
    ///  @param  edges  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, IAllVertices *vertices, AllEdges *edges);
+   virtual void allocateMemory(Layout *layout, IAllVertices *vertices, AllEdges *edges);
 
    /// Load member variables from configuration file.
    /// Registered to OperationManager as Operations::op::loadParameters

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -22,8 +22,8 @@ CPUModel::~CPUModel() {
 }
 
 /// Sets up the Simulation.
-void CPUModel::setupSim() {
-   Model::setupSim();
+void CPUModel::allocateMemory() {
+   Model::allocateMemory();
    // Create a normalized random number generator
    rgNormrnd.push_back(new Norm(0, 1, Simulator::getInstance().getSeed()));
 }

--- a/Simulator/Core/CPUModel.h
+++ b/Simulator/Core/CPUModel.h
@@ -49,7 +49,7 @@ public:
    virtual ~CPUModel();
 
    /// Set up model state, if anym for a specific simulation run.
-   virtual void setupSim();
+   virtual void allocateMemory();
 
    /// Performs any finalization tasks on network following a simulation.
    virtual void finish();

--- a/Simulator/Core/GPUModel.cu
+++ b/Simulator/Core/GPUModel.cu
@@ -82,13 +82,13 @@ void GPUModel::deleteDeviceStruct(void** allVerticesDevice, void** allEdgesDevic
 }
 
 /// Sets up the Simulation.
-void GPUModel::setupSim()
+void GPUModel::allocateMemory()
 {
   // Set device ID
   HANDLE_ERROR( cudaSetDevice( g_deviceId ) );
   // Set DEBUG flag
   HANDLE_ERROR( cudaMemcpyToSymbol (d_debug_mask, &g_debug_mask, sizeof(int) ) );
-  Model::setupSim();
+  Model::allocateMemory();
 
   //initialize Mersenne Twister
   //assuming numVertices >= 100 and is a multiple of 100. Note rng_mt_rng_count must be <= MT_RNG_COUNT

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -78,7 +78,7 @@ public:
    virtual ~GPUModel();
 
    /// Set up model state, if anym for a specific simulation run.
-   virtual void setupSim();
+   virtual void allocateMemory();
 
    /// Performs any finalization tasks on network following a simulation.
    virtual void finish();

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -68,17 +68,17 @@ void Model::createAllVertices() {
 }
 
 /// Sets up the Simulation.
-void Model::setupSim() {
+void Model::allocateMemory() {
    LOG4CPLUS_INFO(fileLogger_, "Setting up Vertices...");
-   layout_->getVertices()->setupVertices();
+   layout_->getVertices()->allocateMemory();
    LOG4CPLUS_INFO(fileLogger_, "Setting up Edges...");
-   connections_->getEdges()->setupEdges();
+   connections_->getEdges()->allocateMemory();
 #ifdef PERFORMANCE_METRICS
    // Start timer for initialization
    Simulator::getInstance.short_timer.start();
 #endif
    LOG4CPLUS_INFO(fileLogger_, "Setting up Layout...");
-   layout_->setupLayout();
+   layout_->allocateMemory();
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (layout)
    t_host_initialization_layout += Simulator::getInstance().short_timer.lap() / 1000000.0;
@@ -97,7 +97,7 @@ void Model::setupSim() {
    Simulator::getInstance().short_timer.start();
 #endif
    LOG4CPLUS_INFO(fileLogger_, "Setting up Connections...");
-   connections_->setupConnections(layout_.get(), layout_->getVertices().get(), connections_->getEdges().get());
+   connections_->allocateMemory(layout_.get(), layout_->getVertices().get(), connections_->getEdges().get());
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (connections)
    t_host_initialization_connections += Simulator::getInstance().short_timer.lap() / 1000000.0;

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -49,8 +49,8 @@ public:
    virtual void saveData();
 
    /// Set up model state, for a specific simulation run.
-   /// Downstream from IModel setupSim()
-   virtual void setupSim();
+   /// Downstream from IModel allocateMemory()
+   virtual void allocateMemory();
 
    /// Performs any finalization tasks on network following a simulation.
    virtual void finish() = 0; 

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -55,7 +55,7 @@ void Simulator::setup() {
    cerr << "done." << endl;
 #endif
    LOG4CPLUS_INFO(fileLogger_, "Initializing models in network... ");
-   model_->setupSim();
+   model_->allocateMemory();
    LOG4CPLUS_INFO(fileLogger_, "Model initialization finished");
 
    // init stimulus input object
@@ -114,7 +114,7 @@ void Simulator::reset() {
    // Reset global simulation Step to 0
    g_simulationStep = 0;
    // Initialize and prepare network for simulation
-   model_->setupSim();
+   model_->allocateMemory();
    LOG4CPLUS_INFO(fileLogger_, "Simulator Reset Finished");
 }
 

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -26,7 +26,7 @@ AllEdges::AllEdges() :
 }
 
 AllEdges::AllEdges(const int numVertices, const int maxEdges) {
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 AllEdges::~AllEdges() {
@@ -71,15 +71,15 @@ void AllEdges::printParameters() const {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllEdges::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+void AllEdges::allocateMemory() {
+   allocateMemory(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 ///
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of edges per vertex.
-void AllEdges::setupEdges(const int numVertices, const int maxEdges) {
+void AllEdges::allocateMemory(const int numVertices, const int maxEdges) {
    BGSIZE maxTotalEdges = maxEdges * numVertices;
 
    maxEdgesPerVertex_ = maxEdges;

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -168,15 +168,6 @@ edgeType AllEdges::edgeOrdinalToType(const int typeOrdinal) {
    }
 }
 
-///  Get the sign of the edgeType.
-///
-///  @param    type    edgeType 
-///  @return   1 or -1, or 0 if error
-int AllEdges::edgSign(const edgeType type) {
-   return ETYPE_UNDEF;
-}
-
-
 ///  Create a edge index map.
 EdgeIndexMap *AllEdges::createEdgeIndexMap() {
    int vertexCount = Simulator::getInstance().getTotalVertices();

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -61,13 +61,7 @@ public:
    ///  Create a edge index map.
    virtual EdgeIndexMap *createEdgeIndexMap();
 
-   ///  Get the sign of the edgeType.
-   ///
-   ///  @param    type    edgeType 
-   ///  @return   1 or -1, or 0 if error
-   int edgSign(const edgeType type);
-
-      ///  Cereal serialization method
+   ///  Cereal serialization method
    ///  (Serializes edge weights, source vertices, and destination vertices)
    template<class Archive>
    void save(Archive &archive) const;

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -25,7 +25,7 @@ public:
    virtual ~AllEdges();
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    /// Load member variables from configuration file.
    /// Registered to OperationManager as Operation::op::loadParameters
@@ -82,7 +82,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of edges per vertex.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Sets the data for Edge to input's data.
    ///

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -20,7 +20,7 @@ All911Edges::~All911Edges() {
 
 }
 
-void All911Edges::setupEdges() {
+void All911Edges::allocateMemory() {
    int numVertices = Simulator::getInstance().getTotalVertices();
    int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
 

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -70,19 +70,3 @@ void All911Edges::printParameters() const {
 void All911Edges::advanceEdge(const BGSIZE iEdg, IAllVertices *vertices) {
 
 }
-
-///  Get the sign of the edgeType.
-///
-///  @param    type    edgeType 
-///  @return   1 or -1, or 0 if error
-int All911Edges::edgSign(const edgeType type) {
-   // switch (type) {
-   //    case CP:
-   //    case PR:
-   //       return -1;
-   //    case ETYPE_UNDEF:
-   //       // TODO error.
-   //       return 0;
-   // }
-   return 0;
-}

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -52,11 +52,6 @@ public:
    virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               edgeType type);
 
-   ///  Get the sign of the edgeType.
-   ///
-   ///  @param    type    edgeType 
-   virtual int edgSign(const edgeType type);
-
    ///  Prints out all parameters to logging file.
    ///  Registered to OperationManager as Operation::printParameters
    virtual void printParameters() const;

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -39,7 +39,7 @@ public:
    static AllEdges *Create() { return new All911Edges(); }
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Create a Edge and connect it to the model.
    ///

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -19,7 +19,7 @@ AllDSSynapses::AllDSSynapses() : AllSpikingSynapses() {
 
 AllDSSynapses::AllDSSynapses(const int numVertices, const int maxEdges) :
       AllSpikingSynapses(numVertices, maxEdges) {
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 AllDSSynapses::~AllDSSynapses() {
@@ -43,16 +43,16 @@ AllDSSynapses::~AllDSSynapses() {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllDSSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+void AllDSSynapses::allocateMemory() {
+   allocateMemory(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 ///
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
-void AllDSSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllSpikingSynapses::setupEdges(numVertices, maxEdges);
+void AllDSSynapses::allocateMemory(const int numVertices, const int maxEdges) {
+   AllSpikingSynapses::allocateMemory(numVertices, maxEdges);
 
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -61,7 +61,7 @@ public:
    static AllEdges *Create() { return new AllDSSynapses(); }
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Reset time varying state vars and recompute decay.
    ///
@@ -92,7 +92,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Sets the data for Synapse to input's data.
    ///

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -19,7 +19,7 @@ AllDynamicSTDPSynapses::AllDynamicSTDPSynapses() : AllSTDPSynapses() {
 
 AllDynamicSTDPSynapses::AllDynamicSTDPSynapses(const int numVertices, const int maxEdges) :
       AllSTDPSynapses(numVertices, maxEdges) {
-    setupEdges(numVertices, maxEdges);
+    allocateMemory(numVertices, maxEdges);
 }
 
 AllDynamicSTDPSynapses::~AllDynamicSTDPSynapses() {
@@ -43,16 +43,16 @@ AllDynamicSTDPSynapses::~AllDynamicSTDPSynapses() {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllDynamicSTDPSynapses::setupEdges() {
-    setupEdges(Simulator::getInstance().getDeltaT(), Simulator::getInstance().getMaxEdgesPerVertex());
+void AllDynamicSTDPSynapses::allocateMemory() {
+    allocateMemory(Simulator::getInstance().getDeltaT(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 /// 
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
-void AllDynamicSTDPSynapses::setupEdges(const int numVertices, const int maxEdges) {
-    AllSTDPSynapses::setupEdges(numVertices, maxEdges);
+void AllDynamicSTDPSynapses::allocateMemory(const int numVertices, const int maxEdges) {
+    AllSTDPSynapses::allocateMemory(numVertices, maxEdges);
 
     BGSIZE maxTotalSynapses = maxEdges * numVertices;
 

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -67,7 +67,7 @@ public:
    static AllEdges *Create() { return new AllDynamicSTDPSynapses(); }
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Reset time varying state vars and recompute decay.
    ///
@@ -98,7 +98,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Sets the data for Synapse to input's data.
    ///

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -13,7 +13,7 @@ AllNeuroEdges::AllNeuroEdges() : AllEdges() {
 }
 
 AllNeuroEdges::AllNeuroEdges(const int numVertices, const int maxEdges) {
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 AllNeuroEdges::~AllNeuroEdges() {
@@ -24,15 +24,15 @@ AllNeuroEdges::~AllNeuroEdges() {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllNeuroEdges::setupEdges() {
+void AllNeuroEdges::allocateMemory() {
    int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
    int numVertices = Simulator::getInstance().getTotalVertices();
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllNeuroEdges::setupEdges(const int numVertices, const int maxEdges) {
-   AllEdges::setupEdges(numVertices, maxEdges);
+void AllNeuroEdges::allocateMemory(const int numVertices, const int maxEdges) {
+   AllEdges::allocateMemory(numVertices, maxEdges);
 
    BGSIZE maxTotalEdges = maxEdges * numVertices;
    

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -47,7 +47,7 @@ public:
    virtual ~AllNeuroEdges();
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Reset time varying state vars and recompute decay.
    ///
@@ -80,7 +80,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of edges per vertex.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Sets the data for Synapse to input's data.
    ///

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -30,7 +30,7 @@ AllSTDPSynapses::AllSTDPSynapses() : AllSpikingSynapses() {
 
 AllSTDPSynapses::AllSTDPSynapses(const int numVertices, const int maxEdges) :
       AllSpikingSynapses(numVertices, maxEdges) {
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 AllSTDPSynapses::~AllSTDPSynapses() {
@@ -72,16 +72,16 @@ AllSTDPSynapses::~AllSTDPSynapses() {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllSTDPSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+void AllSTDPSynapses::allocateMemory() {
+   allocateMemory(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 ///
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
-void AllSTDPSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllSpikingSynapses::setupEdges(numVertices, maxEdges);
+void AllSTDPSynapses::allocateMemory(const int numVertices, const int maxEdges) {
+   AllSpikingSynapses::allocateMemory(numVertices, maxEdges);
 
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -81,7 +81,7 @@ public:
    static AllEdges *Create() { return new AllSTDPSynapses(); }
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Reset time varying state vars and recompute decay.
    ///
@@ -118,7 +118,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Sets the data for Synapse to input's data.
    ///

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -18,7 +18,7 @@ AllSpikingSynapses::AllSpikingSynapses() : AllNeuroEdges() {
 }
 
 AllSpikingSynapses::AllSpikingSynapses(const int numVertices, const int maxEdges) {
-   setupEdges(numVertices, maxEdges);
+   allocateMemory(numVertices, maxEdges);
 }
 
 AllSpikingSynapses::~AllSpikingSynapses() {
@@ -42,16 +42,16 @@ AllSpikingSynapses::~AllSpikingSynapses() {
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
-void AllSpikingSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+void AllSpikingSynapses::allocateMemory() {
+   allocateMemory(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 ///
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
-void AllSpikingSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllNeuroEdges::setupEdges(numVertices, maxEdges);
+void AllSpikingSynapses::allocateMemory(const int numVertices, const int maxEdges) {
+   AllNeuroEdges::allocateMemory(numVertices, maxEdges);
 
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -45,7 +45,7 @@ public:
    }
 
    ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+   virtual void allocateMemory();
 
    ///  Reset time varying state vars and recompute decay.
    ///
@@ -82,7 +82,7 @@ protected:
    ///
    ///  @param  numVertices   Total number of vertices in the network.
    ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+   virtual void allocateMemory(const int numVertices, const int maxEdges);
 
    ///  Initializes the queues for the Synapse.
    ///

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -66,7 +66,7 @@ shared_ptr<IAllVertices> Layout::getVertices() const {
 
 /// Setup the internal structure of the class.
 /// Allocate memories to store all layout state, no sequential dependency in this method
-void Layout::setupLayout() {
+void Layout::allocateMemory() {
    int numVertices = Simulator::getInstance().getTotalVertices();
 
    // Allocate memory

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -35,7 +35,7 @@ public:
 
    /// Setup the internal structure of the class.
    /// Allocate memories to store all layout state.
-   virtual void setupLayout();
+   virtual void allocateMemory();
 
    /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
    virtual void loadParameters() = 0;

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -37,7 +37,7 @@ AllVertices::~AllVertices() {
 }
 
 ///  Setup the internal structure of the class (allocate memories).
-void AllVertices::setupVertices() {
+void AllVertices::allocateMemory() {
    size_ = Simulator::getInstance().getTotalVertices();
    summationMap_ = new BGFLOAT[size_];
 

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -37,7 +37,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices();
+   virtual void allocateMemory();
 
    ///  Prints out all parameters of the neurons to logging file.
    ///  Registered to OperationManager as Operation::printParameters

--- a/Simulator/Vertices/IAllVertices.h
+++ b/Simulator/Vertices/IAllVertices.h
@@ -24,7 +24,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all vertices' state.
-   virtual void setupVertices() = 0;
+   virtual void allocateMemory() = 0;
 
    ///  Load member variables from configuration file.
    ///  Registered to OperationManager as Operation::loadParameters

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -21,8 +21,8 @@ All911Vertices::~All911Vertices() {
     CallNum_ = NULL; 
 }
 
-void All911Vertices::setupVertices() {
-    AllVertices::setupVertices();
+void All911Vertices::allocateMemory() {
+    AllVertices::allocateMemory();
 
     CallNum_ = new int[size_];
     fill_n(CallNum_, size_, 0);    

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -35,7 +35,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all vertices' states.
-   virtual void setupVertices();
+   virtual void allocateMemory();
 
    ///  Creates all the Vertices and assigns initial data for them.
    ///

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -73,8 +73,8 @@ AllIFNeurons::~AllIFNeurons() {
 }
 
 ///  Setup the internal structure of the class (allocate memories).
-void AllIFNeurons::setupVertices() {
-   AllSpikingNeurons::setupVertices();
+void AllIFNeurons::allocateMemory() {
+   AllSpikingNeurons::allocateMemory();
 
    // TODO: Rename variables for easier identification
    C1_ = new BGFLOAT[size_];

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -36,7 +36,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices();
+   virtual void allocateMemory();
 
    ///  Load member variables from configuration file.
    ///  Registered to OperationManager as Operation::loadParameters

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -38,8 +38,8 @@ AllIZHNeurons::~AllIZHNeurons() {
 }
 
 ///  Setup the internal structure of the class (allocate memories).
-void AllIZHNeurons::setupVertices() {
-   AllIFNeurons::setupVertices();
+void AllIZHNeurons::allocateMemory() {
+   AllIFNeurons::allocateMemory();
 
    Aconst_ = new BGFLOAT[size_];
    Bconst_ = new BGFLOAT[size_];

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -87,7 +87,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices();
+   virtual void allocateMemory();
 
    ///  Prints out all parameters of the neurons to logging file.
    ///  Registered to OperationManager as Operation::printParameters

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -36,8 +36,8 @@ AllSpikingNeurons::~AllSpikingNeurons() {
 }
 
 ///  Setup the internal structure of the class (allocate memories).
-void AllSpikingNeurons::setupVertices() {
-   AllVertices::setupVertices();
+void AllSpikingNeurons::allocateMemory() {
+   AllVertices::allocateMemory();
 
    // TODO: Rename variables for easier identification
    hasFired_ = new bool[size_];

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -39,7 +39,7 @@ public:
 
    ///  Setup the internal structure of the class.
    ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices();
+   virtual void allocateMemory();
 
    ///  Clear the spike counts out of all Neurons.
    void clearSpikeCounts();


### PR DESCRIPTION
Fixes issue #164 - renames setupConnection, setupEdges, etc. to allocateMemory()
Moves edgSign from AllEdges to AllNeuroEdges
