### PR TITLE
EdgeIndexMap Fix

### DIFF
--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -54,7 +54,23 @@ shared_ptr<EdgeIndexMap> Connections::getEdgeIndexMap() const {
 }
 
 void Connections::createEdgeIndexMap() {
-   synapseIndexMap_ = shared_ptr<EdgeIndexMap>(edges_->createEdgeIndexMap());
+   Simulator& simulator = Simulator::getInstance();
+   int vertexCount = simulator.getTotalVertices();
+   int maxEdges = vertexCount * edges_->maxEdgesPerVertex_;
+
+   if (synapseIndexMap_ == nullptr) {
+      synapseIndexMap_ = shared_ptr<EdgeIndexMap>(new EdgeIndexMap(vertexCount, maxEdges));
+   }
+
+   // Unsure if required
+   // fill_n(synapseIndexMap_->incomingEdgeBegin_, vertexCount, 0);
+   // fill_n(synapseIndexMap_->incomingEdgeCount_, vertexCount, 0);
+   // fill_n(synapseIndexMap_->incomingEdgeIndexMap_, maxEdges, 0);
+   // fill_n(synapseIndexMap_->outgoingEdgeBegin_, vertexCount, 0);
+   // fill_n(synapseIndexMap_->outgoingEdgeCount_, vertexCount, 0);
+   // fill_n(synapseIndexMap_->outgoingEdgeIndexMap_, maxEdges, 0);
+
+   edges_->createEdgeIndexMap(synapseIndexMap_);
 }
 
 ///  Update the connections status in every epoch.

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -36,8 +36,7 @@ AllEdges::AllEdges() :
 
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
    edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
-
-      }
+}
 
 AllEdges::AllEdges(const int numVertices, const int maxEdges) {
    setupEdges(numVertices, maxEdges);
@@ -46,15 +45,15 @@ AllEdges::AllEdges(const int numVertices, const int maxEdges) {
 AllEdges::~AllEdges() {
    BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;
 
-  if (maxTotalEdges != 0) {
-     delete[] destVertexIndex_;
-     delete[] W_;
-     delete[] summationPoint_;
-     delete[] sourceVertexIndex_;
-     delete[] type_;
-     delete[] inUse_;
-     delete[] edgeCounts_;
-  }
+   if (maxTotalEdges != 0) {
+      delete[] destVertexIndex_;
+      delete[] W_;
+      delete[] summationPoint_;
+      delete[] sourceVertexIndex_;
+      delete[] type_;
+      delete[] inUse_;
+      delete[] edgeCounts_;
+   }
 
    destVertexIndex_ = nullptr;
    W_ = nullptr;
@@ -183,7 +182,7 @@ edgeType AllEdges::edgeOrdinalToType(const int typeOrdinal) {
 }
 
 ///  Create a edge index map.
-EdgeIndexMap *AllEdges::createEdgeIndexMap() {
+void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
    Simulator& simulator = Simulator::getInstance();
    int vertexCount = simulator.getTotalVertices();
    int totalEdgeCount = 0;
@@ -197,17 +196,15 @@ EdgeIndexMap *AllEdges::createEdgeIndexMap() {
    LOG4CPLUS_TRACE(fileLogger_,endl<<"totalEdgeCount: in edgeIndexMap " << totalEdgeCount << endl);
 
    if (totalEdgeCount == 0) {
-      return nullptr;
+      return;
    }
 
-   // allocate memories for forward map
-   vector<BGSIZE> *rgEdgeEdgeIndexMap = new vector<BGSIZE>[vertexCount];
+   // Create vector for edge forwarding map
+   vector<BGSIZE> rgEdgeEdgeIndexMap[vertexCount];
 
    BGSIZE edg_i = 0;
    int curr = 0;
 
-   // create edge forward map & active edge map
-   EdgeIndexMap *edgeIndexMap = new EdgeIndexMap(vertexCount, totalEdgeCount);
    LOG4CPLUS_TRACE(edgeLogger_, "\nSize of edge Index Map "<< vertexCount << "," << totalEdgeCount << endl);
    
    for (int i = 0; i < vertexCount; i++) {
@@ -250,11 +247,6 @@ EdgeIndexMap *AllEdges::createEdgeIndexMap() {
          edgeIndexMap->outgoingEdgeIndexMap_[edg_i] = rgEdgeEdgeIndexMap[i][j];
       }
    }
-
-   // delete memories
-   delete[] rgEdgeEdgeIndexMap;
-
-   return edgeIndexMap;
 }
 
 
@@ -293,8 +285,7 @@ void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg) {
 ///  @param  destVertex The Vertex that receives from the edge.
 ///  @param  sumPoint   Summation point address.
 ///  @param  deltaT      Inner simulation step duration
-void
-AllEdges::addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT *sumPoint,
+void AllEdges::addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT *sumPoint,
                         const BGFLOAT deltaT) {
    if (edgeCounts_[destVertex] >= maxEdgesPerVertex_) {
       LOG4CPLUS_FATAL(edgeLogger_, "Vertex : " << destVertex << " ran out of space for new edges.");

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -58,8 +58,8 @@ public:
    virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
                               edgeType type) = 0;
 
-   ///  Create a edge index map.
-   virtual EdgeIndexMap *createEdgeIndexMap();
+   ///  Populate a edge index map.
+   virtual void createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap);
 
    ///  Cereal serialization method
    ///  (Serializes edge weights, source vertices, and destination vertices)

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -140,9 +140,6 @@ protected:
    ///
    ///  @param  iEdg   index of the synapse to set.
    virtual void initSpikeQueue(const BGSIZE iEdg) override;
-   
-   
-   virtual BGFLOAT synapticWeightModification(const BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
 
 #if defined(USE_GPU)
    public:
@@ -257,6 +254,8 @@ protected:
    ///  @param  iEdg   Index of the Synapse to connect to.
    ///  @return true if there is an input spike event.
    bool isSpikeQueuePost(const BGSIZE iEdg);
+
+   virtual BGFLOAT synapticWeightModification(const BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
 
 private:
    ///  Adjust synapse weight according to the Spike-timing-dependent synaptic modification

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -254,13 +254,13 @@ void AllSpikingSynapses::preSpikeHit(const BGSIZE iEdg) {
    // calculate index where to insert the spike into delayQueue
    //LOG4CPLUS_TRACE(edgeLogger_,"delayidx "<<delayIdx<<" totalDelay "<<totalDelay<<" ldelayQueue "<<ldelayQueue);
    int idx = delayIdx + totalDelay;
-   if (idx >= ldelayQueue) {  //TODO: mod operator more efficient?
+   if (idx >= ldelayQueue) {
       idx -= ldelayQueue;
    }
-   if((delayQueue & (0x1 << idx)) == 0)
+   if((delayQueue & (0x1 << idx)) != 0)
    {
-      LOG4CPLUS_DEBUG(edgeLogger_,"Delay Queue Error " << setbase(2) << delayQueue << setbase(10) << " idx" << idx << " iSync " << iEdg);
-      exit(1);
+      LOG4CPLUS_ERROR(edgeLogger_,"Delay Queue Error " << setbase(2) << delayQueue << setbase(10) << " index " << idx << " edge ID " << iEdg);
+      assert(false);
    }
    
    // set a spike


### PR DESCRIPTION
Proposed fix for EdgeIndexMap creation, addresses issues #188, #199

Does not switch to `valarrays` or `vectors`, that can be done independently later.
Allocates some more memory than it used to, but shouldn't affect how it works.
It used to allocate the minimum required space, now allocates space for `numVertices * maxEdgesPerVertex` edges.