### PR TITLE
Created Github Action to auto-generate Doxygen documentation and deploys it to gh-pages branch.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,12 +1,9 @@
 name: Github Pages
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  schedule:
+    # Triggers at the end of the day on the 1st of every month
+    - cron: '0 0 1 * *'
 
 jobs:
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: Github Pages
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: docs/Doxygen/Doxyfile
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          destination_dir: docs
+          force_orphan: true


### PR DESCRIPTION
Implements #185 
Closes #253 

This Github Action auto-generates the project's Doxygen documentation and deploys it to an orphan gh-pages branch.
The idea is that we can set the docs directory in gh-pages branch as the root for our documentation page: https://uwb-biocomputing.github.io/Graphitti/

Does it make sense to have it executing on every push and pull requests to the master branch?