### PR TITLE
Config file rng fix

### DIFF
--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -90,8 +90,8 @@ void Simulator::loadParameters() {
    ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGParams/@class", type);
    noiseRNG = RNGFactory::getInstance()->createRNG(type);
 
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGParams/Seed/text()", initRngSeed_);
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGParams/Seed/text()", noiseRngSeed_);
+   ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGParams/text()", initRngSeed_);
+   ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGParams/text()", noiseRngSeed_);
    noiseRNG->seed(noiseRngSeed_);
    initRNG.seed(initRngSeed_);
 

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -87,11 +87,11 @@ void Simulator::loadParameters() {
 
    // Instantiate rng object 
    string type;
-   ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGParams/@class", type);
+   ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGSeed/@class", type);
    noiseRNG = RNGFactory::getInstance()->createRNG(type);
 
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGParams/text()", initRngSeed_);
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGParams/text()", noiseRngSeed_);
+   ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGSeed/text()", initRngSeed_);
+   ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGSeed/text()", noiseRngSeed_);
    noiseRNG->seed(noiseRngSeed_);
    initRNG.seed(initRngSeed_);
 

--- a/Testing/RegressionTesting/configfiles/test-medium-connected-long.xml
+++ b/Testing/RegressionTesting/configfiles/test-medium-connected-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-medium-connected.xml
+++ b/Testing/RegressionTesting/configfiles/test-medium-connected.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-medium-long.xml
+++ b/Testing/RegressionTesting/configfiles/test-medium-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-medium.xml
+++ b/Testing/RegressionTesting/configfiles/test-medium.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small-connected-long.xml
+++ b/Testing/RegressionTesting/configfiles/test-small-connected-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small-connected.xml
+++ b/Testing/RegressionTesting/configfiles/test-small-connected.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small-connected.xml
+++ b/Testing/RegressionTesting/configfiles/test-small-connected.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small-long.xml
+++ b/Testing/RegressionTesting/configfiles/test-small-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small.xml
+++ b/Testing/RegressionTesting/configfiles/test-small.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-small.xml
+++ b/Testing/RegressionTesting/configfiles/test-small.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-tiny.xml
+++ b/Testing/RegressionTesting/configfiles/test-tiny.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
         </RNGConfig>
     </SimInfoParams>
 

--- a/Testing/RegressionTesting/configfiles/test-tiny.xml
+++ b/Testing/RegressionTesting/configfiles/test-tiny.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">1</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
         </RNGConfig>
     </SimInfoParams>
 

--- a/Testing/Utils/ParameterManagerTests.cpp
+++ b/Testing/Utils/ParameterManagerTests.cpp
@@ -66,7 +66,7 @@ TEST(ParameterManager, ValidStringTargeting) {
 TEST(ParameterManager, ValidIntTargeting) {
    ASSERT_TRUE (ParameterManager::getInstance().loadParameterFile("../configfiles/test-medium-500.xml"));
    string valid_xpath[] = {"//maxFiringRate/text()", "//PoolSize/x/text()", "//PoolSize/y/text()",
-                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/text()", "//numEpochs/text()"};
+                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGSeed/text()", "//numEpochs/text()"};
    int result[] = {200, 30, 30, 1, 1, 500};
    int referenceVar;
    for (int i = 0; i < 6; i++) {
@@ -150,7 +150,7 @@ TEST(ParameterManager, InvalidBGFloatTargeting) {
 TEST(ParameterManager, ValidLongTargeting) {
    ASSERT_TRUE (ParameterManager::getInstance().loadParameterFile("../configfiles/test-medium-500.xml"));
    string valid_xpath[] = {"//maxFiringRate/text()", "//PoolSize/x/text()", "//PoolSize/y/text()",
-                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/text()", "//numEpochs/text()"};
+                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGSeed/text()", "//numEpochs/text()"};
    long result[] = {200, 30, 30, 1, 1, 500};
    long referenceVar;
    for (int i = 0; i < 6; i++) {

--- a/Testing/Utils/ParameterManagerTests.cpp
+++ b/Testing/Utils/ParameterManagerTests.cpp
@@ -66,7 +66,7 @@ TEST(ParameterManager, ValidStringTargeting) {
 TEST(ParameterManager, ValidIntTargeting) {
    ASSERT_TRUE (ParameterManager::getInstance().loadParameterFile("../configfiles/test-medium-500.xml"));
    string valid_xpath[] = {"//maxFiringRate/text()", "//PoolSize/x/text()", "//PoolSize/y/text()",
-                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/Seed/text()", "//numEpochs/text()"};
+                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/text()", "//numEpochs/text()"};
    int result[] = {200, 30, 30, 1, 1, 500};
    int referenceVar;
    for (int i = 0; i < 6; i++) {
@@ -150,7 +150,7 @@ TEST(ParameterManager, InvalidBGFloatTargeting) {
 TEST(ParameterManager, ValidLongTargeting) {
    ASSERT_TRUE (ParameterManager::getInstance().loadParameterFile("../configfiles/test-medium-500.xml"));
    string valid_xpath[] = {"//maxFiringRate/text()", "//PoolSize/x/text()", "//PoolSize/y/text()",
-                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/Seed/text()", "//numEpochs/text()"};
+                           "//PoolSize/z/text()", "//RNGConfig/NoiseRNGParams/text()", "//numEpochs/text()"};
    long result[] = {200, 30, 30, 1, 1, 500};
    long referenceVar;
    for (int i = 0; i < 6; i++) {

--- a/configfiles/1_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/1_tR_1.0--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
    </SimInfoParams>
 

--- a/configfiles/1_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/1_tR_1.0--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
    </SimInfoParams>
 

--- a/configfiles/full-100x100-cpu-stdp.xml
+++ b/configfiles/full-100x100-cpu-stdp.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
    </SimInfoParams>
 

--- a/configfiles/full-100x100-cpu-stdp.xml
+++ b/configfiles/full-100x100-cpu-stdp.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
    </SimInfoParams>
 

--- a/configfiles/full_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/full_tR_1.0--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../tmp/0429_tR_1.0--fE_0.90_raiju.h5</resultFileName>

--- a/configfiles/full_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/full_tR_1.0--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../tmp/0429_tR_1.0--fE_0.90_raiju.h5</resultFileName>

--- a/configfiles/full_tR_1.0--fE_0.98_10000.xml
+++ b/configfiles/full_tR_1.0--fE_0.98_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">/tmp/0510_tR_1.0--fE_0.98_raiju.h5</resultFileName>

--- a/configfiles/full_tR_1.0--fE_0.98_10000.xml
+++ b/configfiles/full_tR_1.0--fE_0.98_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">/tmp/0510_tR_1.0--fE_0.98_raiju.h5</resultFileName>

--- a/configfiles/full_tR_1.9--fE_0.98_10000.xml
+++ b/configfiles/full_tR_1.9--fE_0.98_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">/tmp/0516_tR_1.9--fE_0.98_raiju.h5</resultFileName>

--- a/configfiles/full_tR_1.9--fE_0.98_10000.xml
+++ b/configfiles/full_tR_1.9--fE_0.98_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">/tmp/0516_tR_1.9--fE_0.98_raiju.h5</resultFileName>

--- a/configfiles/half_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/half_tR_1.0--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">probed/half_tR_1.0--fE_0.90_10000.h5</resultFileName>

--- a/configfiles/half_tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/half_tR_1.0--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">probed/half_tR_1.0--fE_0.90_10000.h5</resultFileName>

--- a/configfiles/static_izh_1000.xml
+++ b/configfiles/static_izh_1000.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">1000</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">777</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
         </RNGConfig>
         <OutputParams name="OutputParams">
             <resultFileName name="resultFileName">../Output/Results/static_izh_historyDump.h5</resultFileName>

--- a/configfiles/static_izh_1000.xml
+++ b/configfiles/static_izh_1000.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">1000</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
         </RNGConfig>
         <OutputParams name="OutputParams">
             <resultFileName name="resultFileName">../Output/Results/static_izh_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.80_10000.xml
+++ b/configfiles/tR_0.1--fE_0.80_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.80_10000.xml
+++ b/configfiles/tR_0.1--fE_0.80_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.90.xml
+++ b/configfiles/tR_0.1--fE_0.90.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.90.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.90.xml
+++ b/configfiles/tR_0.1--fE_0.90.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.90.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.90_10000.xml
+++ b/configfiles/tR_0.1--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.90_10000.xml
+++ b/configfiles/tR_0.1--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.98.xml
+++ b/configfiles/tR_0.1--fE_0.98.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.98.xml
+++ b/configfiles/tR_0.1--fE_0.98.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.98_10000.xml
+++ b/configfiles/tR_0.1--fE_0.98_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_0.1--fE_0.98_10000.xml
+++ b/configfiles/tR_0.1--fE_0.98_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_0.1--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.80_10000.xml
+++ b/configfiles/tR_1.0--fE_0.80_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.80_10000.xml
+++ b/configfiles/tR_1.0--fE_0.80_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.90.xml
+++ b/configfiles/tR_1.0--fE_0.90.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.90_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.90.xml
+++ b/configfiles/tR_1.0--fE_0.90.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.90_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/tR_1.0--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.90_10000.xml
+++ b/configfiles/tR_1.0--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.98.xml
+++ b/configfiles/tR_1.0--fE_0.98.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.98.xml
+++ b/configfiles/tR_1.0--fE_0.98.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.98_10000.xml
+++ b/configfiles/tR_1.0--fE_0.98_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.0--fE_0.98_10000.xml
+++ b/configfiles/tR_1.0--fE_0.98_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.0--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.80_10000.xml
+++ b/configfiles/tR_1.9--fE_0.80_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.80_10000.xml
+++ b/configfiles/tR_1.9--fE_0.80_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.80_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.90.xml
+++ b/configfiles/tR_1.9--fE_0.90.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.90_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.90.xml
+++ b/configfiles/tR_1.9--fE_0.90.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.90_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.90_10000.xml
+++ b/configfiles/tR_1.9--fE_0.90_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.90_10000.xml
+++ b/configfiles/tR_1.9--fE_0.90_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.90_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.98.xml
+++ b/configfiles/tR_1.9--fE_0.98.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.98.xml
+++ b/configfiles/tR_1.9--fE_0.98.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.98_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.98_10000.xml
+++ b/configfiles/tR_1.9--fE_0.98_10000.xml
@@ -15,8 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
+         <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+         <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">777</NoiseRNGSeed>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/tR_1.9--fE_0.98_10000.xml
+++ b/configfiles/tR_1.9--fE_0.98_10000.xml
@@ -15,12 +15,8 @@
          <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
       </SimConfig>
       <RNGConfig name="RNGConfig">
-         <InitRNGParams name="InitRNGParams">
-            <Seed name="Seed">1</Seed>
-         </InitRNGParams>
-         <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-            <Seed name="Seed">777</Seed>
-         </NoiseRNGParams>
+         <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+         <NoiseRNGParams class="Norm" name="NoiseRNGParams">777</NoiseRNGParams>
       </RNGConfig>
       <OutputParams name="OutputParams">
          <resultFileName name="resultFileName">../Output/Results/tR_1.9--fE_0.98_10000_historyDump.h5</resultFileName>

--- a/configfiles/test-large-connected-long.xml
+++ b/configfiles/test-large-connected-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-connected-long.xml
+++ b/configfiles/test-large-connected-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-connected.xml
+++ b/configfiles/test-large-connected.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-connected.xml
+++ b/configfiles/test-large-connected.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-long.xml
+++ b/configfiles/test-large-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-long.xml
+++ b/configfiles/test-large-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-very-long.xml
+++ b/configfiles/test-large-very-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large-very-long.xml
+++ b/configfiles/test-large-very-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large.xml
+++ b/configfiles/test-large.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-large.xml
+++ b/configfiles/test-large.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-100.xml
+++ b/configfiles/test-medium-100.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-100.xml
+++ b/configfiles/test-medium-100.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-2.xml
+++ b/configfiles/test-medium-2.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-2.xml
+++ b/configfiles/test-medium-2.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-500.xml
+++ b/configfiles/test-medium-500.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-500.xml
+++ b/configfiles/test-medium-500.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected-long.xml
+++ b/configfiles/test-medium-connected-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected-long.xml
+++ b/configfiles/test-medium-connected-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected-stdp.xml
+++ b/configfiles/test-medium-connected-stdp.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected-stdp.xml
+++ b/configfiles/test-medium-connected-stdp.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected.xml
+++ b/configfiles/test-medium-connected.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-connected.xml
+++ b/configfiles/test-medium-connected.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-hdf5.xml
+++ b/configfiles/test-medium-hdf5.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-          <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-          <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-hdf5.xml
+++ b/configfiles/test-medium-hdf5.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-long.xml
+++ b/configfiles/test-medium-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-long.xml
+++ b/configfiles/test-medium-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-stdp.xml
+++ b/configfiles/test-medium-stdp.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium-stdp.xml
+++ b/configfiles/test-medium-stdp.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium.xml
+++ b/configfiles/test-medium.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-medium.xml
+++ b/configfiles/test-medium.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-911.xml
+++ b/configfiles/test-small-911.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">88</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-911.xml
+++ b/configfiles/test-small-911.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">88</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-hdf5.xml
+++ b/configfiles/test-small-connected-hdf5.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-          <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-          <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-hdf5.xml
+++ b/configfiles/test-small-connected-hdf5.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-long.xml
+++ b/configfiles/test-small-connected-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-long.xml
+++ b/configfiles/test-small-connected-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-stdp.xml
+++ b/configfiles/test-small-connected-stdp.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected-stdp.xml
+++ b/configfiles/test-small-connected-stdp.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected.xml
+++ b/configfiles/test-small-connected.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-connected.xml
+++ b/configfiles/test-small-connected.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-hdf5.xml
+++ b/configfiles/test-small-hdf5.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-          <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-          <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-hdf5.xml
+++ b/configfiles/test-small-hdf5.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-long.xml
+++ b/configfiles/test-small-long.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small-long.xml
+++ b/configfiles/test-small-long.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small.xml
+++ b/configfiles/test-small.xml
@@ -15,8 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+      <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+      <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-small.xml
+++ b/configfiles/test-small.xml
@@ -15,12 +15,8 @@
       <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
     </SimConfig>
     <RNGConfig name="RNGConfig">
-      <InitRNGParams name="InitRNGParams">
-        <Seed name="Seed">1</Seed>
-      </InitRNGParams>
-      <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-        <Seed name="Seed">1</Seed>
-      </NoiseRNGParams>
+      <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+      <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
     </RNGConfig>
   </SimInfoParams>
 

--- a/configfiles/test-tiny-hdf5.xml
+++ b/configfiles/test-tiny-hdf5.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny-hdf5.xml
+++ b/configfiles/test-tiny-hdf5.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">1</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny-stdp.xml
+++ b/configfiles/test-tiny-stdp.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny-stdp.xml
+++ b/configfiles/test-tiny-stdp.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">1</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny-xml-stdp.xml
+++ b/configfiles/test-tiny-xml-stdp.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny-xml-stdp.xml
+++ b/configfiles/test-tiny-xml-stdp.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">1</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny.xml
+++ b/configfiles/test-tiny.xml
@@ -15,8 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
+            <InitRNGSeed name="InitRNGSeed">1</InitRNGSeed>
+            <NoiseRNGSeed class="Norm" name="NoiseRNGSeed">1</NoiseRNGSeed>
         </RNGConfig>
     </SimInfoParams>
 

--- a/configfiles/test-tiny.xml
+++ b/configfiles/test-tiny.xml
@@ -15,12 +15,8 @@
             <maxEdgesPerVertex name="maxEdgesPerVertex">200</maxEdgesPerVertex>
         </SimConfig>
         <RNGConfig name="RNGConfig">
-            <InitRNGParams name="InitRNGParams">
-                <Seed name="Seed">1</Seed>
-            </InitRNGParams>
-            <NoiseRNGParams class="Norm" name="NoiseRNGParams">
-                <Seed name="Seed">1</Seed>
-            </NoiseRNGParams>
+            <InitRNGParams name="InitRNGParams">1</InitRNGParams>
+            <NoiseRNGParams class="Norm" name="NoiseRNGParams">1</NoiseRNGParams>
         </RNGConfig>
     </SimInfoParams>
 

--- a/docs/InternalTesting/TestConfigFileParameters/testConfigFileParameters.md
+++ b/docs/InternalTesting/TestConfigFileParameters/testConfigFileParameters.md
@@ -38,8 +38,8 @@ between these test config files.
 |-----------------------:|------------------:|
 |          epochDuration |               100 |
 |          maxFiringRate |               200 |
-|     InitRNGParams Seed |                 1 |
-|    NoiseRNGParams Seed |                 1 |
+|            InitRNGSeed |                 1 |
+|           NoiseRNGSeed |                 1 |
 |     Active NList Ratio |               0.1 |
 | Inhibitory NList Ratio |               0.1 |
 |         Vertices Class |     AllLIFNeurons |


### PR DESCRIPTION
Gets rid of the redundant `<Seed>` tag in the config files (for Workbench).

Renames:
`NoiseRNGParams` to `NoiseRNGSeed`
`InitRNGParams` to `InitRNGSeed`