### PR TITLE
Outputfile verify issue 50

### DIFF
--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -53,6 +53,17 @@ Hdf5Recorder::~Hdf5Recorder()
 /// @param[in] stateOutputFileName	File name to save histories
 void Hdf5Recorder::init()
 {
+   // Before trying to create H5File, use ofstream to confirm ability to create and write file.
+   // TODO: Log error using LOG4CPLUS for workbench
+   //       For the time being, we are terminating the program when we can't open a file for writing.
+   ofstream testFileWrite;
+   testFileWrite.open(resultFileName_.c_str());
+   if (!testFileWrite.is_open()) {
+      cerr << "Error opening output file for writing." << endl;
+      exit(0);
+   }
+   testFileWrite.close();
+
     try
     {
        

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -59,8 +59,8 @@ void Hdf5Recorder::init()
    ofstream testFileWrite;
    testFileWrite.open(resultFileName_.c_str());
    if (!testFileWrite.is_open()) {
-      cerr << "Error opening output file for writing." << endl;
-      exit(0);
+      perror("Error opening output file for writing ");
+      exit(EXIT_FAILURE);
    }
    testFileWrite.close();
 

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -19,6 +19,7 @@
 
 #if defined(HDF5)
 
+#include <fstream>
 #include "IRecorder.h"
 #include "Model.h"
 #include "H5Cpp.h"

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -46,10 +46,11 @@ void XmlRecorder::init() {
    // TODO: Log error using LOG4CPLUS for workbench
    //       For the time being, we are terminating the program when we can't open a file for writing.
    if (!stateOut_.is_open()) {
-      cerr << "Error opening output file for writing." << endl;
-      exit(0);
+      perror("Error opening output file for writing ");
+      exit(EXIT_FAILURE);
    }
 }
+
 // TODO: for the empty functions below, what should happen? Should they ever
 // TODO: be called? Is it an error if they're called?
 /// Init radii and rates history matrices with default values

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -42,6 +42,13 @@ XmlRecorder::~XmlRecorder() {
 /// @param[in] stateOutputFileName	File name to save histories
 void XmlRecorder::init() {
    stateOut_.open(resultFileName_.c_str());
+
+   // TODO: Log error using LOG4CPLUS for workbench
+   //       For the time being, we are terminating the program when we can't open a file for writing.
+   if (!stateOut_.is_open()) {
+      cerr << "Error opening output file for writing." << endl;
+      exit(0);
+   }
 }
 // TODO: for the empty functions below, what should happen? Should they ever
 // TODO: be called? Is it an error if they're called?


### PR DESCRIPTION
Added checks to XMLRecorder & HDF5Recoder to ensure that we have write permissions for output file before beginning simulation.