### PR TITLE
Fix hdf5

### DIFF
--- a/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
@@ -33,13 +33,13 @@ void Hdf5GrowthRecorder::initDataSet() {
 
    // create the data space & dataset for rates history
    hsize_t dims[2];
-   dims[0] = static_cast<hsize_t>(simulator.getNumEpochs() * simulator.getEpochDuration() + 1);
+   dims[0] = static_cast<hsize_t>(simulator.getNumEpochs() + 1);
    dims[1] = static_cast<hsize_t>(simulator.getTotalVertices());
    DataSpace dsRatesHist(2, dims);
    dataSetRatesHist_ = new DataSet(stateOut_->createDataSet(nameRatesHist, H5_FLOAT, dsRatesHist));
 
    // create the data space & dataset for radii history
-   dims[0] = static_cast<hsize_t>(simulator.getNumEpochs() * simulator.getEpochDuration() + 1);
+   dims[0] = static_cast<hsize_t>(simulator.getNumEpochs() + 1);
    dims[1] = static_cast<hsize_t>(simulator.getTotalVertices());
    DataSpace dsRadiiHist(2, dims);
    dataSetRadiiHist_ = new DataSet(stateOut_->createDataSet(nameRadiiHist, H5_FLOAT, dsRadiiHist));

--- a/configfiles/test-medium-hdf5.xml
+++ b/configfiles/test-medium-hdf5.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<BGSimParams>
+  <SimInfoParams name="SimInfoParams">
+    <PoolSize name="PoolSize">
+      <x name="x">30</x>
+      <y name="y">30</y>
+      <z name="z">1</z>
+    </PoolSize>
+    <SimParams name="SimParams">
+      <epochDuration name="epochDuration">100.0</epochDuration>
+      <numEpochs name="numEpochs">20</numEpochs>
+    </SimParams>
+    <SimConfig name="SimConfig">
+      <maxFiringRate name="maxFiringRate">200</maxFiringRate>
+      <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
+    </SimConfig>
+    <Seed name="Seed">
+      <value name="value">1</value>
+    </Seed>
+    <OutputParams name="OutputParams">
+      <resultFileName name="resultFileName">../Output/Results/test-medium-out.h5</resultFileName>
+    </OutputParams>
+  </SimInfoParams>
+
+  <ModelParams>
+    <VerticesParams class="AllLIFNeurons" name="VerticesParams">
+      <Iinject name="Iinject">
+        <min name="min">13.5e-09</min>
+        <max name="max">13.5e-09</max>
+      </Iinject>
+      <Inoise name="Inoise">
+        <min name="min">1.0e-09</min>
+        <max name="max">1.5e-09</max>
+      </Inoise>
+      <Vthresh name="Vthresh">
+        <min name="min">15.0e-03</min>
+        <max name="max">15.0e-03</max>
+      </Vthresh>
+      <Vresting name="Vresting">
+        <min name="min">0.0</min>
+        <max name="max">0.0</max>
+      </Vresting>
+      <Vreset name="Vreset">
+        <min name="min">13.5e-03</min>
+        <max name="max">13.5e-03</max>
+      </Vreset>
+      <Vinit name="Vinit">
+        <min name="min">13.0e-03</min>
+        <max name="max">13.0e-03</max>
+      </Vinit>
+      <starter_vthresh name="starter_vthresh">
+        <min name="min">13.565e-3</min>
+        <max name="max">13.655e-3</max>
+      </starter_vthresh>
+      <starter_vreset name="starter_vreset">
+        <min name="min">13.0e-3</min>
+        <max name="max">13.0e-3</max>
+      </starter_vreset>
+    </VerticesParams>
+
+    <EdgesParams class="AllDSSynapses" name="EdgesParams">
+      <tau name="tau">
+        <ii name="ii">6e-3</ii>
+        <ie name="ie">6e-3</ie>
+        <ei name="ei">3e-3</ei>
+        <ee name="ee">3e-3</ee>
+      </tau>
+      <delay name="delay">
+        <ii name="ii">0.8e-3</ii>
+        <ie name="ie">0.8e-3</ie>
+        <ei name="ei">0.8e-3</ei>
+        <ee name="ee">1.5e-3</ee>
+      </delay>
+      <U name="U">
+        <ii name="ii">0.32</ii>
+        <ie name="ie">0.25</ie>
+        <ei name="ei">0.05</ei>
+        <ee name="ee">0.5</ee>
+      </U>
+      <D name="D">
+        <ii name="ii">0.144</ii>
+        <ie name="ie">0.7</ie>
+        <ei name="ei">0.125</ei>
+        <ee name="ee">1.1</ee>
+      </D>
+      <F name="F">
+        <ii name="ii">0.06</ii>
+        <ie name="ie">0.02</ie>
+        <ei name="ei">1.2</ei>
+        <ee name="ee">0.05</ee>
+      </F>
+    </EdgesParams>
+
+    <ConnectionsParams class="ConnGrowth" name="ConnectionsParams">
+      <!-- Growth parameters -->
+      <GrowthParams name="GrowthParams">
+        <epsilon name="epsilon">0.60</epsilon>
+        <beta name="beta">0.10</beta>
+        <rho name="rho">0.0001</rho>
+        <targetRate name="targetRate">1.9</targetRate>
+        <minRadius name="minRadius">0.1</minRadius>
+        <startRadius name="startRadius">0.4</startRadius>
+      </GrowthParams>
+    </ConnectionsParams>
+
+    <LayoutParams class="FixedLayout" name="LayoutParams">
+      <LayoutFiles name="LayoutFiles">
+        <activeNListFileName name="activeNListFileName" type="InputFile">../configfiles/NList/ActiveNList30x30-0.01.xml</activeNListFileName>
+        <inhNListFileName name="inhNListFileName" type="InputFile">../configfiles/NList/InhibitoryNList30x30-0.02.xml</inhNListFileName>
+      </LayoutFiles>
+    </LayoutParams>
+
+    <RecorderParams class="Hdf5GrowthRecorder" name="RecorderParams">
+      <probedNListFileName name="prbNListFileName" type="InputFile">../configfiles/NList/probedNList_900.xml</probedNListFileName>
+    </RecorderParams>
+  </ModelParams>
+</BGSimParams>

--- a/configfiles/test-medium-hdf5.xml
+++ b/configfiles/test-medium-hdf5.xml
@@ -14,9 +14,14 @@
       <maxFiringRate name="maxFiringRate">200</maxFiringRate>
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
-    <Seed name="Seed">
-      <value name="value">1</value>
-    </Seed>
+    <RNGConfig name="RNGConfig">
+      <InitRNGParams name="InitRNGParams">
+          <Seed name="Seed">1</Seed>
+      </InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
+          <Seed name="Seed">1</Seed>
+      </NoiseRNGParams>
+    </RNGConfig>
     <OutputParams name="OutputParams">
       <resultFileName name="resultFileName">../Output/Results/test-medium-out.h5</resultFileName>
     </OutputParams>

--- a/configfiles/test-small-connected-hdf5.xml
+++ b/configfiles/test-small-connected-hdf5.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<BGSimParams>
+  <SimInfoParams name="SimInfoParams">
+    <PoolSize name="PoolSize">
+      <x name="x">10</x>
+      <y name="y">10</y>
+      <z name="z">1</z>
+    </PoolSize>
+    <SimParams name="SimParams">
+      <epochDuration name="epochDuration">100.0</epochDuration>
+      <numEpochs name="numEpochs">2</numEpochs>
+    </SimParams>
+    <SimConfig name="SimConfig">
+      <maxFiringRate name="maxFiringRate">200</maxFiringRate>
+      <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
+    </SimConfig>
+    <Seed name="Seed">
+      <value name="value">1</value>
+    </Seed>
+    <OutputParams name="OutputParams">
+      <resultFileName name="resultFileName">../Output/Results/test-small-connected-out.h5</resultFileName>
+    </OutputParams>
+  </SimInfoParams>
+
+  <ModelParams>
+    <VerticesParams class="AllLIFNeurons" name="VerticesParams">
+      <Iinject name="Iinject">
+        <min name="min">13.5e-09</min>
+        <max name="max">13.5e-09</max>
+      </Iinject>
+      <Inoise name="Inoise">
+        <min name="min">1.0e-09</min>
+        <max name="max">1.5e-09</max>
+      </Inoise>
+      <Vthresh name="Vthresh">
+        <min name="min">15.0e-03</min>
+        <max name="max">15.0e-03</max>
+      </Vthresh>
+      <Vresting name="Vresting">
+        <min name="min">0.0</min>
+        <max name="max">0.0</max>
+      </Vresting>
+      <Vreset name="Vreset">
+        <min name="min">13.5e-03</min>
+        <max name="max">13.5e-03</max>
+      </Vreset>
+      <Vinit name="Vinit">
+        <min name="min">13.0e-03</min>
+        <max name="max">13.0e-03</max>
+      </Vinit>
+      <starter_vthresh name="starter_vthresh">
+        <min name="min">13.565e-3</min>
+        <max name="max">13.655e-3</max>
+      </starter_vthresh>
+      <starter_vreset name="starter_vreset">
+        <min name="min">13.0e-3</min>
+        <max name="max">13.0e-3</max>
+      </starter_vreset>
+    </VerticesParams>
+
+    <EdgesParams class="AllDSSynapses" name="EdgesParams">
+      <tau name="tau">
+        <ii name="ii">6e-3</ii>
+        <ie name="ie">6e-3</ie>
+        <ei name="ei">3e-3</ei>
+        <ee name="ee">3e-3</ee>
+      </tau>
+      <delay name="delay">
+        <ii name="ii">0.8e-3</ii>
+        <ie name="ie">0.8e-3</ie>
+        <ei name="ei">0.8e-3</ei>
+        <ee name="ee">1.5e-3</ee>
+      </delay>
+      <U name="U">
+        <ii name="ii">0.32</ii>
+        <ie name="ie">0.25</ie>
+        <ei name="ei">0.05</ei>
+        <ee name="ee">0.5</ee>
+      </U>
+      <D name="D">
+        <ii name="ii">0.144</ii>
+        <ie name="ie">0.7</ie>
+        <ei name="ei">0.125</ei>
+        <ee name="ee">1.1</ee>
+      </D>
+      <F name="F">
+        <ii name="ii">0.06</ii>
+        <ie name="ie">0.02</ie>
+        <ei name="ei">1.2</ei>
+        <ee name="ee">0.05</ee>
+      </F>
+    </EdgesParams>
+
+    <ConnectionsParams class="ConnGrowth" name="ConnectionsParams">
+      <!-- Growth parameters -->
+      <GrowthParams name="GrowthParams">
+        <epsilon name="epsilon">0.60</epsilon>
+        <beta name="beta">0.10</beta>
+        <rho name="rho">0.0001</rho>
+        <targetRate name="targetRate">1.9</targetRate>
+        <minRadius name="minRadius">0.1</minRadius>
+        <startRadius name="startRadius">0.49</startRadius>
+      </GrowthParams>
+    </ConnectionsParams>
+
+    <LayoutParams class="FixedLayout" name="LayoutParams">
+      <LayoutFiles name="LayoutFiles">
+        <activeNListFileName name="activeNListFileName" type="InputFile">../configfiles/NList/ActiveNList10x10-0.1.xml</activeNListFileName>
+        <inhNListFileName name="inhNListFileName" type="InputFile">../configfiles/NList/InhibitoryNList10x10-0.02.xml</inhNListFileName>
+      </LayoutFiles>
+    </LayoutParams>
+
+    <RecorderParams class="Hdf5GrowthRecorder" name="RecorderParams">
+      <probedNListFileName name="prbNListFileName" type="InputFile">../configfiles/NList/probedNList_2-100.xml</probedNListFileName>
+    </RecorderParams>
+  </ModelParams>
+</BGSimParams>

--- a/configfiles/test-small-connected-hdf5.xml
+++ b/configfiles/test-small-connected-hdf5.xml
@@ -14,9 +14,14 @@
       <maxFiringRate name="maxFiringRate">200</maxFiringRate>
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
-    <Seed name="Seed">
-      <value name="value">1</value>
-    </Seed>
+    <RNGConfig name="RNGConfig">
+      <InitRNGParams name="InitRNGParams">
+          <Seed name="Seed">1</Seed>
+      </InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
+          <Seed name="Seed">1</Seed>
+      </NoiseRNGParams>
+    </RNGConfig>
     <OutputParams name="OutputParams">
       <resultFileName name="resultFileName">../Output/Results/test-small-connected-out.h5</resultFileName>
     </OutputParams>

--- a/configfiles/test-small-hdf5.xml
+++ b/configfiles/test-small-hdf5.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<BGSimParams>
+  <SimInfoParams name="SimInfoParams">
+    <PoolSize name="PoolSize">
+      <x name="x">10</x>
+      <y name="y">10</y>
+      <z name="z">1</z>
+    </PoolSize>
+    <SimParams name="SimParams">
+      <epochDuration name="epochDuration">100.0</epochDuration>
+      <numEpochs name="numEpochs">2</numEpochs>
+    </SimParams>
+    <SimConfig name="SimConfig">
+      <maxFiringRate name="maxFiringRate">200</maxFiringRate>
+      <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
+    </SimConfig>
+    <Seed name="Seed">
+      <value name="value">1</value>
+    </Seed>
+    <OutputParams name="OutputParams">
+      <resultFileName name="resultFileName">../Output/Results/test-small-out.h5</resultFileName>
+    </OutputParams>
+  </SimInfoParams>
+
+  <ModelParams>
+    <VerticesParams class="AllLIFNeurons" name="VerticesParams">
+      <Iinject name="Iinject">
+        <min name="min">13.5e-09</min>
+        <max name="max">13.5e-09</max>
+      </Iinject>
+      <Inoise name="Inoise">
+        <min name="min">1.0e-09</min>
+        <max name="max">1.5e-09</max>
+      </Inoise>
+      <Vthresh name="Vthresh">
+        <min name="min">15.0e-03</min>
+        <max name="max">15.0e-03</max>
+      </Vthresh>
+      <Vresting name="Vresting">
+        <min name="min">0.0</min>
+        <max name="max">0.0</max>
+      </Vresting>
+      <Vreset name="Vreset">
+        <min name="min">13.5e-03</min>
+        <max name="max">13.5e-03</max>
+      </Vreset>
+      <Vinit name="Vinit">
+        <min name="min">13.0e-03</min>
+        <max name="max">13.0e-03</max>
+      </Vinit>
+      <starter_vthresh name="starter_vthresh">
+        <min name="min">13.565e-3</min>
+        <max name="max">13.655e-3</max>
+      </starter_vthresh>
+      <starter_vreset name="starter_vreset">
+        <min name="min">13.0e-3</min>
+        <max name="max">13.0e-3</max>
+      </starter_vreset>
+    </VerticesParams>
+
+    <EdgesParams class="AllDSSynapses" name="EdgesParams">
+      <tau name="tau">
+        <ii name="ii">6e-3</ii>
+        <ie name="ie">6e-3</ie>
+        <ei name="ei">3e-3</ei>
+        <ee name="ee">3e-3</ee>
+      </tau>
+      <delay name="delay">
+        <ii name="ii">0.8e-3</ii>
+        <ie name="ie">0.8e-3</ie>
+        <ei name="ei">0.8e-3</ei>
+        <ee name="ee">1.5e-3</ee>
+      </delay>
+      <U name="U">
+        <ii name="ii">0.32</ii>
+        <ie name="ie">0.25</ie>
+        <ei name="ei">0.05</ei>
+        <ee name="ee">0.5</ee>
+      </U>
+      <D name="D">
+        <ii name="ii">0.144</ii>
+        <ie name="ie">0.7</ie>
+        <ei name="ei">0.125</ei>
+        <ee name="ee">1.1</ee>
+      </D>
+      <F name="F">
+        <ii name="ii">0.06</ii>
+        <ie name="ie">0.02</ie>
+        <ei name="ei">1.2</ei>
+        <ee name="ee">0.05</ee>
+      </F>
+    </EdgesParams>
+
+    <ConnectionsParams class="ConnGrowth" name="ConnectionsParams">
+      <!-- Growth parameters -->
+      <GrowthParams name="GrowthParams">
+        <epsilon name="epsilon">0.60</epsilon>
+        <beta name="beta">0.10</beta>
+        <rho name="rho">0.0001</rho>
+        <targetRate name="targetRate">1.9</targetRate>
+        <minRadius name="minRadius">0.1</minRadius>
+        <startRadius name="startRadius">0.4</startRadius>
+      </GrowthParams>
+    </ConnectionsParams>
+
+    <LayoutParams class="FixedLayout" name="LayoutParams">
+      <LayoutFiles name="LayoutFiles">
+        <activeNListFileName name="activeNListFileName" type="InputFile">../configfiles/NList/ActiveNList10x10-0.1.xml</activeNListFileName>
+        <inhNListFileName name="inhNListFileName" type="InputFile">../configfiles/NList/InhibitoryNList10x10-0.02.xml</inhNListFileName>
+      </LayoutFiles>
+    </LayoutParams>
+    <RecorderParams class="Hdf5GrowthRecorder" name="RecorderParams">
+      <probedNListFileName name="prbNListFileName" type="InputFile">../configfiles/NList/probedNList_2-100.xml</probedNListFileName>
+    </RecorderParams>
+  </ModelParams>
+</BGSimParams>

--- a/configfiles/test-small-hdf5.xml
+++ b/configfiles/test-small-hdf5.xml
@@ -14,9 +14,14 @@
       <maxFiringRate name="maxFiringRate">200</maxFiringRate>
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
-    <Seed name="Seed">
-      <value name="value">1</value>
-    </Seed>
+    <RNGConfig name="RNGConfig">
+      <InitRNGParams name="InitRNGParams">
+          <Seed name="Seed">1</Seed>
+      </InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
+          <Seed name="Seed">1</Seed>
+      </NoiseRNGParams>
+    </RNGConfig>
     <OutputParams name="OutputParams">
       <resultFileName name="resultFileName">../Output/Results/test-small-out.h5</resultFileName>
     </OutputParams>


### PR DESCRIPTION
Change Hdf5Recorder to initialize `burstinessHist_` and `spikesHistory_` as arrays large enough to hold data for multi-epoch simulations. Closes #234.

Incremental HDF5 file writing from BrainGrid was already implemented in d4dc1240a9fb1f8332466846f6012b2a93f1e887. I verified that it was writing readable files using the `h5dump --header` command. I also checked the output file of a simulation in progress and saw that the file size increases after every epoch.