### PR TITLE
Windows, CMakePresets, and vcpkg integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,69 @@
+
+[*.{appxmanifest,axaml,axml,build,c,c++,cc,cginc,compute,config,cp,cpp,cshtml,csproj,cu,cuh,cxx,dbml,discomap,dtd,h,hh,hlsl,hlsli,hlslinc,hpp,htm,html,hxx,inc,inl,ino,ipp,jsproj,lsproj,mpp,mq4,mq5,mqh,njsproj,nuspec,paml,proj,props,proto,razor,resw,resx,StyleCop,targets,tasks,tpp,usf,ush,vbproj,xaml,xamlx,xml,xoml,xsd}]
+indent_style = tab
+indent_size = tab
+tab_width = 4
+
+[*.{asax,ascx,aspx,cs,css,js,jsx,master,skin,ts,tsx,vb}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+
+[*.{json,resjson}]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+[*]
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = none
+csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# ReSharper properties
+resharper_allow_comment_after_lbrace = true
+resharper_cpp_anonymous_method_declaration_braces = end_of_line
+resharper_cpp_case_block_braces = end_of_line
+resharper_cpp_empty_block_style = together
+resharper_cpp_indent_switch_labels = true
+resharper_cpp_invocable_declaration_braces = end_of_line
+resharper_cpp_other_braces = end_of_line
+resharper_cpp_simple_embedded_statement_style = on_single_line
+resharper_cpp_type_declaration_braces = end_of_line
+resharper_csharp_empty_block_style = together
+resharper_indent_access_specifiers_from_class = true
+resharper_indent_class_members_from_access_specifiers = true
+resharper_indent_wrapped_function_names = true
+resharper_linkage_specification_indentation = all
+resharper_namespace_declaration_braces = end_of_line
+resharper_requires_expression_braces = end_of_line
+resharper_simple_block_style = on_single_line
+resharper_simple_case_statement_style = on_single_line
+resharper_use_continuous_line_indent_in_expression_braces = true
+resharper_use_continuous_line_indent_in_method_pars = true
+
+# ReSharper inspection severities
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = hint
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_redundant_base_qualifier_highlighting = warning
+resharper_suggest_var_or_type_built_in_types_highlighting = hint
+resharper_suggest_var_or_type_elsewhere_highlighting = hint
+resharper_suggest_var_or_type_simple_types_highlighting = hint

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ build/Output/Results/*.xml
 build/Output/Results/*.h5
 Testing/RegressionTesting/TestOutput/*.xml
 Testing/RegressionTesting/TestOutput/*.h5
+
+out/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.21)
 
 ############################################################################################
 # CONDITIONAL FLAG (to run simulation on CPU or GPU)
@@ -29,7 +29,7 @@ else()
 endif()
 
 # Setting the base version to C++ 11
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # set(DEBUG_MODE YES) for debugging, no optimization
 # set(DEBUG_MODE NO) for production code, -O3 optimization enabled

--- a/CMakePresets.json.in
+++ b/CMakePresets.json.in
@@ -1,0 +1,117 @@
+﻿{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "description": "Common inherited configuration; unused on its own.",
+      "hidden": true,
+      "generator": "Ninja",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_STANDARD_REQUIRED": true
+      }
+    },
+    {
+      "name": "windows-base",
+      "description": "common inherited configuration for Windows projects; unused on its own.",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "VCPKG_HOST_TARGET": "x64-windows"
+      },
+      "environment": {
+        "VCPKG_ROOT": "C:/Users/$env{username}/Documents/vcpkg"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows" 
+      } 
+    },
+    {
+      "name": "windows-msvc-base",
+      "description": "common inherited configuration for enabling MSVC toolsets; unused on its own.",
+      "hidden": true,
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "vendor": { "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": [ "Windows" ] } }
+    },
+    {
+      "name": "linux-base",
+      "description": "common inherited configuration for Linux projects; unused on its own. ",
+      "hidden": true,
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": "x64-linux",
+        "VCPKG_HOST_TARGET": "x64-linux"
+      },
+      "environment": {
+        "VCPKG_ROOT": "$env{HOME}/vcpkg"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": { "hostOS": [ "Linux" ] },
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": { "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}" }
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "debug-base",
+      "description": "common inherited configuration for debug projects; unused on its own.",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release-base",
+      "description": "common inherited configuration for release projects; unused on its own.",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "cuda-base",
+      "description": "common inherited configuration for CUDA projects; unused on its own.",
+      "hidden": true,
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_CUDA_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD_REQUIRED": true
+      }
+    },
+    {
+      "name": "windows-debug",
+      "displayName": "Windows Debug",
+      "description": "Windows x64 Debug build (no CUDA).",
+      "inherits": [ "windows-base", "debug-base" ]
+    },
+    {
+      "name": "windows-cuda-debug",
+      "displayName": "Windows Debug",
+      "description": "Windows x64 Debug build (CUDA).",
+      "inherits": [ "windows-base", "cuda-base", "debug-base" ]
+    },
+    {
+      "name": "windows-vs22-debug",
+      "description": "Windows x64 Debug build with VS22",
+      "inherits": [ "windows-msvc-base", "debug-base" ]
+    },
+    {
+      "name": "linux-debug",
+      "description": "Linux x64 Debug build (no CUDA).",
+      "inherits": [ "linux-base", "debug-base" ]
+    }
+  ]
+}

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -24,16 +24,16 @@
 
 Connections::Connections() {
    // Create Edges/Synapses class using type definition in configuration file
-   string type;
+   std::string type;
    ParameterManager::getInstance().getStringByXpath("//EdgesParams/@class", type);
    edges_ = EdgesFactory::getInstance()->createEdges(type);
 
    // Register printParameters function as a printParameters operation in the OperationManager
-   function<void()> printParametersFunc = bind(&Connections::printParameters, this);
+   std::function<void()> printParametersFunc = std::bind(&Connections::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 
    // Register loadParameters function with Operation Manager
-   function<void()> function = std::bind(&Connections::loadParameters, this);
+   std::function<void()> function = std::bind(&Connections::loadParameters, this);
    OperationManager::getInstance().registerOperation(Operations::op::loadParameters, function);
 
    // Get a copy of the file logger to use log4cplus macros
@@ -44,11 +44,11 @@ Connections::Connections() {
 Connections::~Connections() {
 }
 
-shared_ptr<AllEdges> Connections::getEdges() const {
+std::shared_ptr<AllEdges> Connections::getEdges() const {
    return edges_;
 }
 
-shared_ptr<EdgeIndexMap> Connections::getEdgeIndexMap() const {
+std::shared_ptr<EdgeIndexMap> Connections::getEdgeIndexMap() const {
    return synapseIndexMap_;
 }
 
@@ -58,15 +58,15 @@ void Connections::createEdgeIndexMap() {
    int maxEdges = vertexCount * edges_->maxEdgesPerVertex_;
 
    if (synapseIndexMap_ == nullptr) {
-      synapseIndexMap_ = shared_ptr<EdgeIndexMap>(new EdgeIndexMap(vertexCount, maxEdges));
+      synapseIndexMap_ = std::shared_ptr<EdgeIndexMap>(new EdgeIndexMap(vertexCount, maxEdges));
    }
 
-   fill_n(synapseIndexMap_->incomingEdgeBegin_, vertexCount, 0);
-   fill_n(synapseIndexMap_->incomingEdgeCount_, vertexCount, 0);
-   fill_n(synapseIndexMap_->incomingEdgeIndexMap_, maxEdges, 0);
-   fill_n(synapseIndexMap_->outgoingEdgeBegin_, vertexCount, 0);
-   fill_n(synapseIndexMap_->outgoingEdgeCount_, vertexCount, 0);
-   fill_n(synapseIndexMap_->outgoingEdgeIndexMap_, maxEdges, 0);
+   std::fill_n(synapseIndexMap_->incomingEdgeBegin_, vertexCount, 0);
+   std::fill_n(synapseIndexMap_->incomingEdgeCount_, vertexCount, 0);
+   std::fill_n(synapseIndexMap_->incomingEdgeIndexMap_, maxEdges, 0);
+   std::fill_n(synapseIndexMap_->outgoingEdgeBegin_, vertexCount, 0);
+   std::fill_n(synapseIndexMap_->outgoingEdgeCount_, vertexCount, 0);
+   std::fill_n(synapseIndexMap_->outgoingEdgeIndexMap_, maxEdges, 0);
 
    edges_->createEdgeIndexMap(synapseIndexMap_);
 }
@@ -80,7 +80,7 @@ bool Connections::updateConnections(AllVertices &vertices, Layout *layout) {
    return false;
 }
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 void Connections::updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &synapses, AllSpikingNeuronsDeviceProperties* allVerticesDevice, AllSpikingSynapsesDeviceProperties* allEdgesDevice, Layout *layout)
 {
 }
@@ -95,7 +95,7 @@ void Connections::updateSynapsesWeights(const int numVertices, AllVertices &vert
 void Connections::updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &synapses, Layout *layout) {
 }
 
-#endif // !USE_GPU
+#endif
 
 ///  Creates synapses from synapse weights saved in the serialization file.
 ///

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -30,7 +30,7 @@ Connections::Connections() {
 
 	// Register printParameters function as a printParameters operation in the OperationManager
 	std::function<void()> printParametersFunc = std::bind(&Connections::printParameters, this);
-	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
 	// Register loadParameters function with Operation Manager
 	std::function<void()> function = std::bind(&Connections::loadParameters, this);
@@ -52,8 +52,7 @@ void Connections::createEdgeIndexMap() {
 	int vertexCount = simulator.getTotalVertices();
 	int maxEdges = vertexCount * edges_->maxEdgesPerVertex_;
 
-	if (synapseIndexMap_ == nullptr) synapseIndexMap_ = std::shared_ptr<EdgeIndexMap>(
-		new EdgeIndexMap(vertexCount, maxEdges));
+	if (synapseIndexMap_ == nullptr) { synapseIndexMap_ = std::make_shared<EdgeIndexMap>(vertexCount, maxEdges); }
 
 	std::fill_n(synapseIndexMap_->incomingEdgeBegin_, vertexCount, 0);
 	std::fill_n(synapseIndexMap_->incomingEdgeCount_, vertexCount, 0);

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -35,8 +35,6 @@
 #include "IRecorder.h"
 #include "EdgeIndexMap.h"
 
-using namespace std;
-
 class Connections {
 public:
    Connections();
@@ -45,11 +43,11 @@ public:
    virtual ~Connections();
 
    /// Returns shared pointer to Synapses/Edges 
-   shared_ptr<AllEdges> getEdges() const;
+   std::shared_ptr<AllEdges> getEdges() const;
 
 
    /// Returns a shared pointer to the EdgeIndexMap
-   shared_ptr<EdgeIndexMap> getEdgeIndexMap() const;
+   std::shared_ptr<EdgeIndexMap> getEdgeIndexMap() const;
 
    /// Calls Synapses to create EdgeIndexMap and stores it as a member variable
    void createEdgeIndexMap();
@@ -84,7 +82,7 @@ public:
    ///  @param  isynapses   The Synapse list to search from.
    void createSynapsesFromWeights(const int numVertices, Layout *layout, AllVertices &vertices, AllEdges &synapses);
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Update the weight of the Synapses in the simulation.
        ///  Note: Platform Dependent.
@@ -107,13 +105,13 @@ public:
    virtual void
    updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &synapses, Layout *layout);
 
-#endif // USE_GPU
+#endif
 
 protected:
 
-   shared_ptr<AllEdges> edges_;
+   std::shared_ptr<AllEdges> edges_;
 
-   shared_ptr<EdgeIndexMap> synapseIndexMap_;
+   std::shared_ptr<EdgeIndexMap> synapseIndexMap_;
 
    log4cplus::Logger fileLogger_;
    log4cplus::Logger edgeLogger_;

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -80,7 +80,7 @@ class Connections {
 		///  @param  layout      Layout information of the neural network.
 		///  @param  ineurons    The Neuron list to search from.
 		///  @param  isynapses   The Synapse list to search from.
-		void createSynapsesFromWeights(const int numVertices, Layout* layout, AllVertices& vertices,
+		void createSynapsesFromWeights(int numVertices, Layout* layout, AllVertices& vertices,
 		                               AllEdges& synapses);
 
 #ifdef __CUDACC__
@@ -104,7 +104,7 @@ class Connections {
 		///  @param  ineurons    The Neuron list to search from.
 		///  @param  isynapses   The Synapse list to search from.
 		virtual void
-			updateSynapsesWeights(const int numVertices, AllVertices& vertices, AllEdges& synapses, Layout* layout);
+			updateSynapsesWeights(int numVertices, AllVertices& vertices, AllEdges& synapses, Layout* layout);
 
 #endif
 

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -27,60 +27,61 @@
 
 #include <log4cplus/loggingmacros.h>
 
-#include "AllVertices.h"
 #include "AllEdges.h"
 #include "AllSpikingNeurons.h"
 #include "AllSpikingSynapses.h"
-#include "Layout.h"
-#include "IRecorder.h"
+#include "AllVertices.h"
 #include "EdgeIndexMap.h"
+#include "IRecorder.h"
+#include "Layout.h"
 
 class Connections {
-public:
-   Connections();
+	public:
+		Connections();
 
-   ///  Destructor
-   virtual ~Connections();
+		///  Destructor
+		virtual ~Connections();
 
-   /// Returns shared pointer to Synapses/Edges 
-   std::shared_ptr<AllEdges> getEdges() const;
+		/// Returns shared pointer to Synapses/Edges 
+		std::shared_ptr<AllEdges> getEdges() const;
 
 
-   /// Returns a shared pointer to the EdgeIndexMap
-   std::shared_ptr<EdgeIndexMap> getEdgeIndexMap() const;
+		/// Returns a shared pointer to the EdgeIndexMap
+		std::shared_ptr<EdgeIndexMap> getEdgeIndexMap() const;
 
-   /// Calls Synapses to create EdgeIndexMap and stores it as a member variable
-   void createEdgeIndexMap();
+		/// Calls Synapses to create EdgeIndexMap and stores it as a member variable
+		void createEdgeIndexMap();
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  layout    Layout information of the neural network.
-   ///  @param  neurons   The Neuron list to search from.
-   ///  @param  synapses  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, AllVertices *vertices, AllEdges *synapses) = 0;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  layout    Layout information of the neural network.
+		///  @param  neurons   The Neuron list to search from.
+		///  @param  synapses  The Synapse list to search from.
+		virtual void setupConnections(Layout* layout, AllVertices* vertices, AllEdges* synapses) = 0;
 
-   /// Load member variables from configuration file.
-   /// Registered to OperationManager as Operations::op::loadParameters
-   virtual void loadParameters() = 0;
+		/// Load member variables from configuration file.
+		/// Registered to OperationManager as Operations::op::loadParameters
+		virtual void loadParameters() = 0;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const = 0;
-   
-   ///  Update the connections status in every epoch.
-   ///
-   ///  @param  neurons  The Neuron list to search from.
-   ///  @param  layout   Layout information of the neural network.
-   ///  @return true if successful, false otherwise.
-   virtual bool updateConnections(AllVertices &vertices, Layout *layout);
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		virtual void printParameters() const = 0;
 
-   ///  Creates synapses from synapse weights saved in the serialization file.
-   ///
-   ///  @param  numVertices Number of vertices to update.
-   ///  @param  layout      Layout information of the neural network.
-   ///  @param  ineurons    The Neuron list to search from.
-   ///  @param  isynapses   The Synapse list to search from.
-   void createSynapsesFromWeights(const int numVertices, Layout *layout, AllVertices &vertices, AllEdges &synapses);
+		///  Update the connections status in every epoch.
+		///
+		///  @param  neurons  The Neuron list to search from.
+		///  @param  layout   Layout information of the neural network.
+		///  @return true if successful, false otherwise.
+		virtual bool updateConnections(AllVertices& vertices, Layout* layout);
+
+		///  Creates synapses from synapse weights saved in the serialization file.
+		///
+		///  @param  numVertices Number of vertices to update.
+		///  @param  layout      Layout information of the neural network.
+		///  @param  ineurons    The Neuron list to search from.
+		///  @param  isynapses   The Synapse list to search from.
+		void createSynapsesFromWeights(const int numVertices, Layout* layout, AllVertices& vertices,
+		                               AllEdges& synapses);
 
 #ifdef __CUDACC__
    public:
@@ -95,25 +96,23 @@ public:
        ///  @param  layout              Layout information of the neural network.
        virtual void updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &synapses, AllSpikingNeuronsDeviceProperties* allVerticesDevice, AllSpikingSynapsesDeviceProperties* allEdgesDevice, Layout *layout);
 #else
-public:
-   ///  Update the weight of the Synapses in the simulation.
-   ///  Note: Platform Dependent.
-   ///
-   ///  @param  numVertices Number of vertices to update.
-   ///  @param  ineurons    The Neuron list to search from.
-   ///  @param  isynapses   The Synapse list to search from.
-   virtual void
-   updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &synapses, Layout *layout);
+	public:
+		///  Update the weight of the Synapses in the simulation.
+		///  Note: Platform Dependent.
+		///
+		///  @param  numVertices Number of vertices to update.
+		///  @param  ineurons    The Neuron list to search from.
+		///  @param  isynapses   The Synapse list to search from.
+		virtual void
+			updateSynapsesWeights(const int numVertices, AllVertices& vertices, AllEdges& synapses, Layout* layout);
 
 #endif
 
-protected:
+	protected:
+		std::shared_ptr<AllEdges> edges_;
 
-   std::shared_ptr<AllEdges> edges_;
+		std::shared_ptr<EdgeIndexMap> synapseIndexMap_;
 
-   std::shared_ptr<EdgeIndexMap> synapseIndexMap_;
-
-   log4cplus::Logger fileLogger_;
-   log4cplus::Logger edgeLogger_;
+		log4cplus::Logger fileLogger_;
+		log4cplus::Logger edgeLogger_;
 };
-

--- a/Simulator/Connections/ConnectionsFactory.cpp
+++ b/Simulator/Connections/ConnectionsFactory.cpp
@@ -43,8 +43,7 @@ std::shared_ptr<Connections> ConnectionsFactory::createConnections(const std::st
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
 Connections* ConnectionsFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Connections/ConnectionsFactory.cpp
+++ b/Simulator/Connections/ConnectionsFactory.cpp
@@ -29,14 +29,14 @@ ConnectionsFactory::~ConnectionsFactory() {
 ///
 ///  @param  className class name.
 ///  @param  Pointer to the class creation function.
-void ConnectionsFactory::registerClass(const string &className, CreateFunction function) {
+void ConnectionsFactory::registerClass(const std::string &className, CreateFunction function) {
    createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired connections class.
-shared_ptr<Connections> ConnectionsFactory::createConnections(const string &className) {
-   connectionsInstance = shared_ptr<Connections>(invokeCreateFunction(className));
+std::shared_ptr<Connections> ConnectionsFactory::createConnections(const std::string &className) {
+   connectionsInstance = std::shared_ptr<Connections>(invokeCreateFunction(className));
    return connectionsInstance;
 }
 
@@ -44,7 +44,7 @@ shared_ptr<Connections> ConnectionsFactory::createConnections(const string &clas
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-Connections *ConnectionsFactory::invokeCreateFunction(const string &className) {
+Connections *ConnectionsFactory::invokeCreateFunction(const std::string &className) {
    for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
       if (className == i->first)
          return i->second();

--- a/Simulator/Connections/ConnectionsFactory.cpp
+++ b/Simulator/Connections/ConnectionsFactory.cpp
@@ -7,47 +7,44 @@
  */
 
 #include "ConnectionsFactory.h"
-#include "ConnStatic.h"
-#include "ConnGrowth.h"
 #include "Connections911.h"
+#include "ConnGrowth.h"
+#include "ConnStatic.h"
 
 
 /// Constructor is private to keep a singleton instance of this class.
 ConnectionsFactory::ConnectionsFactory() {
-   // register neurons classes
-   registerClass("ConnStatic", &ConnStatic::Create);
-   registerClass("ConnGrowth", &ConnGrowth::Create);
-   registerClass("Connections911", &Connections911::Create);
+	// register neurons classes
+	registerClass("ConnStatic", &ConnStatic::Create);
+	registerClass("ConnGrowth", &ConnGrowth::Create);
+	registerClass("Connections911", &Connections911::Create);
 }
 
-ConnectionsFactory::~ConnectionsFactory() {
-   createFunctions.clear();
-}
+ConnectionsFactory::~ConnectionsFactory() { createFunctions.clear(); }
 
 
 ///  Register connections class and its creation function to the factory.
 ///
 ///  @param  className class name.
 ///  @param  Pointer to the class creation function.
-void ConnectionsFactory::registerClass(const std::string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void ConnectionsFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired connections class.
-std::shared_ptr<Connections> ConnectionsFactory::createConnections(const std::string &className) {
-   connectionsInstance = std::shared_ptr<Connections>(invokeCreateFunction(className));
-   return connectionsInstance;
+std::shared_ptr<Connections> ConnectionsFactory::createConnections(const std::string& className) {
+	connectionsInstance = std::shared_ptr<Connections>(invokeCreateFunction(className));
+	return connectionsInstance;
 }
 
 /// Create an instance of the connections class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-Connections *ConnectionsFactory::invokeCreateFunction(const std::string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+Connections* ConnectionsFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Connections/ConnectionsFactory.h
+++ b/Simulator/Connections/ConnectionsFactory.h
@@ -15,8 +15,6 @@
 #include "Global.h"
 #include "Connections.h"
 
-using namespace std;
-
 class ConnectionsFactory {
 
 public:
@@ -28,7 +26,7 @@ public:
    }
 
    /// Invokes constructor for desired concrete class
-   shared_ptr<Connections> createConnections(const string &className);
+   std::shared_ptr<Connections> createConnections(const std::string &className);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    ConnectionsFactory(ConnectionsFactory const &) = delete;
@@ -39,20 +37,20 @@ private:
    ConnectionsFactory();
 
    /// Pointer to connections instance.
-   shared_ptr<Connections> connectionsInstance;
+   std::shared_ptr<Connections> connectionsInstance;
 
    /// Defines function type for usage in internal map
-   typedef Connections *(*CreateFunction)(void);
+   using CreateFunction = Connections *(*)(void);
 
    /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> ConnectionsFunctionMap;
+   using ConnectionsFunctionMap =  std::map<std::string, CreateFunction>;
 
    /// Makes class-to-function map an internal factory member.
    ConnectionsFunctionMap createFunctions;
 
    /// Retrieves and invokes correct ::Create() function.
-   Connections *invokeCreateFunction(const string &className);
+   Connections *invokeCreateFunction(const std::string &className);
 
    /// Register connection class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+   void registerClass(const std::string &className, CreateFunction function);
 };

--- a/Simulator/Connections/ConnectionsFactory.h
+++ b/Simulator/Connections/ConnectionsFactory.h
@@ -12,45 +12,45 @@
 #include <memory>
 #include <string>
 
-#include "Global.h"
 #include "Connections.h"
+#include "Global.h"
 
 class ConnectionsFactory {
 
-public:
-   ~ConnectionsFactory();
+	public:
+		~ConnectionsFactory();
 
-   static ConnectionsFactory *getInstance() {
-      static ConnectionsFactory instance;
-      return &instance;
-   }
+		static ConnectionsFactory* getInstance() {
+			static ConnectionsFactory instance;
+			return &instance;
+		}
 
-   /// Invokes constructor for desired concrete class
-   std::shared_ptr<Connections> createConnections(const std::string &className);
+		/// Invokes constructor for desired concrete class
+		std::shared_ptr<Connections> createConnections(const std::string& className);
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   ConnectionsFactory(ConnectionsFactory const &) = delete;
-   void operator=(ConnectionsFactory const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		ConnectionsFactory(const ConnectionsFactory&) = delete;
+		void operator=(const ConnectionsFactory&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   ConnectionsFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		ConnectionsFactory();
 
-   /// Pointer to connections instance.
-   std::shared_ptr<Connections> connectionsInstance;
+		/// Pointer to connections instance.
+		std::shared_ptr<Connections> connectionsInstance;
 
-   /// Defines function type for usage in internal map
-   using CreateFunction = Connections *(*)(void);
+		/// Defines function type for usage in internal map
+		using CreateFunction = Connections *(*)(void);
 
-   /// Defines map between class name and corresponding ::Create() function.
-   using ConnectionsFunctionMap =  std::map<std::string, CreateFunction>;
+		/// Defines map between class name and corresponding ::Create() function.
+		using ConnectionsFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   ConnectionsFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		ConnectionsFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   Connections *invokeCreateFunction(const std::string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		Connections* invokeCreateFunction(const std::string& className);
 
-   /// Register connection class and it's create function to the factory.
-   void registerClass(const std::string &className, CreateFunction function);
+		/// Register connection class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -78,14 +78,14 @@ void Connections911::loadParameters() {
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void Connections911::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << endl
-    << "\tConnections Type: Connections911" << endl
-    << "\tConnections per vertex: " << connsPerVertex_ << endl
-    << "\tPSAPs to erase: " << psapsToErase_ << endl
-    << "\tRESPs to erase: " << respsToErase_ << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
+    << "\tConnections Type: Connections911" << std::endl
+    << "\tConnections per vertex: " << connsPerVertex_ << std::endl
+    << "\tPSAPs to erase: " << psapsToErase_ << std::endl
+    << "\tRESPs to erase: " << respsToErase_ << std::endl << std::endl);
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 ///  Update the connections status in every epoch.
 ///
 ///  @param  vertices  The Vertex list to search from.
@@ -121,7 +121,7 @@ bool Connections911::updateConnections(AllVertices &vertices, Layout *layout) {
 bool Connections911::erasePSAP(AllVertices &vertices, Layout *layout) {
    int numVertices = Simulator::getInstance().getTotalVertices();
 
-   vector<int> psaps;
+   std::vector<int> psaps;
    psaps.clear();
 
    // Find all psaps
@@ -141,8 +141,8 @@ bool Connections911::erasePSAP(AllVertices &vertices, Layout *layout) {
 
    BGSIZE maxTotalEdges = edges_->maxEdgesPerVertex_ * numVertices;
    bool changesMade = false;
-   vector<int> callersToReroute;
-   vector<int> respsToReroute;
+   std::vector<int> callersToReroute;
+   std::vector<int> respsToReroute;
 
    callersToReroute.clear();
    respsToReroute.clear();
@@ -255,7 +255,7 @@ bool Connections911::erasePSAP(AllVertices &vertices, Layout *layout) {
 bool Connections911::eraseRESP(AllVertices &vertices, Layout *layout) {
    int numVertices = Simulator::getInstance().getTotalVertices();
 
-   vector<int> resps;
+   std::vector<int> resps;
    resps.clear();
 
    // Find all resps
@@ -306,9 +306,9 @@ bool Connections911::eraseRESP(AllVertices &vertices, Layout *layout) {
 }
 
 ///  @return xml representation of a single edge
-string Connections911::ChangedEdge::toString() {
-   stringstream os;
-   string type_s;
+std::string Connections911::ChangedEdge::toString() {
+   std::stringstream os;
+   std::string type_s;
 
    switch (eType){
       case CP: type_s = "CP"; break;
@@ -320,26 +320,26 @@ string Connections911::ChangedEdge::toString() {
 
    os << "<item>";
    os << srcV << " " << destV << " " << type_s;
-   os << "</item>" << endl;
+   os << "</item>" << std::endl;
 
    return os.str();
 }
 
-///  Returns the complete list of all deleted or added edges as a string.
+///  Returns the complete list of all deleted or added edges as a std::string.
 ///  @param added    true returns the list of added edges, false = erased
 ///  @return xml representation of all deleted or added edges
-string Connections911::changedEdgesToXML(bool added) {
-   stringstream os;
+std::string Connections911::changedEdgesToXML(bool added) {
+   std::stringstream os;
 
-   vector<ChangedEdge> changed = edgesErased;
-   string name = "edgesDeleted";
+   std::vector<ChangedEdge> changed = edgesErased;
+   std::string name = "edgesDeleted";
 
    if (added) {
       changed = edgesAdded;
       name = "edgesAdded";
    }
 
-   os << "<Matrix name=\"" << name << "\" type=\"complete\" rows=\"" << changed.size() << "\" columns=\"3\" multiplier=\"1.0\">" << endl;
+   os << "<Matrix name=\"" << name << "\" type=\"complete\" rows=\"" << changed.size() << "\" columns=\"3\" multiplier=\"1.0\">" << std::endl;
 
    for (int i = 0; i < changed.size(); i++) {
       os << "   " << changed[i].toString();
@@ -349,12 +349,12 @@ string Connections911::changedEdgesToXML(bool added) {
    return os.str();
 }
 
-///  Returns the complete list of deleted vertices as a string.
+///  Returns the complete list of deleted vertices as a std::string.
 ///  @return xml representation of all deleted vertices
-string Connections911::erasedVerticesToXML() {
-   stringstream os;
+std::string Connections911::erasedVerticesToXML() {
+   std::stringstream os;
 
-   os << "<Matrix name=\"verticesDeleted\" type=\"complete\" rows=\"1\" columns=\"" << verticesErased.size() << "\" multiplier=\"1.0\">" << endl;
+   os << "<Matrix name=\"verticesDeleted\" type=\"complete\" rows=\"1\" columns=\"" << verticesErased.size() << "\" multiplier=\"1.0\">" << std::endl;
    os << "   ";
 
    sort(verticesErased.begin(), verticesErased.end());
@@ -362,7 +362,7 @@ string Connections911::erasedVerticesToXML() {
       os << verticesErased[i] << " ";
    }
 
-   os << endl << "</Matrix>";
+   os << std::endl << "</Matrix>";
    return os.str();
 }
 

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -8,81 +8,75 @@
 */
 
 #include "Connections911.h"
-#include "ParameterManager.h"
 #include "All911Vertices.h"
 #include "Layout911.h"
+#include "ParameterManager.h"
 
-Connections911::Connections911() {
+Connections911::Connections911() {}
 
-}
+Connections911::~Connections911() { if (oldTypeMap_ != nullptr) delete[] oldTypeMap_; }
 
-Connections911::~Connections911() {
-   if (oldTypeMap_ != nullptr) delete[] oldTypeMap_;
-}
+void Connections911::setupConnections(Layout* layout, AllVertices* vertices, AllEdges* edges) {
+	int numVertices = Simulator::getInstance().getTotalVertices();
 
-void Connections911::setupConnections(Layout *layout, AllVertices *vertices, AllEdges *edges) {
-   int numVertices = Simulator::getInstance().getTotalVertices();
+	int added = 0;
 
-   int added = 0;
+	LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
 
-   LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
+	auto layout911 = dynamic_cast<Layout911*>(layout);
 
-   Layout911 *layout911 = dynamic_cast<Layout911 *>(layout); 
+	// For each source vertex
+	for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
+		int connsAdded = 0;
 
-   // For each source vertex
-   for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
-      int connsAdded = 0;
+		// For each destination verex
+		for (int destVertex = 0; destVertex < numVertices; destVertex++) {
+			if (connsAdded >= connsPerVertex_) break;
+			if (srcVertex == destVertex) continue;
 
-      // For each destination verex
-      for (int destVertex = 0; destVertex < numVertices; destVertex++) {
-         if (connsAdded >= connsPerVertex_) { break; }
-         if (srcVertex == destVertex) { continue; }
+			BGFLOAT dist = (*layout->dist_)(srcVertex, destVertex);
+			edgeType type = layout->edgType(srcVertex, destVertex);
 
-         BGFLOAT dist = (*layout->dist_)(srcVertex, destVertex);
-         edgeType type = layout->edgType(srcVertex, destVertex);
+			// Undefined edge types
+			if (type == ETYPE_UNDEF) continue;
 
-         // Undefined edge types
-         if (type == ETYPE_UNDEF) { continue; }
+			// Zone each vertex belongs to
+			int srcZone = layout911->zone(srcVertex);
+			int destZone = layout911->zone(destVertex);
 
-         // Zone each vertex belongs to
-         int srcZone = layout911->zone(srcVertex);
-         int destZone = layout911->zone(destVertex);
+			// CP and PR where they aren't in the same zone
+			// All PP and RC are defined
+			if (type == CP || type == PR) if (srcZone != destZone) continue;
 
-         // CP and PR where they aren't in the same zone
-         // All PP and RC are defined
-         if (type == CP || type == PR) {
-            if (srcZone != destZone) { continue; }
-         }
+			BGFLOAT* sumPoint = &vertices->summationMap_[destVertex];
 
-         BGFLOAT *sumPoint = &vertices->summationMap_[destVertex];
+			LOG4CPLUS_DEBUG(fileLogger_, "Source: " << srcVertex << " Dest: " << destVertex << " Dist: "
+			                << dist);
 
-         LOG4CPLUS_DEBUG(fileLogger_, "Source: " << srcVertex << " Dest: " << destVertex << " Dist: "
-                                       << dist);
+			BGSIZE iEdg;
+			edges->addEdge(iEdg, type, srcVertex, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
+			added++;
+			connsAdded++;
+		}
+	}
 
-         BGSIZE iEdg;
-         edges->addEdge(iEdg, type, srcVertex, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
-         added++;
-         connsAdded++;
-      }
-   }
-
-   LOG4CPLUS_DEBUG(fileLogger_,"Added connections: " << added);
+	LOG4CPLUS_DEBUG(fileLogger_, "Added connections: " << added);
 }
 
 void Connections911::loadParameters() {
-   ParameterManager::getInstance().getIntByXpath("//connsPerVertex/text()", connsPerVertex_);
-   ParameterManager::getInstance().getIntByXpath("//psapsToErase/text()", psapsToErase_);
-   ParameterManager::getInstance().getIntByXpath("//respsToErase/text()", respsToErase_);
+	ParameterManager::getInstance().getIntByXpath("//connsPerVertex/text()", connsPerVertex_);
+	ParameterManager::getInstance().getIntByXpath("//psapsToErase/text()", psapsToErase_);
+	ParameterManager::getInstance().getIntByXpath("//respsToErase/text()", respsToErase_);
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void Connections911::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
-    << "\tConnections Type: Connections911" << std::endl
-    << "\tConnections per vertex: " << connsPerVertex_ << std::endl
-    << "\tPSAPs to erase: " << psapsToErase_ << std::endl
-    << "\tRESPs to erase: " << respsToErase_ << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
+	                << "\tConnections Type: Connections911" << std::endl
+	                << "\tConnections per vertex: " << connsPerVertex_ << std::endl
+	                << "\tPSAPs to erase: " << psapsToErase_ << std::endl
+	                << "\tRESPs to erase: " << respsToErase_ << std::endl << std::endl);
 }
 
 #ifndef __CUDACC__
@@ -91,26 +85,22 @@ void Connections911::printParameters() const {
 ///  @param  vertices  The Vertex list to search from.
 ///  @param  layout   Layout information of the vertex network.
 ///  @return true if successful, false otherwise.
-bool Connections911::updateConnections(AllVertices &vertices, Layout *layout) {
-   // Only run on the first epoch
-   if (Simulator::getInstance().getCurrentStep() != 1) { return false; }
+bool Connections911::updateConnections(AllVertices& vertices, Layout* layout) {
+	// Only run on the first epoch
+	if (Simulator::getInstance().getCurrentStep() != 1) return false;
 
-   // Record old type map
-   int numVertices = Simulator::getInstance().getTotalVertices();
-   oldTypeMap_ = new vertexType[numVertices];
-   memcpy(oldTypeMap_, layout->vertexTypeMap_, numVertices*sizeof(vertexType));
+	// Record old type map
+	int numVertices = Simulator::getInstance().getTotalVertices();
+	oldTypeMap_ = new vertexType[numVertices];
+	memcpy(oldTypeMap_, layout->vertexTypeMap_, numVertices * sizeof(vertexType));
 
-   // Erase PSAPs
-   for (int i = 0; i < psapsToErase_; i++) {
-      erasePSAP(vertices, layout);
-   }
+	// Erase PSAPs
+	for (int i = 0; i < psapsToErase_; i++) erasePSAP(vertices, layout);
 
-   // Erase RESPs
-   for (int i = 0; i < respsToErase_; i++) {
-      eraseRESP(vertices, layout);
-   }
+	// Erase RESPs
+	for (int i = 0; i < respsToErase_; i++) eraseRESP(vertices, layout);
 
-   return true;
+	return true;
 }
 
 ///  Randomly delete 1 PSAP and rewire all the edges around it.
@@ -118,133 +108,125 @@ bool Connections911::updateConnections(AllVertices &vertices, Layout *layout) {
 ///  @param  vertices  The Vertex list to search from.
 ///  @param  layout   Layout information of the vertex network.
 ///  @return true if successful, false otherwise.
-bool Connections911::erasePSAP(AllVertices &vertices, Layout *layout) {
-   int numVertices = Simulator::getInstance().getTotalVertices();
+bool Connections911::erasePSAP(AllVertices& vertices, Layout* layout) {
+	int numVertices = Simulator::getInstance().getTotalVertices();
 
-   std::vector<int> psaps;
-   psaps.clear();
+	std::vector<int> psaps;
+	psaps.clear();
 
-   // Find all psaps
-   for (int i = 0; i < numVertices; i++) {
-      if (layout->vertexTypeMap_[i] == PSAP) {
-         psaps.push_back(i);
-      }
-   }
+	// Find all psaps
+	for (int i = 0; i < numVertices; i++) { if (layout->vertexTypeMap_[i] == PSAP) psaps.push_back(i); }
 
-   // Only 1 psap, do not delete me :(
-   if (psaps.size() < 2) { return false; }
+	// Only 1 psap, do not delete me :(
+	if (psaps.size() < 2) return false;
 
-   // Pick random PSAP
-   int randVal = initRNG.inRange(0, psaps.size());
-   int randPSAP = psaps[randVal];
-   psaps.erase(psaps.begin() + randVal);
+	// Pick random PSAP
+	int randVal = initRNG.inRange(0, psaps.size());
+	int randPSAP = psaps[randVal];
+	psaps.erase(psaps.begin() + randVal);
 
-   BGSIZE maxTotalEdges = edges_->maxEdgesPerVertex_ * numVertices;
-   bool changesMade = false;
-   std::vector<int> callersToReroute;
-   std::vector<int> respsToReroute;
+	BGSIZE maxTotalEdges = edges_->maxEdgesPerVertex_ * numVertices;
+	bool changesMade = false;
+	std::vector<int> callersToReroute;
+	std::vector<int> respsToReroute;
 
-   callersToReroute.clear();
-   respsToReroute.clear();
+	callersToReroute.clear();
+	respsToReroute.clear();
 
-   // Iterate through all edges
-   for (int iEdg = 0; iEdg < maxTotalEdges; iEdg++) {
-      if (!edges_->inUse_[iEdg]) { continue; }
-      int srcVertex = edges_->sourceVertexIndex_[iEdg];
-      int destVertex = edges_->destVertexIndex_[iEdg];
+	// Iterate through all edges
+	for (int iEdg = 0; iEdg < maxTotalEdges; iEdg++) {
+		if (!edges_->inUse_[iEdg]) continue;
+		int srcVertex = edges_->sourceVertexIndex_[iEdg];
+		int destVertex = edges_->destVertexIndex_[iEdg];
 
-      // Find PSAP edge
-      if (srcVertex == randPSAP || destVertex == randPSAP) {
-         // Record erased edge
-         ChangedEdge erasedEdge;
-         erasedEdge.srcV = srcVertex;
-         erasedEdge.destV = destVertex;
-         erasedEdge.eType = layout->edgType(srcVertex, destVertex);
-         edgesErased.push_back(erasedEdge);
+		// Find PSAP edge
+		if (srcVertex == randPSAP || destVertex == randPSAP) {
+			// Record erased edge
+			ChangedEdge erasedEdge;
+			erasedEdge.srcV = srcVertex;
+			erasedEdge.destV = destVertex;
+			erasedEdge.eType = layout->edgType(srcVertex, destVertex);
+			edgesErased.push_back(erasedEdge);
 
-         changesMade = true;
-         edges_->eraseEdge(destVertex, iEdg);
+			changesMade = true;
+			edges_->eraseEdge(destVertex, iEdg);
 
-         // Identify all psap-less callers
-         if (layout->vertexTypeMap_[srcVertex] == CALR) {
-            callersToReroute.push_back(srcVertex);
-         }
+			// Identify all psap-less callers
+			if (layout->vertexTypeMap_[srcVertex] == CALR) callersToReroute.push_back(srcVertex);
 
-         // Identify all psap-less responders
-         if (layout->vertexTypeMap_[destVertex] == RESP) {
-            respsToReroute.push_back(destVertex);
-         }
-      }
-   }
+			// Identify all psap-less responders
+			if (layout->vertexTypeMap_[destVertex] == RESP) respsToReroute.push_back(destVertex);
+		}
+	}
 
-   if (changesMade) {
-      // This is here so that we don't delete the vertex if we can't find any edges
-      verticesErased.push_back(randPSAP);
-      layout->vertexTypeMap_[randPSAP] = VTYPE_UNDEF;
-   }
+	if (changesMade) {
+		// This is here so that we don't delete the vertex if we can't find any edges
+		verticesErased.push_back(randPSAP);
+		layout->vertexTypeMap_[randPSAP] = VTYPE_UNDEF;
+	}
 
-   // Failsafe
-   if (psaps.size() < 1) { return false; }
+	// Failsafe
+	if (psaps.size() < 1) return false;
 
-   // For each psap-less caller, find closest match
-   for (int i = 0; i < callersToReroute.size(); i++) {
-      int srcVertex = callersToReroute[i];
+	// For each psap-less caller, find closest match
+	for (int i = 0; i < callersToReroute.size(); i++) {
+		int srcVertex = callersToReroute[i];
 
-      int closestPSAP = psaps[0];
-      BGFLOAT smallestDist = (*layout->dist_)(srcVertex, closestPSAP);
+		int closestPSAP = psaps[0];
+		BGFLOAT smallestDist = (*layout->dist_)(srcVertex, closestPSAP);
 
-      // Find closest PSAP
-      for (int i = 0; i < psaps.size(); i++) {
-         BGFLOAT dist = (*layout->dist_)(srcVertex, psaps[i]);
-         if (dist < smallestDist) {
-            smallestDist = dist;
-            closestPSAP = psaps[i];
-         }
-      }
+		// Find closest PSAP
+		for (int i = 0; i < psaps.size(); i++) {
+			BGFLOAT dist = (*layout->dist_)(srcVertex, psaps[i]);
+			if (dist < smallestDist) {
+				smallestDist = dist;
+				closestPSAP = psaps[i];
+			}
+		}
 
-      // Insert Caller to PSAP edge
-      BGFLOAT *sumPoint = &vertices.summationMap_[closestPSAP];
-      BGSIZE iEdg;
-      edges_->addEdge(iEdg, CP, srcVertex, closestPSAP, sumPoint, Simulator::getInstance().getDeltaT());
+		// Insert Caller to PSAP edge
+		BGFLOAT* sumPoint = &vertices.summationMap_[closestPSAP];
+		BGSIZE iEdg;
+		edges_->addEdge(iEdg, CP, srcVertex, closestPSAP, sumPoint, Simulator::getInstance().getDeltaT());
 
-      // Record added edge
-      ChangedEdge addedEdge;
-      addedEdge.srcV = srcVertex;
-      addedEdge.destV = closestPSAP;
-      addedEdge.eType = CP;
-      edgesAdded.push_back(addedEdge);
-   }
+		// Record added edge
+		ChangedEdge addedEdge;
+		addedEdge.srcV = srcVertex;
+		addedEdge.destV = closestPSAP;
+		addedEdge.eType = CP;
+		edgesAdded.push_back(addedEdge);
+	}
 
-   // For each psap-less responder, find closest match
-   for (int i = 0; i < respsToReroute.size(); i++) {
-      int destVertex = respsToReroute[i];
+	// For each psap-less responder, find closest match
+	for (int i = 0; i < respsToReroute.size(); i++) {
+		int destVertex = respsToReroute[i];
 
-      int closestPSAP = psaps[0];
-      BGFLOAT smallestDist = (*layout->dist_)(closestPSAP, destVertex);
+		int closestPSAP = psaps[0];
+		BGFLOAT smallestDist = (*layout->dist_)(closestPSAP, destVertex);
 
-      // Find closest PSAP
-      for (int i = 0; i < psaps.size(); i++) {
-         BGFLOAT dist = (*layout->dist_)(psaps[i], destVertex);
-         if (dist < smallestDist) {
-            smallestDist = dist;
-            closestPSAP = psaps[i];
-         }
-      }
+		// Find closest PSAP
+		for (int i = 0; i < psaps.size(); i++) {
+			BGFLOAT dist = (*layout->dist_)(psaps[i], destVertex);
+			if (dist < smallestDist) {
+				smallestDist = dist;
+				closestPSAP = psaps[i];
+			}
+		}
 
-      // Insert PSAP to Responder edge
-      BGFLOAT *sumPoint = &vertices.summationMap_[destVertex];
-      BGSIZE iEdg;
-      edges_->addEdge(iEdg, PR, closestPSAP, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
+		// Insert PSAP to Responder edge
+		BGFLOAT* sumPoint = &vertices.summationMap_[destVertex];
+		BGSIZE iEdg;
+		edges_->addEdge(iEdg, PR, closestPSAP, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
 
-      // Record added edge
-      ChangedEdge addedEdge;
-      addedEdge.srcV = closestPSAP;
-      addedEdge.destV = destVertex;
-      addedEdge.eType = PR;
-      edgesAdded.push_back(addedEdge);
-   }
+		// Record added edge
+		ChangedEdge addedEdge;
+		addedEdge.srcV = closestPSAP;
+		addedEdge.destV = destVertex;
+		addedEdge.eType = PR;
+		edgesAdded.push_back(addedEdge);
+	}
 
-   return changesMade;
+	return changesMade;
 }
 
 ///  Randomly delete 1 RESP.
@@ -252,118 +234,116 @@ bool Connections911::erasePSAP(AllVertices &vertices, Layout *layout) {
 ///  @param  vertices  The Vertex list to search from.
 ///  @param  layout   Layout information of the vertex network.
 ///  @return true if successful, false otherwise.
-bool Connections911::eraseRESP(AllVertices &vertices, Layout *layout) {
-   int numVertices = Simulator::getInstance().getTotalVertices();
+bool Connections911::eraseRESP(AllVertices& vertices, Layout* layout) {
+	int numVertices = Simulator::getInstance().getTotalVertices();
 
-   std::vector<int> resps;
-   resps.clear();
+	std::vector<int> resps;
+	resps.clear();
 
-   // Find all resps
-   for (int i = 0; i < numVertices; i++) {
-      if (layout->vertexTypeMap_[i] == RESP) {
-         resps.push_back(i);
-      }
-   }
+	// Find all resps
+	for (int i = 0; i < numVertices; i++) { if (layout->vertexTypeMap_[i] == RESP) resps.push_back(i); }
 
-   // Only 1 resp, do not delete me :(
-   if (resps.size() < 2) { return false; }
+	// Only 1 resp, do not delete me :(
+	if (resps.size() < 2) return false;
 
-   // Pick random RESP
-   int randVal = initRNG.inRange(0, resps.size());
-   int randRESP = resps[randVal];
-   resps.erase(resps.begin() + randVal);
+	// Pick random RESP
+	int randVal = initRNG.inRange(0, resps.size());
+	int randRESP = resps[randVal];
+	resps.erase(resps.begin() + randVal);
 
-   BGSIZE maxTotalEdges = edges_->maxEdgesPerVertex_ * numVertices;
-   bool changesMade = false;
+	BGSIZE maxTotalEdges = edges_->maxEdgesPerVertex_ * numVertices;
+	bool changesMade = false;
 
-   // Iterate through all edges
-   for (int iEdg = 0; iEdg < maxTotalEdges; iEdg++) {
-      if (!edges_->inUse_[iEdg]) { continue; }
-      int srcVertex = edges_->sourceVertexIndex_[iEdg];
-      int destVertex = edges_->destVertexIndex_[iEdg];
+	// Iterate through all edges
+	for (int iEdg = 0; iEdg < maxTotalEdges; iEdg++) {
+		if (!edges_->inUse_[iEdg]) continue;
+		int srcVertex = edges_->sourceVertexIndex_[iEdg];
+		int destVertex = edges_->destVertexIndex_[iEdg];
 
-      // Find RESP edge
-      if (srcVertex == randRESP || destVertex == randRESP) {
-         // Record erased edge
-         ChangedEdge erasedEdge;
-         erasedEdge.srcV = srcVertex;
-         erasedEdge.destV = destVertex;
-         erasedEdge.eType = layout->edgType(srcVertex, destVertex);
-         edgesErased.push_back(erasedEdge);
+		// Find RESP edge
+		if (srcVertex == randRESP || destVertex == randRESP) {
+			// Record erased edge
+			ChangedEdge erasedEdge;
+			erasedEdge.srcV = srcVertex;
+			erasedEdge.destV = destVertex;
+			erasedEdge.eType = layout->edgType(srcVertex, destVertex);
+			edgesErased.push_back(erasedEdge);
 
-         changesMade = true;
-         edges_->eraseEdge(destVertex, iEdg);
-      }
-   }
+			changesMade = true;
+			edges_->eraseEdge(destVertex, iEdg);
+		}
+	}
 
-   if (changesMade) {
-      // This is here so that we don't delete the vertex if we can't find any edges
-      verticesErased.push_back(randRESP);
-      layout->vertexTypeMap_[randRESP] = VTYPE_UNDEF;
-   }
+	if (changesMade) {
+		// This is here so that we don't delete the vertex if we can't find any edges
+		verticesErased.push_back(randRESP);
+		layout->vertexTypeMap_[randRESP] = VTYPE_UNDEF;
+	}
 
-   return changesMade;
+	return changesMade;
 }
 
 ///  @return xml representation of a single edge
 std::string Connections911::ChangedEdge::toString() {
-   std::stringstream os;
-   std::string type_s;
+	std::stringstream os;
+	std::string type_s;
 
-   switch (eType){
-      case CP: type_s = "CP"; break;
-      case PR: type_s = "PR"; break;
-      case PP: type_s = "PP"; break;
-      case RC: type_s = "RC"; break;
-      default: type_s = "ETYPE_UNDEF";
-   }
+	switch (eType) {
+		case CP: type_s = "CP";
+			break;
+		case PR: type_s = "PR";
+			break;
+		case PP: type_s = "PP";
+			break;
+		case RC: type_s = "RC";
+			break;
+		default: type_s = "ETYPE_UNDEF";
+	}
 
-   os << "<item>";
-   os << srcV << " " << destV << " " << type_s;
-   os << "</item>" << std::endl;
+	os << "<item>";
+	os << srcV << " " << destV << " " << type_s;
+	os << "</item>" << std::endl;
 
-   return os.str();
+	return os.str();
 }
 
 ///  Returns the complete list of all deleted or added edges as a std::string.
 ///  @param added    true returns the list of added edges, false = erased
 ///  @return xml representation of all deleted or added edges
 std::string Connections911::changedEdgesToXML(bool added) {
-   std::stringstream os;
+	std::stringstream os;
 
-   std::vector<ChangedEdge> changed = edgesErased;
-   std::string name = "edgesDeleted";
+	std::vector<ChangedEdge> changed = edgesErased;
+	std::string name = "edgesDeleted";
 
-   if (added) {
-      changed = edgesAdded;
-      name = "edgesAdded";
-   }
+	if (added) {
+		changed = edgesAdded;
+		name = "edgesAdded";
+	}
 
-   os << "<Matrix name=\"" << name << "\" type=\"complete\" rows=\"" << changed.size() << "\" columns=\"3\" multiplier=\"1.0\">" << std::endl;
+	os << "<Matrix name=\"" << name << "\" type=\"complete\" rows=\"" << changed.size() <<
+		"\" columns=\"3\" multiplier=\"1.0\">" << std::endl;
 
-   for (int i = 0; i < changed.size(); i++) {
-      os << "   " << changed[i].toString();
-   }
+	for (int i = 0; i < changed.size(); i++) os << "   " << changed[i].toString();
 
-   os << "</Matrix>";
-   return os.str();
+	os << "</Matrix>";
+	return os.str();
 }
 
 ///  Returns the complete list of deleted vertices as a std::string.
 ///  @return xml representation of all deleted vertices
 std::string Connections911::erasedVerticesToXML() {
-   std::stringstream os;
+	std::stringstream os;
 
-   os << "<Matrix name=\"verticesDeleted\" type=\"complete\" rows=\"1\" columns=\"" << verticesErased.size() << "\" multiplier=\"1.0\">" << std::endl;
-   os << "   ";
+	os << "<Matrix name=\"verticesDeleted\" type=\"complete\" rows=\"1\" columns=\"" << verticesErased.size() <<
+		"\" multiplier=\"1.0\">" << std::endl;
+	os << "   ";
 
-   sort(verticesErased.begin(), verticesErased.end());
-   for (int i = 0; i < verticesErased.size(); i++) {
-      os << verticesErased[i] << " ";
-   }
+	sort(verticesErased.begin(), verticesErased.end());
+	for (int i = 0; i < verticesErased.size(); i++) os << verticesErased[i] << " ";
 
-   os << std::endl << "</Matrix>";
-   return os.str();
+	os << std::endl << "</Matrix>";
+	return os.str();
 }
 
 #endif

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -38,7 +38,7 @@ void Connections911::setupConnections(Layout* layout, AllVertices* vertices, All
 			edgeType type = layout->edgType(srcVertex, destVertex);
 
 			// Undefined edge types
-			if (type == ETYPE_UNDEF) continue;
+			if (type == edgeType::ETYPE_UNDEF) continue;
 
 			// Zone each vertex belongs to
 			int srcZone = layout911->zone(srcVertex);
@@ -46,7 +46,7 @@ void Connections911::setupConnections(Layout* layout, AllVertices* vertices, All
 
 			// CP and PR where they aren't in the same zone
 			// All PP and RC are defined
-			if (type == CP || type == PR) if (srcZone != destZone) continue;
+			if (type == edgeType::CP || type == edgeType::PR) if (srcZone != destZone) continue;
 
 			BGFLOAT* sumPoint = &vertices->summationMap_[destVertex];
 
@@ -115,7 +115,7 @@ bool Connections911::erasePSAP(AllVertices& vertices, Layout* layout) {
 	psaps.clear();
 
 	// Find all psaps
-	for (int i = 0; i < numVertices; i++) { if (layout->vertexTypeMap_[i] == PSAP) psaps.push_back(i); }
+	for (int i = 0; i < numVertices; i++) if (layout->vertexTypeMap_[i] == vertexType::PSAP) psaps.push_back(i);
 
 	// Only 1 psap, do not delete me :(
 	if (psaps.size() < 2) return false;
@@ -152,17 +152,17 @@ bool Connections911::erasePSAP(AllVertices& vertices, Layout* layout) {
 			edges_->eraseEdge(destVertex, iEdg);
 
 			// Identify all psap-less callers
-			if (layout->vertexTypeMap_[srcVertex] == CALR) callersToReroute.push_back(srcVertex);
+			if (layout->vertexTypeMap_[srcVertex] == vertexType::CALR) callersToReroute.push_back(srcVertex);
 
 			// Identify all psap-less responders
-			if (layout->vertexTypeMap_[destVertex] == RESP) respsToReroute.push_back(destVertex);
+			if (layout->vertexTypeMap_[destVertex] == vertexType::RESP) respsToReroute.push_back(destVertex);
 		}
 	}
 
 	if (changesMade) {
 		// This is here so that we don't delete the vertex if we can't find any edges
 		verticesErased.push_back(randPSAP);
-		layout->vertexTypeMap_[randPSAP] = VTYPE_UNDEF;
+		layout->vertexTypeMap_[randPSAP] = vertexType::VTYPE_UNDEF;
 	}
 
 	// Failsafe
@@ -187,13 +187,13 @@ bool Connections911::erasePSAP(AllVertices& vertices, Layout* layout) {
 		// Insert Caller to PSAP edge
 		BGFLOAT* sumPoint = &vertices.summationMap_[closestPSAP];
 		BGSIZE iEdg;
-		edges_->addEdge(iEdg, CP, srcVertex, closestPSAP, sumPoint, Simulator::getInstance().getDeltaT());
+		edges_->addEdge(iEdg, edgeType::CP, srcVertex, closestPSAP, sumPoint, Simulator::getInstance().getDeltaT());
 
 		// Record added edge
 		ChangedEdge addedEdge;
 		addedEdge.srcV = srcVertex;
 		addedEdge.destV = closestPSAP;
-		addedEdge.eType = CP;
+		addedEdge.eType = edgeType::CP;
 		edgesAdded.push_back(addedEdge);
 	}
 
@@ -216,13 +216,13 @@ bool Connections911::erasePSAP(AllVertices& vertices, Layout* layout) {
 		// Insert PSAP to Responder edge
 		BGFLOAT* sumPoint = &vertices.summationMap_[destVertex];
 		BGSIZE iEdg;
-		edges_->addEdge(iEdg, PR, closestPSAP, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
+		edges_->addEdge(iEdg, edgeType::PR, closestPSAP, destVertex, sumPoint, Simulator::getInstance().getDeltaT());
 
 		// Record added edge
 		ChangedEdge addedEdge;
 		addedEdge.srcV = closestPSAP;
 		addedEdge.destV = destVertex;
-		addedEdge.eType = PR;
+		addedEdge.eType = edgeType::PR;
 		edgesAdded.push_back(addedEdge);
 	}
 
@@ -241,7 +241,7 @@ bool Connections911::eraseRESP(AllVertices& vertices, Layout* layout) {
 	resps.clear();
 
 	// Find all resps
-	for (int i = 0; i < numVertices; i++) { if (layout->vertexTypeMap_[i] == RESP) resps.push_back(i); }
+	for (int i = 0; i < numVertices; i++) if (layout->vertexTypeMap_[i] == vertexType::RESP) resps.push_back(i);
 
 	// Only 1 resp, do not delete me :(
 	if (resps.size() < 2) return false;
@@ -277,7 +277,7 @@ bool Connections911::eraseRESP(AllVertices& vertices, Layout* layout) {
 	if (changesMade) {
 		// This is here so that we don't delete the vertex if we can't find any edges
 		verticesErased.push_back(randRESP);
-		layout->vertexTypeMap_[randRESP] = VTYPE_UNDEF;
+		layout->vertexTypeMap_[randRESP] = vertexType::VTYPE_UNDEF;
 	}
 
 	return changesMade;
@@ -289,13 +289,13 @@ std::string Connections911::ChangedEdge::toString() {
 	std::string type_s;
 
 	switch (eType) {
-		case CP: type_s = "CP";
+		case edgeType::CP: type_s = "CP";
 			break;
-		case PR: type_s = "PR";
+		case edgeType::PR: type_s = "PR";
 			break;
-		case PP: type_s = "PP";
+		case edgeType::PP: type_s = "PP";
 			break;
-		case RC: type_s = "RC";
+		case edgeType::RC: type_s = "RC";
 			break;
 		default: type_s = "ETYPE_UNDEF";
 	}

--- a/Simulator/Connections/NG911/Connections911.h
+++ b/Simulator/Connections/NG911/Connections911.h
@@ -9,103 +9,103 @@
 
 #pragma once
 
-#include "Global.h"
-#include "Connections.h"
-#include "Simulator.h"
 #include <vector>
+#include "Connections.h"
+#include "Global.h"
+#include "Simulator.h"
 
 class Connections911 : public Connections {
-public:
-   Connections911();
+	public:
+		Connections911();
 
-   virtual ~Connections911();
+		~Connections911() override;
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static Connections *Create() { return new Connections911(); }
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static Connections* Create() { return new Connections911(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///  Initialize the network characterized by parameters:
-   ///  number of maximum connections per vertex, connection radius threshold
-   ///
-   ///  @param  layout    Layout information of the network.
-   ///  @param  vertices  The Vertex list to search from.
-   ///  @param  edges     The edge list to search from.
-   virtual void setupConnections(Layout *layout, AllVertices *vertices, AllEdges *edges) override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///  Initialize the network characterized by parameters:
+		///  number of maximum connections per vertex, connection radius threshold
+		///
+		///  @param  layout    Layout information of the network.
+		///  @param  vertices  The Vertex list to search from.
+		///  @param  edges     The edge list to search from.
+		void setupConnections(Layout* layout, AllVertices* vertices, AllEdges* edges) override;
 
-   /// Load member variables from configuration file.
-   /// Registered to OperationManager as Operations::op::loadParameters
-   virtual void loadParameters() override;
+		/// Load member variables from configuration file.
+		/// Registered to OperationManager as Operations::op::loadParameters
+		void loadParameters() override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   /// Records typeMap history for recorders
-   vertexType *oldTypeMap_;
+		/// Records typeMap history for recorders
+		vertexType* oldTypeMap_;
 
-private:
-   /// number of maximum connections per vertex
-   int connsPerVertex_;
+	private:
+		/// number of maximum connections per vertex
+		int connsPerVertex_;
 
-   /// number of psaps to erase at the end of 1 epoch
-   int psapsToErase_;
+		/// number of psaps to erase at the end of 1 epoch
+		int psapsToErase_;
 
-   /// number of responder nodes to erase at the end of 1 epoch
-   int respsToErase_;
+		/// number of responder nodes to erase at the end of 1 epoch
+		int respsToErase_;
 
-   struct ChangedEdge;
+		struct ChangedEdge;
 
-   // Edges that were added but later removed are still here
-   std::vector<ChangedEdge> edgesAdded;
+		// Edges that were added but later removed are still here
+		std::vector<ChangedEdge> edgesAdded;
 
-   // New edges = (old edges + edgesAdded) - edgesErased  <-- works
-   // New edges = (old edges - edgesErased) + edgesAdded  <-- does not work
-   std::vector<ChangedEdge> edgesErased;
+		// New edges = (old edges + edgesAdded) - edgesErased  <-- works
+		// New edges = (old edges - edgesErased) + edgesAdded  <-- does not work
+		std::vector<ChangedEdge> edgesErased;
 
-   std::vector<int> verticesErased;
+		std::vector<int> verticesErased;
 
 #ifndef __CUDACC__
 
-public:
-   ///  Update the connections status in every epoch.
-   ///  Uses the parent definition for __CUDACC__
-   ///
-   ///  @param  vertices The Vertex list to search from.
-   ///  @param  layout   Layout information of the vertex network.
-   ///  @return true if successful, false otherwise.
-   virtual bool updateConnections(AllVertices &vertices, Layout *layout) override;
+	public:
+		///  Update the connections status in every epoch.
+		///  Uses the parent definition for __CUDACC__
+		///
+		///  @param  vertices The Vertex list to search from.
+		///  @param  layout   Layout information of the vertex network.
+		///  @return true if successful, false otherwise.
+		bool updateConnections(AllVertices& vertices, Layout* layout) override;
 
-   ///  Returns the complete list of all deleted or added edges as a string.
-   ///  @return xml representation of all deleted or added edges
-   std::string changedEdgesToXML(bool added);
+		///  Returns the complete list of all deleted or added edges as a string.
+		///  @return xml representation of all deleted or added edges
+		std::string changedEdgesToXML(bool added);
 
-   ///  Returns the complete list of deleted vertices as a string.
-   ///  @return xml representation of all deleted vertices
-   std::string erasedVerticesToXML();
+		///  Returns the complete list of deleted vertices as a string.
+		///  @return xml representation of all deleted vertices
+		std::string erasedVerticesToXML();
 
-private:
-   ///  Randomly delete 1 PSAP and rewire all the edges around it.
-   ///
-   ///  @param  vertices  The Vertex list to search from.
-   ///  @param  layout   Layout information of the vertex network.
-   ///  @return true if successful, false otherwise.
-   bool erasePSAP(AllVertices &vertices, Layout *layout);
+	private:
+		///  Randomly delete 1 PSAP and rewire all the edges around it.
+		///
+		///  @param  vertices  The Vertex list to search from.
+		///  @param  layout   Layout information of the vertex network.
+		///  @return true if successful, false otherwise.
+		bool erasePSAP(AllVertices& vertices, Layout* layout);
 
-   ///  Randomly delete 1 RESP.
-   ///
-   ///  @param  vertices  The Vertex list to search from.
-   ///  @param  layout   Layout information of the vertex network.
-   ///  @return true if successful, false otherwise.
-   bool eraseRESP(AllVertices &vertices, Layout *layout);
+		///  Randomly delete 1 RESP.
+		///
+		///  @param  vertices  The Vertex list to search from.
+		///  @param  layout   Layout information of the vertex network.
+		///  @return true if successful, false otherwise.
+		bool eraseRESP(AllVertices& vertices, Layout* layout);
 
-   struct ChangedEdge {
-      int srcV;
-      int destV;
-      edgeType eType;
-      std::string toString();
-   };
+		struct ChangedEdge {
+			int srcV;
+			int destV;
+			edgeType eType;
+			std::string toString();
+		};
 
 #else
 public:

--- a/Simulator/Connections/NG911/Connections911.h
+++ b/Simulator/Connections/NG911/Connections911.h
@@ -14,8 +14,6 @@
 #include "Simulator.h"
 #include <vector>
 
-using namespace std;
-
 class Connections911 : public Connections {
 public:
    Connections911();
@@ -60,19 +58,19 @@ private:
    struct ChangedEdge;
 
    // Edges that were added but later removed are still here
-   vector<ChangedEdge> edgesAdded;
+   std::vector<ChangedEdge> edgesAdded;
 
    // New edges = (old edges + edgesAdded) - edgesErased  <-- works
    // New edges = (old edges - edgesErased) + edgesAdded  <-- does not work
-   vector<ChangedEdge> edgesErased;
+   std::vector<ChangedEdge> edgesErased;
 
-   vector<int> verticesErased;
+   std::vector<int> verticesErased;
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 public:
    ///  Update the connections status in every epoch.
-   ///  Uses the parent definition for USE_GPU
+   ///  Uses the parent definition for __CUDACC__
    ///
    ///  @param  vertices The Vertex list to search from.
    ///  @param  layout   Layout information of the vertex network.
@@ -81,11 +79,11 @@ public:
 
    ///  Returns the complete list of all deleted or added edges as a string.
    ///  @return xml representation of all deleted or added edges
-   string changedEdgesToXML(bool added);
+   std::string changedEdgesToXML(bool added);
 
    ///  Returns the complete list of deleted vertices as a string.
    ///  @return xml representation of all deleted vertices
-   string erasedVerticesToXML();
+   std::string erasedVerticesToXML();
 
 private:
    ///  Randomly delete 1 PSAP and rewire all the edges around it.
@@ -106,7 +104,7 @@ private:
       int srcV;
       int destV;
       edgeType eType;
-      string toString();
+      std::string toString();
    };
 
 #else

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -47,15 +47,7 @@
 #include "Hdf5GrowthRecorder.h"
 #endif
 
-ConnGrowth::ConnGrowth() : Connections() {
-	W_ = nullptr;
-	radii_ = nullptr;
-	rates_ = nullptr;
-	delta_ = nullptr;
-	area_ = nullptr;
-	outgrowth_ = nullptr;
-	deltaR_ = nullptr;
-	radiiSize_ = 0;
+ConnGrowth::ConnGrowth() : Connections(), radiiSize_(0), deltaR_(nullptr), outgrowth_(nullptr), area_(nullptr), delta_(nullptr), rates_(nullptr), radii_(nullptr), W_(nullptr) {
 }
 
 ConnGrowth::~ConnGrowth() {

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -112,7 +112,7 @@ void ConnGrowth::loadParameters() {
    if (growthParams_.epsilon != 0) {
       growthParams_.maxRate = growthParams_.targetRate / growthParams_.epsilon;
 	} else {
-      LOG4CPLUS_FATAL(fileLogger_, "Parameter GrowthParams/epsilon/ has a value of 0" << endl);
+      LOG4CPLUS_FATAL(fileLogger_, "Parameter GrowthParams/epsilon/ has a value of 0" << std::endl);
       exit(EXIT_FAILURE);
    }
 }
@@ -120,14 +120,14 @@ void ConnGrowth::loadParameters() {
 /// Prints out all parameters to logging file.
 /// Registered to OperationManager as Operation::printParameters
 void ConnGrowth::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nCONNECTIONS PARAMETERS" << endl
-    << "\tConnections type: ConnGrowth" << endl
-    << "\tepsilon: " << growthParams_.epsilon << endl
-    << "\tbeta: " << growthParams_.beta << endl
-    << "\trho: " << growthParams_.rho << endl
-    << "\tTarget rate: " << growthParams_.targetRate << "," << endl
-    << "\tMinimum radius: " << growthParams_.minRadius << endl
-    << "\tStarting radius: " << growthParams_.startRadius << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nCONNECTIONS PARAMETERS" << std::endl
+    << "\tConnections type: ConnGrowth" << std::endl
+    << "\tepsilon: " << growthParams_.epsilon << std::endl
+    << "\tbeta: " << growthParams_.beta << std::endl
+    << "\trho: " << growthParams_.rho << std::endl
+    << "\tTarget rate: " << growthParams_.targetRate << "," << std::endl
+    << "\tMinimum radius: " << growthParams_.minRadius << std::endl
+    << "\tStarting radius: " << growthParams_.startRadius << std::endl << std::endl);
 }
 
 ///  Update the connections status in every epoch.
@@ -202,11 +202,11 @@ void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout *layout) {
             BGFLOAT r1 = (*radii_)[i];
             BGFLOAT r2 = (*radii_)[j];
 
-            if (lenAB + min(r1, r2) <= max(r1, r2)) {
-               (*area_)(i, j) = pi * min(r1, r2) * min(r1, r2); // Completely overlapping unit
+            if (lenAB + std::min(r1, r2) <= std::max(r1, r2)) {
+               (*area_)(i, j) = pi * std::min(r1, r2) * std::min(r1, r2); // Completely overlapping unit
 
                LOG4CPLUS_DEBUG(fileLogger_, "Completely overlapping (i, j, r1, r2, area): "
-                     << i << ", " << j << ", " << r1 << ", " << r2 << ", " << (*area_)(i, j) << endl);
+                     << i << ", " << j << ", " << r1 << ", " << r2 << ", " << (*area_)(i, j) << std::endl);
             } else {
                // Partially overlapping unit
                BGFLOAT lenAB2 = (*layout->dist2_)(i, j);
@@ -234,7 +234,7 @@ void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout *layout) {
    }
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Update the weight of the Synapses in the simulation.
 ///  To be clear, iterates through all source and destination neurons
@@ -325,12 +325,12 @@ void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices &verti
              << "\nAdded: " << added);
 }
 
-#endif // !USE_GPU
+#endif
 
 ///  Prints radii 
 void ConnGrowth::printRadii() const {
    for (int i = 0; i < radiiSize_; i++) {
-      cout << "radii[" << i << "] = " << (*radii_)[i] << endl;
+      std::cout << "radii[" << i << "] = " << (*radii_)[i] << std::endl;
    }
 }
 

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -33,48 +33,48 @@
  */
 
 #include "ConnGrowth.h"
-#include "ParseParamError.h"
 #include "AllEdges.h"
-#include "XmlGrowthRecorder.h"
 #include "AllSpikingNeurons.h"
+#include "OperationManager.h"
+#include "ParameterManager.h"
+#include "ParseParamError.h"
+#include "XmlGrowthRecorder.h"
 #include "Matrix/CompleteMatrix.h"
 #include "Matrix/Matrix.h"
 #include "Matrix/VectorMatrix.h"
-#include "ParameterManager.h"
-#include "OperationManager.h"
 
 #ifdef USE_HDF5
 #include "Hdf5GrowthRecorder.h"
 #endif
 
 ConnGrowth::ConnGrowth() : Connections() {
-   W_ = nullptr;
-   radii_ = nullptr;
-   rates_ = nullptr;
-   delta_ = nullptr;
-   area_ = nullptr;
-   outgrowth_ = nullptr;
-   deltaR_ = nullptr;
-   radiiSize_ = 0;
+	W_ = nullptr;
+	radii_ = nullptr;
+	rates_ = nullptr;
+	delta_ = nullptr;
+	area_ = nullptr;
+	outgrowth_ = nullptr;
+	deltaR_ = nullptr;
+	radiiSize_ = 0;
 }
 
 ConnGrowth::~ConnGrowth() {
-   if (W_ != nullptr) delete W_;
-   if (radii_ != nullptr) delete radii_;
-   if (rates_ != nullptr) delete rates_;
-   if (delta_ != nullptr) delete delta_;
-   if (area_ != nullptr) delete area_;
-   if (outgrowth_ != nullptr) delete outgrowth_;
-   if (deltaR_ != nullptr) delete deltaR_;
+	if (W_ != nullptr) delete W_;
+	if (radii_ != nullptr) delete radii_;
+	if (rates_ != nullptr) delete rates_;
+	if (delta_ != nullptr) delete delta_;
+	if (area_ != nullptr) delete area_;
+	if (outgrowth_ != nullptr) delete outgrowth_;
+	if (deltaR_ != nullptr) delete deltaR_;
 
-   W_ = nullptr;
-   radii_ = nullptr;
-   rates_ = nullptr;
-   delta_ = nullptr;
-   area_ = nullptr;
-   outgrowth_ = nullptr;
-   deltaR_ = nullptr;
-   radiiSize_ = 0;
+	W_ = nullptr;
+	radii_ = nullptr;
+	rates_ = nullptr;
+	delta_ = nullptr;
+	area_ = nullptr;
+	outgrowth_ = nullptr;
+	deltaR_ = nullptr;
+	radiiSize_ = 0;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -82,52 +82,51 @@ ConnGrowth::~ConnGrowth() {
 ///  @param  layout    Layout information of the neural network.
 ///  @param  vertices   The vertex list to search from.
 ///  @param  synapses  The Synapse list to search from.
-void ConnGrowth::setupConnections(Layout *layout, AllVertices *vertices, AllEdges *synapses) {
-   int numVertices = Simulator::getInstance().getTotalVertices();
-   radiiSize_ = numVertices;
+void ConnGrowth::setupConnections(Layout* layout, AllVertices* vertices, AllEdges* synapses) {
+	int numVertices = Simulator::getInstance().getTotalVertices();
+	radiiSize_ = numVertices;
 
-   W_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices, 0);
-   radii_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices, growthParams_.startRadius);
-   rates_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices, 0);
-   delta_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
-   area_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices, 0);
-   outgrowth_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
-   deltaR_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
+	W_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices, 0);
+	radii_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices, growthParams_.startRadius);
+	rates_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices, 0);
+	delta_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
+	area_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices, 0);
+	outgrowth_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
+	deltaR_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
 
-   // Init connection frontier distance change matrix with the current distances
-   (*delta_) = (*layout->dist_);
+	// Init connection frontier distance change matrix with the current distances
+	(*delta_) = (*layout->dist_);
 }
 
 /// Load member variables from configuration file.
 /// Registered to OperationManager as Operations::op::loadParameters
 void ConnGrowth::loadParameters() {
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/epsilon/text()", growthParams_.epsilon);
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/beta/text()", growthParams_.beta);
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/rho/text()", growthParams_.rho);
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/targetRate/text()", growthParams_.targetRate);
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/minRadius/text()", growthParams_.minRadius);
-   ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/startRadius/text()", growthParams_.startRadius);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/epsilon/text()", growthParams_.epsilon);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/beta/text()", growthParams_.beta);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/rho/text()", growthParams_.rho);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/targetRate/text()", growthParams_.targetRate);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/minRadius/text()", growthParams_.minRadius);
+	ParameterManager::getInstance().getBGFloatByXpath("//GrowthParams/startRadius/text()", growthParams_.startRadius);
 
-   // initial maximum firing rate
-   if (growthParams_.epsilon != 0) {
-      growthParams_.maxRate = growthParams_.targetRate / growthParams_.epsilon;
-	} else {
-      LOG4CPLUS_FATAL(fileLogger_, "Parameter GrowthParams/epsilon/ has a value of 0" << std::endl);
-      exit(EXIT_FAILURE);
-   }
+	// initial maximum firing rate
+	if (growthParams_.epsilon != 0) growthParams_.maxRate = growthParams_.targetRate / growthParams_.epsilon;
+	else {
+		LOG4CPLUS_FATAL(fileLogger_, "Parameter GrowthParams/epsilon/ has a value of 0" << std::endl);
+		exit(EXIT_FAILURE);
+	}
 }
 
 /// Prints out all parameters to logging file.
 /// Registered to OperationManager as Operation::printParameters
 void ConnGrowth::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nCONNECTIONS PARAMETERS" << std::endl
-    << "\tConnections type: ConnGrowth" << std::endl
-    << "\tepsilon: " << growthParams_.epsilon << std::endl
-    << "\tbeta: " << growthParams_.beta << std::endl
-    << "\trho: " << growthParams_.rho << std::endl
-    << "\tTarget rate: " << growthParams_.targetRate << "," << std::endl
-    << "\tMinimum radius: " << growthParams_.minRadius << std::endl
-    << "\tStarting radius: " << growthParams_.startRadius << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nCONNECTIONS PARAMETERS" << std::endl
+	                << "\tConnections type: ConnGrowth" << std::endl
+	                << "\tepsilon: " << growthParams_.epsilon << std::endl
+	                << "\tbeta: " << growthParams_.beta << std::endl
+	                << "\trho: " << growthParams_.rho << std::endl
+	                << "\tTarget rate: " << growthParams_.targetRate << "," << std::endl
+	                << "\tMinimum radius: " << growthParams_.minRadius << std::endl
+	                << "\tStarting radius: " << growthParams_.startRadius << std::endl << std::endl);
 }
 
 ///  Update the connections status in every epoch.
@@ -135,103 +134,103 @@ void ConnGrowth::printParameters() const {
 ///  @param  vertices  The vertex list to search from.
 ///  @param  layout   Layout information of the neural network.
 ///  @return true if successful, false otherwise.
-bool ConnGrowth::updateConnections(AllVertices &vertices, Layout *layout) {
-   // Update Connections data
-   updateConns(vertices);
+bool ConnGrowth::updateConnections(AllVertices& vertices, Layout* layout) {
+	// Update Connections data
+	updateConns(vertices);
 
-   // Update the distance between frontiers of vertices
-   updateFrontiers(Simulator::getInstance().getTotalVertices(), layout);
+	// Update the distance between frontiers of vertices
+	updateFrontiers(Simulator::getInstance().getTotalVertices(), layout);
 
-   // Update the areas of overlap in between vertices
-   updateOverlap(Simulator::getInstance().getTotalVertices(), layout);
+	// Update the areas of overlap in between vertices
+	updateOverlap(Simulator::getInstance().getTotalVertices(), layout);
 
-   return true;
+	return true;
 }
 
 ///  Calculates firing rates, vertex radii change and assign new values.
 ///
 ///  @param  vertices  The vertex list to search from.
-void ConnGrowth::updateConns(AllVertices &vertices) {
-   AllSpikingNeurons &spNeurons = dynamic_cast<AllSpikingNeurons &>(vertices);
+void ConnGrowth::updateConns(AllVertices& vertices) {
+	auto& spNeurons = dynamic_cast<AllSpikingNeurons&>(vertices);
 
-   // Calculate growth cycle firing rate for previous period
-   int maxSpikes = static_cast<int> (Simulator::getInstance().getEpochDuration() *
-                                      Simulator::getInstance().getMaxFiringRate());
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      // Calculate firing rate
-      assert(spNeurons.spikeCount_[i] < maxSpikes);
-      (*rates_)[i] = spNeurons.spikeCount_[i] / Simulator::getInstance().getEpochDuration();
-   }
-   
-   // compute vertex radii change and assign new values
-   (*outgrowth_) =
-         1.0 - 2.0 / (1.0 + exp((growthParams_.epsilon - *rates_ / growthParams_.maxRate) / growthParams_.beta));
-   (*deltaR_) = Simulator::getInstance().getEpochDuration() * growthParams_.rho * *outgrowth_;
-   (*radii_) += (*deltaR_);
+	// Calculate growth cycle firing rate for previous period
+	int maxSpikes = static_cast<int>(Simulator::getInstance().getEpochDuration() *
+		Simulator::getInstance().getMaxFiringRate());
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		// Calculate firing rate
+		assert(spNeurons.spikeCount_[i] < maxSpikes);
+		(*rates_)[i] = spNeurons.spikeCount_[i] / Simulator::getInstance().getEpochDuration();
+	}
+
+	// compute vertex radii change and assign new values
+	(*outgrowth_) =
+		1.0 - 2.0 / (1.0 + exp((growthParams_.epsilon - *rates_ / growthParams_.maxRate) / growthParams_.beta));
+	(*deltaR_) = Simulator::getInstance().getEpochDuration() * growthParams_.rho * *outgrowth_;
+	(*radii_) += (*deltaR_);
 }
 
 ///  Update the distance between frontiers of vertices.
 ///
 ///  @param  numVertices  Number of vertices to update.
 ///  @param  layout      Layout information of the neural network.
-void ConnGrowth::updateFrontiers(const int numVertices, Layout *layout) {
-   LOG4CPLUS_INFO(fileLogger_, "Updating distance between frontiers...");
-   // Update distance between frontiers
-   for (int unit = 0; unit < numVertices - 1; unit++) {
-      for (int i = unit + 1; i < numVertices; i++) {
-         (*delta_)(unit, i) = (*layout->dist_)(unit, i) - ((*radii_)[unit] + (*radii_)[i]);
-         (*delta_)(i, unit) = (*delta_)(unit, i);
-      }
-   }
+void ConnGrowth::updateFrontiers(const int numVertices, Layout* layout) {
+	LOG4CPLUS_INFO(fileLogger_, "Updating distance between frontiers...");
+	// Update distance between frontiers
+	for (int unit = 0; unit < numVertices - 1; unit++) {
+		for (int i = unit + 1; i < numVertices; i++) {
+			(*delta_)(unit, i) = (*layout->dist_)(unit, i) - ((*radii_)[unit] + (*radii_)[i]);
+			(*delta_)(i, unit) = (*delta_)(unit, i);
+		}
+	}
 }
 
 ///  Update the areas of overlap in between Neurons.
 ///
 ///  @param  numVertices  Number of vertices to update.
 ///  @param  layout      Layout information of the neural network.
-void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout *layout) {
-   LOG4CPLUS_INFO(fileLogger_, "Computing areas of overlap");
+void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout* layout) {
+	LOG4CPLUS_INFO(fileLogger_, "Computing areas of overlap");
 
-   // Compute areas of overlap; this is only done for overlapping units
-   for (int i = 0; i < numVertices; i++) {
-      for (int j = 0; j < numVertices; j++) {
-         (*area_)(i, j) = 0.0;
+	// Compute areas of overlap; this is only done for overlapping units
+	for (int i = 0; i < numVertices; i++) {
+		for (int j = 0; j < numVertices; j++) {
+			(*area_)(i, j) = 0.0;
 
-         if ((*delta_)(i, j) < 0) {
-            BGFLOAT lenAB = (*layout->dist_)(i, j);
-            BGFLOAT r1 = (*radii_)[i];
-            BGFLOAT r2 = (*radii_)[j];
+			if ((*delta_)(i, j) < 0) {
+				BGFLOAT lenAB = (*layout->dist_)(i, j);
+				BGFLOAT r1 = (*radii_)[i];
+				BGFLOAT r2 = (*radii_)[j];
 
-            if (lenAB + std::min(r1, r2) <= std::max(r1, r2)) {
-               (*area_)(i, j) = pi * std::min(r1, r2) * std::min(r1, r2); // Completely overlapping unit
+				if (lenAB + std::min(r1, r2) <= std::max(r1, r2)) {
+					(*area_)(i, j) = pi * std::min(r1, r2) * std::min(r1, r2); // Completely overlapping unit
 
-               LOG4CPLUS_DEBUG(fileLogger_, "Completely overlapping (i, j, r1, r2, area): "
-                     << i << ", " << j << ", " << r1 << ", " << r2 << ", " << (*area_)(i, j) << std::endl);
-            } else {
-               // Partially overlapping unit
-               BGFLOAT lenAB2 = (*layout->dist2_)(i, j);
-               BGFLOAT r12 = r1 * r1;
-               BGFLOAT r22 = r2 * r2;
+					LOG4CPLUS_DEBUG(fileLogger_, "Completely overlapping (i, j, r1, r2, area): "
+					                << i << ", " << j << ", " << r1 << ", " << r2 << ", " << (*area_)(i, j) << std::
+					                endl);
+				}
+				else {
+					// Partially overlapping unit
+					BGFLOAT lenAB2 = (*layout->dist2_)(i, j);
+					BGFLOAT r12 = r1 * r1;
+					BGFLOAT r22 = r2 * r2;
 
-               BGFLOAT cosCBA = (r22 + lenAB2 - r12) / (2.0 * r2 * lenAB);
-               BGFLOAT cosCAB = (r12 + lenAB2 - r22) / (2.0 * r1 * lenAB);
+					BGFLOAT cosCBA = (r22 + lenAB2 - r12) / (2.0 * r2 * lenAB);
+					BGFLOAT cosCAB = (r12 + lenAB2 - r22) / (2.0 * r1 * lenAB);
 
-               if (fabs(cosCBA) >= 1.0 || fabs(cosCAB) >= 1.0) {
-                  (*area_)(i, j) = 0.0;
-               } else {
+					if (fabs(cosCBA) >= 1.0 || fabs(cosCAB) >= 1.0) (*area_)(i, j) = 0.0;
+					else {
+						BGFLOAT angCBA = acos(cosCBA);
+						BGFLOAT angCBD = 2.0 * angCBA;
 
-                  BGFLOAT angCBA = acos(cosCBA);
-                  BGFLOAT angCBD = 2.0 * angCBA;
+						BGFLOAT angCAB = acos(cosCAB);
+						BGFLOAT angCAD = 2.0 * angCAB;
 
-                  BGFLOAT angCAB = acos(cosCAB);
-                  BGFLOAT angCAD = 2.0 * angCAB;
-
-                  (*area_)(i, j) = 0.5 * (r22 * (angCBD - sin(angCBD)) + r12 * (angCAD - sin(angCAD)));
-               }
-            }
-         }
-      }
-   }
+						(*area_)(i, j) = 0.5 * (r22 * (angCBD - sin(angCBD)) + r12 * (angCAD - sin(angCAD)));
+					}
+				}
+			}
+		}
+	}
 }
 
 #ifndef __CUDACC__
@@ -245,93 +244,88 @@ void ConnGrowth::updateOverlap(BGFLOAT numVertices, Layout *layout) {
 ///  @param  ivertices    the AllVertices object.
 ///  @param  iedges   the AllEdges object.
 ///  @param  layout      the Layout object.
-void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices &vertices, AllEdges &iedges,
-                                       Layout *layout) {
-   AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(iedges);
+void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices& vertices, AllEdges& iedges,
+                                       Layout* layout) {
+	auto& synapses = dynamic_cast<AllNeuroEdges&>(iedges);
 
-   // For now, we just set the weights to equal the areas. We will later
-   // scale it and set its sign (when we index and get its sign).
-   (*W_) = (*area_);
+	// For now, we just set the weights to equal the areas. We will later
+	// scale it and set its sign (when we index and get its sign).
+	(*W_) = (*area_);
 
-   int adjusted = 0;
-   int couldBeRemoved = 0; // TODO: use this value
-   int removed = 0;
-   int added = 0;
+	int adjusted = 0;
+	int couldBeRemoved = 0; // TODO: use this value
+	int removed = 0;
+	int added = 0;
 
-   LOG4CPLUS_INFO(fileLogger_, "Adjusting Synapse weights");
+	LOG4CPLUS_INFO(fileLogger_, "Adjusting Synapse weights");
 
-   // Scale and add sign to the areas
-   // visit each neuron 'a'
-   for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
-      // and each destination neuron 'b'
-      for (int destVertex = 0; destVertex < numVertices; destVertex++) {
-         // visit each synapse at (xa,ya)
-         bool connected = false;
-         edgeType type = layout->edgType(srcVertex, destVertex);
+	// Scale and add sign to the areas
+	// visit each neuron 'a'
+	for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
+		// and each destination neuron 'b'
+		for (int destVertex = 0; destVertex < numVertices; destVertex++) {
+			// visit each synapse at (xa,ya)
+			bool connected = false;
+			edgeType type = layout->edgType(srcVertex, destVertex);
 
-         // for each existing synapse
-         BGSIZE synapseCounts = synapses.edgeCounts_[destVertex];
-         BGSIZE synapse_adjusted = 0;
-         BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * destVertex;
-         for (BGSIZE synapseIndex = 0; synapse_adjusted < synapseCounts; synapseIndex++, iEdg++) {
-            if (synapses.inUse_[iEdg] == true) {
-               // if there is a synapse between a and b
-               if (synapses.sourceVertexIndex_[iEdg] == srcVertex) {
-                  connected = true;
-                  adjusted++;
-                  // adjust the strength of the synapse or remove
-                  // it from the synapse map if it has gone below
-                  // zero.
-                  if ((*W_)(srcVertex, destVertex) <= 0) {
-                     removed++;
-                     synapses.eraseEdge(destVertex, iEdg);
-                  } else {
-                     // adjust
-                     // SYNAPSE_STRENGTH_ADJUSTMENT is 1.0e-8;
-                     synapses.W_[iEdg] = (*W_)(srcVertex, destVertex) *
-                                         synapses.edgSign(type) * AllNeuroEdges::SYNAPSE_STRENGTH_ADJUSTMENT;
+			// for each existing synapse
+			BGSIZE synapseCounts = synapses.edgeCounts_[destVertex];
+			BGSIZE synapse_adjusted = 0;
+			BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * destVertex;
+			for (BGSIZE synapseIndex = 0; synapse_adjusted < synapseCounts; synapseIndex++, iEdg++) {
+				if (synapses.inUse_[iEdg] == true) {
+					// if there is a synapse between a and b
+					if (synapses.sourceVertexIndex_[iEdg] == srcVertex) {
+						connected = true;
+						adjusted++;
+						// adjust the strength of the synapse or remove
+						// it from the synapse map if it has gone below
+						// zero.
+						if ((*W_)(srcVertex, destVertex) <= 0) {
+							removed++;
+							synapses.eraseEdge(destVertex, iEdg);
+						}
+						else {
+							// adjust
+							// SYNAPSE_STRENGTH_ADJUSTMENT is 1.0e-8;
+							synapses.W_[iEdg] = (*W_)(srcVertex, destVertex) *
+								synapses.edgSign(type) * AllNeuroEdges::SYNAPSE_STRENGTH_ADJUSTMENT;
 
-                     LOG4CPLUS_DEBUG(fileLogger_, "Weight of rgSynapseMap" <<
-                                                                           "[" << synapseIndex << "]: " <<
-                                                                           synapses.W_[iEdg]);
-                  }
-               }
-               synapse_adjusted++;
+							LOG4CPLUS_DEBUG(fileLogger_, "Weight of rgSynapseMap" <<
+							                "[" << synapseIndex << "]: " <<
+							                synapses.W_[iEdg]);
+						}
+					}
+					synapse_adjusted++;
+				}
+			}
 
-            }
-         }
+			// if not connected and weight(a,b) > 0, add a new synapse from a to b
+			if (!connected && ((*W_)(srcVertex, destVertex) > 0)) {
 
-         // if not connected and weight(a,b) > 0, add a new synapse from a to b
-         if (!connected && ((*W_)(srcVertex, destVertex) > 0)) {
+				// locate summation point
+				BGFLOAT* sumPoint = &(vertices.summationMap_[destVertex]);
+				added++;
 
-            // locate summation point
-            BGFLOAT *sumPoint = &(vertices.summationMap_[destVertex]);
-            added++;
+				BGSIZE iEdg;
+				synapses.addEdge(iEdg, type, srcVertex, destVertex, sumPoint,
+				                 Simulator::getInstance().getDeltaT());
+				synapses.W_[iEdg] =
+					(*W_)(srcVertex, destVertex) * synapses.edgSign(type) *
+					AllNeuroEdges::SYNAPSE_STRENGTH_ADJUSTMENT;
+			}
+		}
+	}
 
-            BGSIZE iEdg;
-            synapses.addEdge(iEdg, type, srcVertex, destVertex, sumPoint,
-                                Simulator::getInstance().getDeltaT());
-            synapses.W_[iEdg] =
-                  (*W_)(srcVertex, destVertex) * synapses.edgSign(type) *
-                  AllNeuroEdges::SYNAPSE_STRENGTH_ADJUSTMENT;
-
-         }
-      }
-   }
-
-   LOG4CPLUS_INFO(fileLogger_, "\nAdjusted: " << adjusted
-             << "\nCould have been removed (TODO: calculate this): " << couldBeRemoved
-             << "\nRemoved: " << removed
-             << "\nAdded: " << added);
+	LOG4CPLUS_INFO(fileLogger_, "\nAdjusted: " << adjusted
+	               << "\nCould have been removed (TODO: calculate this): " << couldBeRemoved
+	               << "\nRemoved: " << removed
+	               << "\nAdded: " << added);
 }
 
 #endif
 
 ///  Prints radii 
 void ConnGrowth::printRadii() const {
-   for (int i = 0; i < radiiSize_; i++) {
-      std::cout << "radii[" << i << "] = " << (*radii_)[i] << std::endl;
-   }
+	for (int i = 0; i < radiiSize_; i++) std::cout << "radii[" << i << "] = " << (*radii_)[i] << std::endl;
 }
-
-

--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -77,47 +77,47 @@
 #include <cereal/types/vector.hpp>
 
 class ConnGrowth : public Connections {
-public:
-   ConnGrowth();
+	public:
+		ConnGrowth();
 
-   virtual ~ConnGrowth();
+		~ConnGrowth() override;
 
-   static Connections *Create() { return new ConnGrowth(); }
+		static Connections* Create() { return new ConnGrowth(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  layout    Layout information of the neural network.
-   ///  @param  neurons   The Neuron list to search from.
-   ///  @param  synapses  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, AllVertices *neurons, AllEdges *synapses) override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  layout    Layout information of the neural network.
+		///  @param  neurons   The Neuron list to search from.
+		///  @param  synapses  The Synapse list to search from.
+		void setupConnections(Layout* layout, AllVertices* neurons, AllEdges* synapses) override;
 
-   /// Load member variables from configuration file.
-   /// Registered to OperationManager as Operations::op::loadParameters
-   virtual void loadParameters() override;
+		/// Load member variables from configuration file.
+		/// Registered to OperationManager as Operations::op::loadParameters
+		void loadParameters() override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Update the connections status in every epoch.
-   ///
-   ///  @param  neurons  The Neuron list to search from.
-   ///  @param  layout   Layout information of the neural network.
-   ///  @return true if successful, false otherwise.
-   virtual bool updateConnections(AllVertices &neurons, Layout *layout) override;
+		///  Update the connections status in every epoch.
+		///
+		///  @param  neurons  The Neuron list to search from.
+		///  @param  layout   Layout information of the neural network.
+		///  @return true if successful, false otherwise.
+		bool updateConnections(AllVertices& neurons, Layout* layout) override;
 
-   ///  Cereal serialization method
-   ///  (Serializes radii)
-   template<class Archive>
-   void save(Archive &archive) const;
+		///  Cereal serialization method
+		///  (Serializes radii)
+		template <class Archive>
+		void save(Archive& archive) const;
 
-   ///  Cereal deserialization method
-   ///  (Deserializes radii)
-   template<class Archive>
-   void load(Archive &archive);
+		///  Cereal deserialization method
+		///  (Deserializes radii)
+		template <class Archive>
+		void load(Archive& archive);
 
-   ///  Prints radii
-   void printRadii() const;
+		///  Prints radii
+		void printRadii() const;
 
 #ifdef __CUDACC__
    ///  Update the weights of the Synapses in the simulation. To be clear,
@@ -137,115 +137,112 @@ public:
          AllSpikingSynapsesDeviceProperties* allEdgesDevice,
          Layout *layout) override;
 #else
-   ///  Update the weights of the Synapses in the simulation. To be clear,
-   ///  iterates through all source and destination neurons and updates their
-   ///  synaptic strengths from the weight matrix.
-   ///  Note: Platform Dependent.
-   ///
-   ///  @param  numVertices  Number of vertices to update.
-   ///  @param  ineurons    The AllVertices object.
-   ///  @param  isynapses   The AllEdges object.
-   ///  @param  layout      The Layout object.
-   virtual void
-   updateSynapsesWeights(const int numVertices,
-         AllVertices &vertices,
-         AllEdges &synapses,
-         Layout *layout) override;
+		///  Update the weights of the Synapses in the simulation. To be clear,
+		///  iterates through all source and destination neurons and updates their
+		///  synaptic strengths from the weight matrix.
+		///  Note: Platform Dependent.
+		///
+		///  @param  numVertices  Number of vertices to update.
+		///  @param  ineurons    The AllVertices object.
+		///  @param  isynapses   The AllEdges object.
+		///  @param  layout      The Layout object.
+		void
+			updateSynapsesWeights(const int numVertices,
+			                      AllVertices& vertices,
+			                      AllEdges& synapses,
+			                      Layout* layout) override;
 
 #endif
-private:
-   ///  Calculates firing rates, neuron radii change and assign new values.
-   ///
-   ///  @param  neurons  The Neuron list to search from.
-   void updateConns(AllVertices &neurons);
+	private:
+		///  Calculates firing rates, neuron radii change and assign new values.
+		///
+		///  @param  neurons  The Neuron list to search from.
+		void updateConns(AllVertices& neurons);
 
-   ///  Update the distance between frontiers of Neurons.
-   ///
-   ///  @param  numVertices  Number of vertices to update.
-   ///  @param  layout      Layout information of the neural network.
-   void updateFrontiers(const int numVertices, Layout *layout);
+		///  Update the distance between frontiers of Neurons.
+		///
+		///  @param  numVertices  Number of vertices to update.
+		///  @param  layout      Layout information of the neural network.
+		void updateFrontiers(const int numVertices, Layout* layout);
 
-   ///  Update the areas of overlap in between Neurons.
-   ///
-   ///  @param  numVertices  Number of vertices to update.
-   ///  @param  layout      Layout information of the neural network.
-   void updateOverlap(BGFLOAT numVertices, Layout *layout);
+		///  Update the areas of overlap in between Neurons.
+		///
+		///  @param  numVertices  Number of vertices to update.
+		///  @param  layout      Layout information of the neural network.
+		void updateOverlap(BGFLOAT numVertices, Layout* layout);
 
-public:
-   struct GrowthParams {
-      BGFLOAT epsilon;     ///< null firing rate(zero outgrowth)
-      BGFLOAT beta;        ///< sensitivity of outgrowth to firing rate
-      BGFLOAT rho;         ///< outgrowth rate constant
-      BGFLOAT targetRate;  ///<  Spikes/second
-      BGFLOAT maxRate;     ///<  = targetRate / epsilon;
-      BGFLOAT minRadius;   ///<  To ensure that even rapidly-firing neurons will connect to
-                           ///< other neurons, when within their RFS.
-      BGFLOAT startRadius; ///< No need to wait a long time before RFs start to overlap
-   };
+	public:
+		struct GrowthParams {
+			BGFLOAT epsilon; ///< null firing rate(zero outgrowth)
+			BGFLOAT beta; ///< sensitivity of outgrowth to firing rate
+			BGFLOAT rho; ///< outgrowth rate constant
+			BGFLOAT targetRate; ///<  Spikes/second
+			BGFLOAT maxRate; ///<  = targetRate / epsilon;
+			BGFLOAT minRadius;
+			///<  To ensure that even rapidly-firing neurons will connect to
+			                          ///< other neurons, when within their RFS.
+			BGFLOAT startRadius; ///< No need to wait a long time before RFs start to overlap
+		};
 
-   /// structure to keep growth parameters
-   GrowthParams growthParams_;
+		/// structure to keep growth parameters
+		GrowthParams growthParams_;
 
-   /// spike count for each epoch
-   int *spikeCounts_;
+		/// spike count for each epoch
+		int* spikeCounts_;
 
-   /// radii size
-   int radiiSize_;
+		/// radii size
+		int radiiSize_;
 
-   /// synapse weight
-   CompleteMatrix *W_;
+		/// synapse weight
+		CompleteMatrix* W_;
 
-   /// neuron radii
-   VectorMatrix *radii_;
+		/// neuron radii
+		VectorMatrix* radii_;
 
-   /// spiking rate
-   VectorMatrix *rates_;
+		/// spiking rate
+		VectorMatrix* rates_;
 
-   /// distance between connection frontiers
-   CompleteMatrix *delta_;
+		/// distance between connection frontiers
+		CompleteMatrix* delta_;
 
-   /// areas of overlap
-   CompleteMatrix *area_;
+		/// areas of overlap
+		CompleteMatrix* area_;
 
-   /// neuron's outgrowth
-   VectorMatrix *outgrowth_;
+		/// neuron's outgrowth
+		VectorMatrix* outgrowth_;
 
-   /// displacement of neuron radii
-   VectorMatrix *deltaR_;
+		/// displacement of neuron radii
+		VectorMatrix* deltaR_;
 
 };
 
 ///  Cereal serialization method
 ///  (Serializes radii)
-template<class Archive>
-void ConnGrowth::save(Archive &archive) const {
-   // uses vector to save radii
-   std::vector<BGFLOAT> radiiVector;
-   for (int i = 0; i < radiiSize_; i++) {
-      radiiVector.push_back((*radii_)[i]);
-   }
-   // serialization
-   archive(radiiVector);
+template <class Archive>
+void ConnGrowth::save(Archive& archive) const {
+	// uses vector to save radii
+	std::vector<BGFLOAT> radiiVector;
+	for (int i = 0; i < radiiSize_; i++) radiiVector.push_back((*radii_)[i]);
+	// serialization
+	archive(radiiVector);
 }
 
 ///  Cereal deserialization method
 ///  (Deserializes radii)
-template<class Archive>
-void ConnGrowth::load(Archive &archive) {
-   // uses vector to load radii
-   std::vector<BGFLOAT> radiiVector;
+template <class Archive>
+void ConnGrowth::load(Archive& archive) {
+	// uses vector to load radii
+	std::vector<BGFLOAT> radiiVector;
 
-   // deserializing data to this vector
-   archive(radiiVector);
+	// deserializing data to this vector
+	archive(radiiVector);
 
-   // check to see if serialized data size matches object size
-   if (radiiVector.size() != radiiSize_) {
-      std::cerr << "Failed deserializing radii. Please verify totalVertices data member." << std::endl;
-      throw cereal::Exception("Deserialization Error");
-   }
+	// check to see if serialized data size matches object size
+	if (radiiVector.size() != radiiSize_) {
+		std::cerr << "Failed deserializing radii. Please verify totalVertices data member." << std::endl;
+		throw cereal::Exception("Deserialization Error");
+	}
 
-   // assigns serialized data to objects
-   for (int i = 0; i < radiiSize_; i++) {
-      (*radii_)[i] = radiiVector[i];
-   }
+	// assigns serialized data to objects
+	for (int i = 0; i < radiiSize_; i++) (*radii_)[i] = radiiVector[i];
 }

--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -76,8 +76,6 @@
 // cereal
 #include <cereal/types/vector.hpp>
 
-using namespace std;
-
 class ConnGrowth : public Connections {
 public:
    ConnGrowth();
@@ -121,7 +119,7 @@ public:
    ///  Prints radii
    void printRadii() const;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    ///  Update the weights of the Synapses in the simulation. To be clear,
    ///  iterates through all source and destination neurons and updates their
    ///  synaptic strengths from the weight matrix.
@@ -222,7 +220,7 @@ public:
 template<class Archive>
 void ConnGrowth::save(Archive &archive) const {
    // uses vector to save radii
-   vector<BGFLOAT> radiiVector;
+   std::vector<BGFLOAT> radiiVector;
    for (int i = 0; i < radiiSize_; i++) {
       radiiVector.push_back((*radii_)[i]);
    }
@@ -235,14 +233,14 @@ void ConnGrowth::save(Archive &archive) const {
 template<class Archive>
 void ConnGrowth::load(Archive &archive) {
    // uses vector to load radii
-   vector<BGFLOAT> radiiVector;
+   std::vector<BGFLOAT> radiiVector;
 
    // deserializing data to this vector
    archive(radiiVector);
 
    // check to see if serialized data size matches object size
    if (radiiVector.size() != radiiSize_) {
-      cerr << "Failed deserializing radii. Please verify totalVertices data member." << endl;
+      std::cerr << "Failed deserializing radii. Please verify totalVertices data member." << std::endl;
       throw cereal::Exception("Deserialization Error");
    }
 

--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -147,7 +147,7 @@ class ConnGrowth : public Connections {
 		///  @param  isynapses   The AllEdges object.
 		///  @param  layout      The Layout object.
 		void
-			updateSynapsesWeights(const int numVertices,
+			updateSynapsesWeights(int numVertices,
 			                      AllVertices& vertices,
 			                      AllEdges& synapses,
 			                      Layout* layout) override;
@@ -163,7 +163,7 @@ class ConnGrowth : public Connections {
 		///
 		///  @param  numVertices  Number of vertices to update.
 		///  @param  layout      Layout information of the neural network.
-		void updateFrontiers(const int numVertices, Layout* layout);
+		void updateFrontiers(int numVertices, Layout* layout);
 
 		///  Update the areas of overlap in between Neurons.
 		///

--- a/Simulator/Connections/Neuro/ConnGrowth_d.cu
+++ b/Simulator/Connections/Neuro/ConnGrowth_d.cu
@@ -58,7 +58,7 @@ void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices &verti
 
         blocksPerGrid = ( simulator.getTotalVertices() + threadsPerBlock - 1 ) / threadsPerBlock;
         updateSynapsesWeightsDevice <<< blocksPerGrid, threadsPerBlock >>> ( simulator.getTotalVertices(), deltaT, W_d, simulator.getMaxEdgesPerVertex(), allVerticesDevice, allEdgesDevice, neuronTypeMapD );
-        
+
         // free memories
         HANDLE_ERROR( cudaFree( W_d ) );
         delete[] W_h;

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -81,7 +81,7 @@ void ConnStatic::setupConnections(Layout* layout, AllVertices* vertices, AllEdge
 		// sort ascendant
 		sort(distDestVertices[srcVertex].begin(), distDestVertices[srcVertex].end());
 		// pick the shortest connsPerVertex_ connections
-		for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && (int)i < connsPerVertex_; i++) {
+		for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && static_cast<int>(i) < connsPerVertex_; i++) {
 			int destVertex = distDestVertices[srcVertex][i].destVertex;
 			edgeType type = layout->edgType(srcVertex, destVertex);
 			BGFLOAT* sumPoint = &vertices->summationMap_[destVertex];

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -51,8 +51,8 @@ ConnStatic::~ConnStatic() {
 ///  @param  edges  The Synapse list to search from.
 void ConnStatic::setupConnections(Layout *layout, AllVertices *vertices, AllEdges *edges) {
    Simulator& simulator = Simulator::getInstance();
-   int numVertices = simulator.getTotalVertices();
-   vector<DistDestVertex> distDestVertices[numVertices];
+   const int numVertices = simulator.getTotalVertices();
+   std::vector<std::vector<DistDestVertex>> distDestVertices(numVertices);
    BGSIZE maxTotalEdges =  simulator.getMaxEdgesPerVertex() * simulator.getTotalVertices();
    WCurrentEpoch_ = new BGFLOAT[maxTotalEdges];
    sourceVertexIndexCurrentEpoch_ = new int[maxTotalEdges];
@@ -104,7 +104,7 @@ void ConnStatic::setupConnections(Layout *layout, AllVertices *vertices, AllEdge
       }
    }
    
-   string weight_str="";
+   std::string weight_str="";
    for(int i=0; i<maxTotalEdges; i++)
    {
       WCurrentEpoch_[i] = neuroEdges->W_[i];
@@ -113,7 +113,7 @@ void ConnStatic::setupConnections(Layout *layout, AllVertices *vertices, AllEdge
       
       if(WCurrentEpoch_[i]!=0) {
          // LOG4CPLUS_DEBUG(edgeLogger_,i << WCurrentEpoch_[i]);
-         weight_str += to_string(WCurrentEpoch_[i]) + " ";
+         weight_str += std::to_string(WCurrentEpoch_[i]) + " ";
       }
       
    }
@@ -141,15 +141,15 @@ void ConnStatic::loadParameters() {
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void ConnStatic::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << endl
-                   << "\tConnections Type: ConnStatic" << endl
-                   << "\tConnection radius threshold: " << threshConnsRadius_ << endl
-                   << "\tConnections per neuron: " << connsPerVertex_ << endl
-                   << "\tRewiring probability: " << rewiringProbability_ << endl
-                   << "\tExhitatory min weight: " << excWeight_[0] << endl
-                   << "\tExhitatory max weight: " << excWeight_[1] << endl
-                   << "\tInhibitory min weight: " << inhWeight_[0] << endl
-                   << "\tInhibitory max weight: " << inhWeight_[1] << endl
-                   << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
+                   << "\tConnections Type: ConnStatic" << std::endl
+                   << "\tConnection radius threshold: " << threshConnsRadius_ << std::endl
+                   << "\tConnections per neuron: " << connsPerVertex_ << std::endl
+                   << "\tRewiring probability: " << rewiringProbability_ << std::endl
+                   << "\tExhitatory min weight: " << excWeight_[0] << std::endl
+                   << "\tExhitatory max weight: " << excWeight_[1] << std::endl
+                   << "\tInhibitory min weight: " << inhWeight_[0] << std::endl
+                   << "\tInhibitory max weight: " << inhWeight_[1] << std::endl
+                   << std::endl);
 }
 

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -22,15 +22,9 @@
 
 #include <algorithm>
 
-ConnStatic::ConnStatic() {
-	threshConnsRadius_ = 0;
-	connsPerVertex_ = 0;
-	rewiringProbability_ = 0;
-	WCurrentEpoch_ = nullptr;
-	destVertexIndexCurrentEpoch_ = nullptr;
-	sourceVertexIndexCurrentEpoch_ = nullptr;
-	radiiSize_ = 0;
-}
+ConnStatic::ConnStatic(): sourceVertexIndexCurrentEpoch_(nullptr), destVertexIndexCurrentEpoch_(nullptr),
+                          WCurrentEpoch_(nullptr),
+                          radiiSize_(0), connsPerVertex_(0), threshConnsRadius_(0), rewiringProbability_(0) {}
 
 ConnStatic::~ConnStatic() {
 	if (WCurrentEpoch_ != nullptr) delete [] WCurrentEpoch_;

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -8,12 +8,12 @@
 
 
 #include "ConnStatic.h"
-#include "ParseParamError.h"
-#include "AllVertices.h"
 #include "AllEdges.h"
 #include "AllNeuroEdges.h"
+#include "AllVertices.h"
 #include "OperationManager.h"
 #include "ParameterManager.h"
+#include "ParseParamError.h"
 #include "XmlRecorder.h"
 
 #ifdef USE_HDF5
@@ -23,22 +23,22 @@
 #include <algorithm>
 
 ConnStatic::ConnStatic() {
-   threshConnsRadius_ = 0;
-   connsPerVertex_ = 0;
-   rewiringProbability_ = 0;
-   WCurrentEpoch_ = nullptr;
-   destVertexIndexCurrentEpoch_ = nullptr;
-   sourceVertexIndexCurrentEpoch_ = nullptr;
-   radiiSize_ = 0;
+	threshConnsRadius_ = 0;
+	connsPerVertex_ = 0;
+	rewiringProbability_ = 0;
+	WCurrentEpoch_ = nullptr;
+	destVertexIndexCurrentEpoch_ = nullptr;
+	sourceVertexIndexCurrentEpoch_ = nullptr;
+	radiiSize_ = 0;
 }
 
 ConnStatic::~ConnStatic() {
-   if (WCurrentEpoch_ != nullptr) delete [] WCurrentEpoch_;
-   WCurrentEpoch_ = nullptr;
-   if (destVertexIndexCurrentEpoch_ != nullptr) delete [] destVertexIndexCurrentEpoch_;
-   destVertexIndexCurrentEpoch_ = nullptr;
-   if (sourceVertexIndexCurrentEpoch_ != nullptr) delete [] sourceVertexIndexCurrentEpoch_;
-   sourceVertexIndexCurrentEpoch_ = nullptr;
+	if (WCurrentEpoch_ != nullptr) delete [] WCurrentEpoch_;
+	WCurrentEpoch_ = nullptr;
+	if (destVertexIndexCurrentEpoch_ != nullptr) delete [] destVertexIndexCurrentEpoch_;
+	destVertexIndexCurrentEpoch_ = nullptr;
+	if (sourceVertexIndexCurrentEpoch_ != nullptr) delete [] sourceVertexIndexCurrentEpoch_;
+	sourceVertexIndexCurrentEpoch_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -49,107 +49,101 @@ ConnStatic::~ConnStatic() {
 ///  @param  layout    Layout information of the neural network.
 ///  @param  vertices   The Vertex list to search from.
 ///  @param  edges  The Synapse list to search from.
-void ConnStatic::setupConnections(Layout *layout, AllVertices *vertices, AllEdges *edges) {
-   Simulator& simulator = Simulator::getInstance();
-   const int numVertices = simulator.getTotalVertices();
-   std::vector<std::vector<DistDestVertex>> distDestVertices(numVertices);
-   BGSIZE maxTotalEdges =  simulator.getMaxEdgesPerVertex() * simulator.getTotalVertices();
-   WCurrentEpoch_ = new BGFLOAT[maxTotalEdges];
-   sourceVertexIndexCurrentEpoch_ = new int[maxTotalEdges];
-   destVertexIndexCurrentEpoch_ = new int[maxTotalEdges];
-   AllNeuroEdges *neuroEdges = dynamic_cast<AllNeuroEdges *>(edges);
-   
-   radiiSize_ = numVertices;
-   int added = 0;
+void ConnStatic::setupConnections(Layout* layout, AllVertices* vertices, AllEdges* edges) {
+	Simulator& simulator = Simulator::getInstance();
+	const int numVertices = simulator.getTotalVertices();
+	std::vector<std::vector<DistDestVertex>> distDestVertices(numVertices);
+	BGSIZE maxTotalEdges = simulator.getMaxEdgesPerVertex() * simulator.getTotalVertices();
+	WCurrentEpoch_ = new BGFLOAT[maxTotalEdges];
+	sourceVertexIndexCurrentEpoch_ = new int[maxTotalEdges];
+	destVertexIndexCurrentEpoch_ = new int[maxTotalEdges];
+	auto neuroEdges = dynamic_cast<AllNeuroEdges*>(edges);
 
-   LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
+	radiiSize_ = numVertices;
+	int added = 0;
 
-   for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
-      distDestVertices[srcVertex].clear();
+	LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
 
-      // pick the connections shorter than threshConnsRadius
-      for (int destVertex = 0; destVertex < numVertices; destVertex++) {
-         if (srcVertex != destVertex) {
-            BGFLOAT dist = (*layout->dist_)(srcVertex, destVertex);
-            if (dist <= threshConnsRadius_) {
-               DistDestVertex distDestVertex{dist, destVertex};
-               distDestVertices[srcVertex].push_back(distDestVertex);
-            }
-         }
-      }
+	for (int srcVertex = 0; srcVertex < numVertices; srcVertex++) {
+		distDestVertices[srcVertex].clear();
 
-      // sort ascendant
-      sort(distDestVertices[srcVertex].begin(), distDestVertices[srcVertex].end());
-      // pick the shortest connsPerVertex_ connections
-      for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && (int) i < connsPerVertex_; i++) {
-         int destVertex = distDestVertices[srcVertex][i].destVertex;
-         edgeType type = layout->edgType(srcVertex, destVertex);
-         BGFLOAT *sumPoint = &vertices->summationMap_[destVertex];
+		// pick the connections shorter than threshConnsRadius
+		for (int destVertex = 0; destVertex < numVertices; destVertex++) {
+			if (srcVertex != destVertex) {
+				BGFLOAT dist = (*layout->dist_)(srcVertex, destVertex);
+				if (dist <= threshConnsRadius_) {
+					DistDestVertex distDestVertex{dist, destVertex};
+					distDestVertices[srcVertex].push_back(distDestVertex);
+				}
+			}
+		}
 
-         LOG4CPLUS_DEBUG(fileLogger_, "Source: " << srcVertex << " Dest: " << destVertex << " Dist: "
-                         << distDestVertices[srcVertex][i].dist);
+		// sort ascendant
+		sort(distDestVertices[srcVertex].begin(), distDestVertices[srcVertex].end());
+		// pick the shortest connsPerVertex_ connections
+		for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && (int)i < connsPerVertex_; i++) {
+			int destVertex = distDestVertices[srcVertex][i].destVertex;
+			edgeType type = layout->edgType(srcVertex, destVertex);
+			BGFLOAT* sumPoint = &vertices->summationMap_[destVertex];
 
-         BGSIZE iEdg;
-         edges->addEdge(iEdg, type, srcVertex, destVertex, sumPoint, simulator.getDeltaT());
-         added++;
+			LOG4CPLUS_DEBUG(fileLogger_, "Source: " << srcVertex << " Dest: " << destVertex << " Dist: "
+			                << distDestVertices[srcVertex][i].dist);
+
+			BGSIZE iEdg;
+			edges->addEdge(iEdg, type, srcVertex, destVertex, sumPoint, simulator.getDeltaT());
+			added++;
 
 
-         // set edge weight
-         // TODO: we need another synaptic weight distibution mode (normal distribution)
-         if (neuroEdges->edgSign(type) > 0) {
-            neuroEdges->W_[iEdg] = initRNG.inRange(excWeight_[0], excWeight_[1]);
-         } else {
-            neuroEdges->W_[iEdg] = initRNG.inRange(inhWeight_[0], inhWeight_[1]);
-         }
-      }
-   }
-   
-   std::string weight_str="";
-   for(int i=0; i<maxTotalEdges; i++)
-   {
-      WCurrentEpoch_[i] = neuroEdges->W_[i];
-      sourceVertexIndexCurrentEpoch_[i] = neuroEdges->sourceVertexIndex_[i];
-      destVertexIndexCurrentEpoch_[i] = neuroEdges->destVertexIndex_[i];
-      
-      if(WCurrentEpoch_[i]!=0) {
-         // LOG4CPLUS_DEBUG(edgeLogger_,i << WCurrentEpoch_[i]);
-         weight_str += std::to_string(WCurrentEpoch_[i]) + " ";
-      }
-      
-   }
-   // LOG4CPLUS_DEBUG(edgeLogger_, "Weights are " << weight_str);
+			// set edge weight
+			// TODO: we need another synaptic weight distibution mode (normal distribution)
+			if (neuroEdges->edgSign(type) > 0) neuroEdges->W_[iEdg] = initRNG.inRange(excWeight_[0], excWeight_[1]);
+			else neuroEdges->W_[iEdg] = initRNG.inRange(inhWeight_[0], inhWeight_[1]);
+		}
+	}
 
-   int nRewiring = added * rewiringProbability_;
+	std::string weight_str = "";
+	for (int i = 0; i < maxTotalEdges; i++) {
+		WCurrentEpoch_[i] = neuroEdges->W_[i];
+		sourceVertexIndexCurrentEpoch_[i] = neuroEdges->sourceVertexIndex_[i];
+		destVertexIndexCurrentEpoch_[i] = neuroEdges->destVertexIndex_[i];
 
-   LOG4CPLUS_DEBUG(fileLogger_,"Rewiring connections: " << nRewiring);
+		if (WCurrentEpoch_[i] != 0) {
+			// LOG4CPLUS_DEBUG(edgeLogger_,i << WCurrentEpoch_[i]);
+			weight_str += std::to_string(WCurrentEpoch_[i]) + " ";
+		}
+	}
+	// LOG4CPLUS_DEBUG(edgeLogger_, "Weights are " << weight_str);
 
-   LOG4CPLUS_DEBUG(fileLogger_,"Added connections: " << added);
+	int nRewiring = added * rewiringProbability_;
+
+	LOG4CPLUS_DEBUG(fileLogger_, "Rewiring connections: " << nRewiring);
+
+	LOG4CPLUS_DEBUG(fileLogger_, "Added connections: " << added);
 }
 
 /// Load member variables from configuration file.
 /// Registered to OperationManager as Operations::op::loadParameters
 void ConnStatic::loadParameters() {
-   ParameterManager::getInstance().getBGFloatByXpath("//threshConnsRadius/text()", threshConnsRadius_);
-   ParameterManager::getInstance().getIntByXpath("//connsPerNeuron/text()", connsPerVertex_);
-   ParameterManager::getInstance().getBGFloatByXpath("//rewiringProbability/text()", rewiringProbability_);
-   //ParameterManager::getInstance().getBGFloatByXpath("//excWeight/min/text()", excWeight_[0]);
-   //ParameterManager::getInstance().getBGFloatByXpath("//excWeight/max/text()", excWeight_[1]);
-   //ParameterManager::getInstance().getBGFloatByXpath("//inhWeight/min/text()", inhWeight_[0]);
-   //ParameterManager::getInstance().getBGFloatByXpath("//inhWeight/max/text()", inhWeight_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//threshConnsRadius/text()", threshConnsRadius_);
+	ParameterManager::getInstance().getIntByXpath("//connsPerNeuron/text()", connsPerVertex_);
+	ParameterManager::getInstance().getBGFloatByXpath("//rewiringProbability/text()", rewiringProbability_);
+	//ParameterManager::getInstance().getBGFloatByXpath("//excWeight/min/text()", excWeight_[0]);
+	//ParameterManager::getInstance().getBGFloatByXpath("//excWeight/max/text()", excWeight_[1]);
+	//ParameterManager::getInstance().getBGFloatByXpath("//inhWeight/min/text()", inhWeight_[0]);
+	//ParameterManager::getInstance().getBGFloatByXpath("//inhWeight/max/text()", inhWeight_[1]);
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void ConnStatic::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
-                   << "\tConnections Type: ConnStatic" << std::endl
-                   << "\tConnection radius threshold: " << threshConnsRadius_ << std::endl
-                   << "\tConnections per neuron: " << connsPerVertex_ << std::endl
-                   << "\tRewiring probability: " << rewiringProbability_ << std::endl
-                   << "\tExhitatory min weight: " << excWeight_[0] << std::endl
-                   << "\tExhitatory max weight: " << excWeight_[1] << std::endl
-                   << "\tInhibitory min weight: " << inhWeight_[0] << std::endl
-                   << "\tInhibitory max weight: " << inhWeight_[1] << std::endl
-                   << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS" << std::endl
+	                << "\tConnections Type: ConnStatic" << std::endl
+	                << "\tConnection radius threshold: " << threshConnsRadius_ << std::endl
+	                << "\tConnections per neuron: " << connsPerVertex_ << std::endl
+	                << "\tRewiring probability: " << rewiringProbability_ << std::endl
+	                << "\tExhitatory min weight: " << excWeight_[0] << std::endl
+	                << "\tExhitatory max weight: " << excWeight_[1] << std::endl
+	                << "\tInhibitory min weight: " << inhWeight_[0] << std::endl
+	                << "\tInhibitory max weight: " << inhWeight_[1] << std::endl
+	                << std::endl);
 }
-

--- a/Simulator/Connections/Neuro/ConnStatic.h
+++ b/Simulator/Connections/Neuro/ConnStatic.h
@@ -25,96 +25,94 @@
 
 #pragma once
 
-#include "Global.h"
-#include "Connections.h"
-#include "Simulator.h"
-#include <vector>
 #include <iostream>
+#include <vector>
+#include "Connections.h"
+#include "Global.h"
+#include "Simulator.h"
 // cereal
 #include <cereal/types/vector.hpp>
 
 class ConnStatic : public Connections {
-public:
-   ConnStatic();
+	public:
+		ConnStatic();
 
-   virtual ~ConnStatic();
+		~ConnStatic() override;
 
-   static Connections *Create() { return new ConnStatic(); }
+		static Connections* Create() { return new ConnStatic(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///  Initialize the small world network characterized by parameters:
-   ///  number of maximum connections per vertex, connection radius threshold, and
-   ///  small-world rewiring probability.
-   ///
-   ///  @param  layout    Layout information of the neural network.
-   ///  @param  vertices   The Neuron list to search from.
-   ///  @param  edges  The Synapse list to search from.
-   virtual void setupConnections(Layout *layout, AllVertices *vertices, AllEdges *edges) override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///  Initialize the small world network characterized by parameters:
+		///  number of maximum connections per vertex, connection radius threshold, and
+		///  small-world rewiring probability.
+		///
+		///  @param  layout    Layout information of the neural network.
+		///  @param  vertices   The Neuron list to search from.
+		///  @param  edges  The Synapse list to search from.
+		void setupConnections(Layout* layout, AllVertices* vertices, AllEdges* edges) override;
 
-   /// Load member variables from configuration file.
-   /// Registered to OperationManager as Operations::op::loadParameters
-   virtual void loadParameters() override;
+		/// Load member variables from configuration file.
+		/// Registered to OperationManager as Operations::op::loadParameters
+		void loadParameters() override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Get connection radius threshold
-   BGFLOAT getConnsRadiusThresh() const { return threshConnsRadius_; }
+		///  Get connection radius threshold
+		BGFLOAT getConnsRadiusThresh() const { return threshConnsRadius_; }
 
-   /// Get array of vertex weights
-   BGFLOAT* getWCurrentEpoch() const { return WCurrentEpoch_; }
+		/// Get array of vertex weights
+		BGFLOAT* getWCurrentEpoch() const { return WCurrentEpoch_; }
 
-   /// Get all edge source vertex indices
-   int* getSourceVertexIndexCurrentEpoch() const { return sourceVertexIndexCurrentEpoch_; }
+		/// Get all edge source vertex indices
+		int* getSourceVertexIndexCurrentEpoch() const { return sourceVertexIndexCurrentEpoch_; }
 
-      /// Get all edge destination vertex indices
-   int* getDestVertexIndexCurrentEpoch() const { return destVertexIndexCurrentEpoch_; }
+		/// Get all edge destination vertex indices
+		int* getDestVertexIndexCurrentEpoch() const { return destVertexIndexCurrentEpoch_; }
 
-  ///  Cereal serialization method
-  ///  (Serializes radii)
-   template<class Archive>
-   void save(Archive &archive) const;
-   
-   ///  Cereal deserialization method
-   ///  (Deserializes radii)
-   template<class Archive>
-   void load(Archive &archive);
-   
-private:
-   /// Indices of the source vertex for each edge
-   int *sourceVertexIndexCurrentEpoch_;
-   
-    /// Indices of the destination vertex for each edge
-   int *destVertexIndexCurrentEpoch_;
-   
-    /// The weight (scaling factor, strength, maximal amplitude) of each vertex for the current epoch.
-   BGFLOAT *WCurrentEpoch_;
-   
-   /// radii size （2020/2/13 add radiiSize for use in serialization/deserialization)
-   int radiiSize_;
+		///  Cereal serialization method
+		///  (Serializes radii)
+		template <class Archive>
+		void save(Archive& archive) const;
 
-   /// number of maximum connections per vertex
-   int connsPerVertex_;
+		///  Cereal deserialization method
+		///  (Deserializes radii)
+		template <class Archive>
+		void load(Archive& archive);
 
-   /// Connection radius threshold
-   BGFLOAT threshConnsRadius_;
+	private:
+		/// Indices of the source vertex for each edge
+		int* sourceVertexIndexCurrentEpoch_;
 
-   /// Small-world rewiring probability
-   BGFLOAT rewiringProbability_;
+		/// Indices of the destination vertex for each edge
+		int* destVertexIndexCurrentEpoch_;
 
-   /// Min/max values of excitatory neuron's synapse weight
-   BGFLOAT excWeight_[2];
+		/// The weight (scaling factor, strength, maximal amplitude) of each vertex for the current epoch.
+		BGFLOAT* WCurrentEpoch_;
 
-   /// Min/max values of inhibitory neuron's synapse weight
-   BGFLOAT inhWeight_[2];
+		/// radii size （2020/2/13 add radiiSize for use in serialization/deserialization)
+		int radiiSize_;
 
-   struct DistDestVertex {
-      BGFLOAT dist;     ///< destance to the destination vertex
-      int destVertex;  ///< index of the destination vertex
+		/// number of maximum connections per vertex
+		int connsPerVertex_;
 
-      bool operator<(const DistDestVertex &other) const {
-         return (dist < other.dist);
-      }
-   };
+		/// Connection radius threshold
+		BGFLOAT threshConnsRadius_;
+
+		/// Small-world rewiring probability
+		BGFLOAT rewiringProbability_;
+
+		/// Min/max values of excitatory neuron's synapse weight
+		BGFLOAT excWeight_[2];
+
+		/// Min/max values of inhibitory neuron's synapse weight
+		BGFLOAT inhWeight_[2];
+
+		struct DistDestVertex {
+			BGFLOAT dist; ///< destance to the destination vertex
+			int destVertex; ///< index of the destination vertex
+
+			bool operator<(const DistDestVertex& other) const { return (dist < other.dist); }
+		};
 };

--- a/Simulator/Connections/Neuro/ConnStatic.h
+++ b/Simulator/Connections/Neuro/ConnStatic.h
@@ -104,10 +104,10 @@ class ConnStatic : public Connections {
 		BGFLOAT rewiringProbability_;
 
 		/// Min/max values of excitatory neuron's synapse weight
-		BGFLOAT excWeight_[2];
+		BGFLOAT excWeight_[2]{};
 
 		/// Min/max values of inhibitory neuron's synapse weight
-		BGFLOAT inhWeight_[2];
+		BGFLOAT inhWeight_[2]{};
 
 		struct DistDestVertex {
 			BGFLOAT dist; ///< destance to the destination vertex

--- a/Simulator/Connections/Neuro/ConnStatic.h
+++ b/Simulator/Connections/Neuro/ConnStatic.h
@@ -33,8 +33,6 @@
 // cereal
 #include <cereal/types/vector.hpp>
 
-using namespace std;
-
 class ConnStatic : public Connections {
 public:
    ConnStatic();

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -10,7 +10,7 @@
 #include "Simulator.h"
 #include "AllDSSynapses.h"
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 /// Constructor
 CPUModel::CPUModel() : Model() {
@@ -50,13 +50,13 @@ void CPUModel::updateConnections() {
 
 /// Copy GPU Synapse data to CPU. (Inheritance, no implem)
 void CPUModel::copyGPUtoCPU() {
-   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyGPUtoCPU() was called." << endl);
+   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyGPUtoCPU() was called." << std::endl);
    exit(EXIT_FAILURE);
 }
 
 /// Copy CPU Synapse data to GPU. (Inheritance, no implem, GPUModel has implem)
 void CPUModel::copyCPUtoGPU() {
-   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyCPUtoGPU() was called." << endl);
+   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyCPUtoGPU() was called." << std::endl);
    exit(EXIT_FAILURE);
 }
-# endif // define(USE_GPU)
+# endif 

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -7,56 +7,55 @@
  */
 
 #include "CPUModel.h"
-#include "Simulator.h"
 #include "AllDSSynapses.h"
+#include "Simulator.h"
 
 #ifndef __CUDACC__
 
 /// Constructor
-CPUModel::CPUModel() : Model() {
-}
+CPUModel::CPUModel() : Model() {}
 
 /// Destructor
 CPUModel::~CPUModel() {
-   // Let Model base class handle de-allocation
+	// Let Model base class handle de-allocation
 }
 
 /// Performs any finalization tasks on network following a simulation.
 void CPUModel::finish() {
-   // No GPU code to deallocate, and CPU side deallocation is handled by destructors.
+	// No GPU code to deallocate, and CPU side deallocation is handled by destructors.
 }
 
 /// Advance everything in the model one time step.
 void CPUModel::advance() {
-   // ToDo: look at pointer v no pointer in params - to change
-   // dereferencing the ptr, lose late binding -- look into changing!
-   layout_->getVertices()->advanceVertices(*(connections_->getEdges().get()), connections_->getEdgeIndexMap().get());
-   connections_->getEdges()->advanceEdges(layout_->getVertices().get(), connections_->getEdgeIndexMap().get());
+	// ToDo: look at pointer v no pointer in params - to change
+	// dereferencing the ptr, lose late binding -- look into changing!
+	layout_->getVertices()->advanceVertices(*(connections_->getEdges().get()), connections_->getEdgeIndexMap().get());
+	connections_->getEdges()->advanceEdges(layout_->getVertices().get(), connections_->getEdgeIndexMap().get());
 }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.
 void CPUModel::updateConnections() {
-   // Update Connections data
-   if (connections_->updateConnections(*layout_->getVertices(), layout_.get())) {
-      connections_->updateSynapsesWeights(
-            Simulator::getInstance().getTotalVertices(),
-            *layout_->getVertices(),
-            *connections_->getEdges(),
-            layout_.get());
-      // create synapse inverse map
-      connections_->createEdgeIndexMap();
-   }
+	// Update Connections data
+	if (connections_->updateConnections(*layout_->getVertices(), layout_.get())) {
+		connections_->updateSynapsesWeights(
+			Simulator::getInstance().getTotalVertices(),
+			*layout_->getVertices(),
+			*connections_->getEdges(),
+			layout_.get());
+		// create synapse inverse map
+		connections_->createEdgeIndexMap();
+	}
 }
 
 /// Copy GPU Synapse data to CPU. (Inheritance, no implem)
 void CPUModel::copyGPUtoCPU() {
-   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyGPUtoCPU() was called." << std::endl);
-   exit(EXIT_FAILURE);
+	LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyGPUtoCPU() was called." << std::endl);
+	exit(EXIT_FAILURE);
 }
 
 /// Copy CPU Synapse data to GPU. (Inheritance, no implem, GPUModel has implem)
 void CPUModel::copyCPUtoGPU() {
-   LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyCPUtoGPU() was called." << std::endl);
-   exit(EXIT_FAILURE);
+	LOG4CPLUS_WARN(fileLogger_, "ERROR: CPUModel::copyCPUtoGPU() was called." << std::endl);
+	exit(EXIT_FAILURE);
 }
-# endif 
+# endif

--- a/Simulator/Core/CPUModel.h
+++ b/Simulator/Core/CPUModel.h
@@ -35,37 +35,33 @@
 
 #pragma once
 
-#include "Connections/Connections.h"
-#include "AllVertices.h"
 #include "AllEdges.h"
+#include "AllVertices.h"
+#include "Connections/Connections.h"
 #include "Layouts/Layout.h"
 
 class CPUModel : public Model {
-public:
-   /// Constructor
-   CPUModel();
+	public:
+		/// Constructor
+		CPUModel();
 
-   /// Destructor
-   virtual ~CPUModel();
+		/// Destructor
+		~CPUModel() override;
 
-   /// Performs any finalization tasks on network following a simulation.
-   virtual void finish() override;
+		/// Performs any finalization tasks on network following a simulation.
+		void finish() override;
 
-   /// Advances network state one simulation step.
-   virtual void advance() override;
+		/// Advances network state one simulation step.
+		void advance() override;
 
-   /// Modifies connections between neurons based on current state of the network and behavior
-   /// over the past epoch. Should be called once every epoch.
-   virtual void updateConnections() override;
+		/// Modifies connections between neurons based on current state of the network and behavior
+		/// over the past epoch. Should be called once every epoch.
+		void updateConnections() override;
 
-   /// Copy GPU Synapse data to CPU.
-   virtual void copyGPUtoCPU() override;
+		/// Copy GPU Synapse data to CPU.
+		void copyGPUtoCPU() override;
 
-   /// Copy CPU Synapse data to GPU.
-   virtual void copyCPUtoGPU() override;
+		/// Copy CPU Synapse data to GPU.
+		void copyCPUtoGPU() override;
 
 };
-
-
-
-

--- a/Simulator/Core/Driver.cpp
+++ b/Simulator/Core/Driver.cpp
@@ -79,8 +79,8 @@ int main(int argc, char* argv[]) {
 	std::fstream("Output/Debug/edges.txt", std::ios::out | std::ios::trunc);
 
 	// Initialize log4cplus and set properties based on configure file
-	::log4cplus::initialize();
-	::log4cplus::PropertyConfigurator::doConfigure("RuntimeFiles/log4cplus_configure.ini");
+	log4cplus::initialize();
+	log4cplus::PropertyConfigurator::doConfigure("RuntimeFiles/log4cplus_configure.ini");
 
 	// Get the instance of the console logger and print status
 	log4cplus::Logger consoleLogger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
 
 	// Invoke instantiated simulator objects to load parameters from the configuration file
 	LOG4CPLUS_TRACE(consoleLogger, "Loading parameters from configuration file");
-	OperationManager::getInstance().executeOperation(Operations::loadParameters);
+	OperationManager::getInstance().executeOperation(Operations::op::loadParameters);
 
 	time_t start_time, end_time;
 	time(&start_time);
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
 	simulator.setup();
 
 	// Invoke instantiated simulator objects to print parameters, used for testing purposes only.
-	OperationManager::getInstance().executeOperation(Operations::printParameters);
+	OperationManager::getInstance().executeOperation(Operations::op::printParameters);
 
 	// Deserializes internal state from a prior run of the simulation
 	if (!simulator.getDeserializationFileName().empty()) {
@@ -269,7 +269,7 @@ bool deserializeSynapses() {
 
 	// Deserializes synapse weights along with each synapse's source vertex and destination vertex
 	// Uses "try catch" to catch any cereal exception
-	try { archive(*(dynamic_cast<AllEdges*>(connections->getEdges().get()))); }
+	try { archive(*connections->getEdges().get()); }
 	catch (cereal::Exception e) {
 		std::cerr << "Failed deserializing synapse weights, source vertices, and/or destination vertices." << std::endl;
 		return false;
@@ -326,9 +326,11 @@ void serializeSynapses() {
 	std::shared_ptr<Model> model = simulator.getModel();
 
 	// Serializes synapse weights along with each synapse's source vertex and destination vertex
-	archive(*(dynamic_cast<AllEdges*>(model->getConnections()->getEdges().get())));
+	archive(*model->getConnections()->getEdges().get());
 
 	// Serializes radii (only if it is a connGrowth model)
-	if (dynamic_cast<ConnGrowth*>(model->getConnections().get()) != nullptr) archive(
-		*(dynamic_cast<ConnGrowth*>(model->getConnections().get())));
+	if (dynamic_cast<ConnGrowth*>(model->getConnections().get()) != nullptr) {
+		archive(
+			*(dynamic_cast<ConnGrowth*>(model->getConnections().get())));
+	}
 }

--- a/Simulator/Core/EdgeIndexMap.h
+++ b/Simulator/Core/EdgeIndexMap.h
@@ -23,8 +23,6 @@
 
 #include "BGTypes.h"
 
-using namespace std;
-
 struct EdgeIndexMap {
    /// Pointer to the outgoing edge index map.
    BGSIZE* outgoingEdgeIndexMap_;

--- a/Simulator/Core/EdgeIndexMap.h
+++ b/Simulator/Core/EdgeIndexMap.h
@@ -24,70 +24,69 @@
 #include "BGTypes.h"
 
 struct EdgeIndexMap {
-   /// Pointer to the outgoing edge index map.
-   BGSIZE* outgoingEdgeIndexMap_;
+	/// Pointer to the outgoing edge index map.
+	BGSIZE* outgoingEdgeIndexMap_;
 
-   /// The beginning index of the outgoing edge for each vertex.
-   /// Indexed by a source vertex index.
-   BGSIZE *outgoingEdgeBegin_;
+	/// The beginning index of the outgoing edge for each vertex.
+	/// Indexed by a source vertex index.
+	BGSIZE* outgoingEdgeBegin_;
 
-   /// The number of outgoing edges of each vertex.
-   /// Indexed by a source vertex index.
-   BGSIZE *outgoingEdgeCount_;
+	/// The number of outgoing edges of each vertex.
+	/// Indexed by a source vertex index.
+	BGSIZE* outgoingEdgeCount_;
 
-   /// Pointer to the incoming edge index map.
-   BGSIZE* incomingEdgeIndexMap_;
+	/// Pointer to the incoming edge index map.
+	BGSIZE* incomingEdgeIndexMap_;
 
-   /// The beginning index of the incoming edge for each vertex.
-   /// Indexed by a destination vertex index.
-   BGSIZE *incomingEdgeBegin_;
+	/// The beginning index of the incoming edge for each vertex.
+	/// Indexed by a destination vertex index.
+	BGSIZE* incomingEdgeBegin_;
 
-   /// The number of incoming edges for each vertex.
-   /// Indexed by a destination vertex index.
-   BGSIZE *incomingEdgeCount_;
+	/// The number of incoming edges for each vertex.
+	/// Indexed by a destination vertex index.
+	BGSIZE* incomingEdgeCount_;
 
-   EdgeIndexMap() : numOfVertices_(0), numOfEdges_(0) {
-      outgoingEdgeBegin_ = nullptr;
-      outgoingEdgeCount_ = nullptr;
-      incomingEdgeBegin_ = nullptr;
-      incomingEdgeCount_ = nullptr;
+	EdgeIndexMap() : numOfVertices_(0), numOfEdges_(0) {
+		outgoingEdgeBegin_ = nullptr;
+		outgoingEdgeCount_ = nullptr;
+		incomingEdgeBegin_ = nullptr;
+		incomingEdgeCount_ = nullptr;
 
-      outgoingEdgeIndexMap_ = nullptr;
-      incomingEdgeIndexMap_ = nullptr;
-   };
+		outgoingEdgeIndexMap_ = nullptr;
+		incomingEdgeIndexMap_ = nullptr;
+	};
 
-   EdgeIndexMap(int vertexCount, int edgeCount) : numOfVertices_(vertexCount), numOfEdges_(edgeCount) {
-      if (numOfVertices_ > 0) {
-         outgoingEdgeBegin_ = new BGSIZE[numOfVertices_];
-         outgoingEdgeCount_ = new BGSIZE[numOfVertices_];
-         incomingEdgeBegin_ = new BGSIZE[numOfVertices_];
-         incomingEdgeCount_ = new BGSIZE[numOfVertices_];
-      }
+	EdgeIndexMap(int vertexCount, int edgeCount) : numOfVertices_(vertexCount), numOfEdges_(edgeCount) {
+		if (numOfVertices_ > 0) {
+			outgoingEdgeBegin_ = new BGSIZE[numOfVertices_];
+			outgoingEdgeCount_ = new BGSIZE[numOfVertices_];
+			incomingEdgeBegin_ = new BGSIZE[numOfVertices_];
+			incomingEdgeCount_ = new BGSIZE[numOfVertices_];
+		}
 
-      if (numOfEdges_ > 0) {
-         outgoingEdgeIndexMap_ = new BGSIZE[numOfEdges_];
-         incomingEdgeIndexMap_ = new BGSIZE[numOfEdges_];
-      }
-   };
+		if (numOfEdges_ > 0) {
+			outgoingEdgeIndexMap_ = new BGSIZE[numOfEdges_];
+			incomingEdgeIndexMap_ = new BGSIZE[numOfEdges_];
+		}
+	};
 
-   ~EdgeIndexMap() {
-      if (numOfVertices_ > 0) {
-         delete[] outgoingEdgeBegin_;
-         delete[] outgoingEdgeCount_;
-         delete[] incomingEdgeBegin_;
-         delete[] incomingEdgeCount_;
-      }
-      if (numOfEdges_ > 0) {
-         delete[] outgoingEdgeIndexMap_;
-         delete[] incomingEdgeIndexMap_;
-      }
-   }
+	~EdgeIndexMap() {
+		if (numOfVertices_ > 0) {
+			delete[] outgoingEdgeBegin_;
+			delete[] outgoingEdgeCount_;
+			delete[] incomingEdgeBegin_;
+			delete[] incomingEdgeCount_;
+		}
+		if (numOfEdges_ > 0) {
+			delete[] outgoingEdgeIndexMap_;
+			delete[] incomingEdgeIndexMap_;
+		}
+	}
 
-private:
-    /// Number of total vertices.
-    BGSIZE numOfVertices_;
+	private:
+		/// Number of total vertices.
+		BGSIZE numOfVertices_;
 
-    /// Number of total edges.
-    BGSIZE numOfEdges_;
+		/// Number of total edges.
+		BGSIZE numOfEdges_;
 };
-

--- a/Simulator/Core/EdgeIndexMap.h
+++ b/Simulator/Core/EdgeIndexMap.h
@@ -46,14 +46,7 @@ struct EdgeIndexMap {
 	/// Indexed by a destination vertex index.
 	BGSIZE* incomingEdgeCount_;
 
-	EdgeIndexMap() : numOfVertices_(0), numOfEdges_(0) {
-		outgoingEdgeBegin_ = nullptr;
-		outgoingEdgeCount_ = nullptr;
-		incomingEdgeBegin_ = nullptr;
-		incomingEdgeCount_ = nullptr;
-
-		outgoingEdgeIndexMap_ = nullptr;
-		incomingEdgeIndexMap_ = nullptr;
+	EdgeIndexMap() : incomingEdgeIndexMap_(nullptr), outgoingEdgeIndexMap_(nullptr), incomingEdgeCount_(nullptr), incomingEdgeBegin_(nullptr), outgoingEdgeCount_(nullptr), outgoingEdgeBegin_(nullptr), numOfVertices_(0), numOfEdges_(0) {
 	};
 
 	EdgeIndexMap(int vertexCount, int edgeCount) : numOfVertices_(vertexCount), numOfEdges_(edgeCount) {

--- a/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
+++ b/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
@@ -16,9 +16,9 @@
 #include "Operations.h"
 
 /// Constructor, Function Signature: void ()
-GenericFunctionNode::GenericFunctionNode(const Operations::op& operation, const std::function<void()>& func) {
+GenericFunctionNode::GenericFunctionNode(const Operations::op& operation, const std::function<void()>& func) :
+	function_(func) {
 	operationType_ = operation;
-	function_ = func;
 }
 
 /// Destructor

--- a/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
+++ b/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
@@ -16,22 +16,19 @@
 #include "Operations.h"
 
 /// Constructor, Function Signature: void ()
-GenericFunctionNode::GenericFunctionNode(const Operations::op &operation, const std::function<void()> &func) {
-    operationType_ = operation;
-    function_ = func;
+GenericFunctionNode::GenericFunctionNode(const Operations::op& operation, const std::function<void()>& func) {
+	operationType_ = operation;
+	function_ = func;
 }
 
 /// Destructor
-GenericFunctionNode::~GenericFunctionNode() {
-}
+GenericFunctionNode::~GenericFunctionNode() {}
 
 /// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
-bool GenericFunctionNode::invokeFunction(const Operations::op &operation) const {
-    if (operation == operationType_) {
-        std::invoke(function_);
-        return true;
-    }
-    return false;
+bool GenericFunctionNode::invokeFunction(const Operations::op& operation) const {
+	if (operation == operationType_) {
+		std::invoke(function_);
+		return true;
+	}
+	return false;
 }
-
-

--- a/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
+++ b/Simulator/Core/FunctionNodes/GenericFunctionNode.cpp
@@ -28,7 +28,7 @@ GenericFunctionNode::~GenericFunctionNode() {
 /// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
 bool GenericFunctionNode::invokeFunction(const Operations::op &operation) const {
     if (operation == operationType_) {
-        __invoke(function_);
+        std::invoke(function_);
         return true;
     }
     return false;

--- a/Simulator/Core/FunctionNodes/GenericFunctionNode.h
+++ b/Simulator/Core/FunctionNodes/GenericFunctionNode.h
@@ -14,18 +14,16 @@
 #include "IFunctionNode.h"
 
 class GenericFunctionNode : public IFunctionNode {
-public:
-    /// Constructor, Function Signature: void ()
-    GenericFunctionNode(const Operations::op &operationType, const std::function<void()> &function);
+	public:
+		/// Constructor, Function Signature: void ()
+		GenericFunctionNode(const Operations::op& operationType, const std::function<void()>& function);
 
-    /// Destructor
-    ~GenericFunctionNode();
+		/// Destructor
+		~GenericFunctionNode() override;
 
-    /// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
-    bool invokeFunction(const Operations::op &operation) const override;
+		/// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
+		bool invokeFunction(const Operations::op& operation) const override;
 
-private:
-    std::function<void()> function_; ///< Stored function.
+	private:
+		std::function<void()> function_; ///< Stored function.
 };
-
-

--- a/Simulator/Core/FunctionNodes/GenericFunctionNode.h
+++ b/Simulator/Core/FunctionNodes/GenericFunctionNode.h
@@ -13,8 +13,6 @@
 
 #include "IFunctionNode.h"
 
-using namespace std;
-
 class GenericFunctionNode : public IFunctionNode {
 public:
     /// Constructor, Function Signature: void ()

--- a/Simulator/Core/FunctionNodes/IFunctionNode.h
+++ b/Simulator/Core/FunctionNodes/IFunctionNode.h
@@ -11,8 +11,6 @@
 
 #include "Operations.h"
 
-using namespace std;
-
 class IFunctionNode {
 public:
     /// Destructor.

--- a/Simulator/Core/FunctionNodes/IFunctionNode.h
+++ b/Simulator/Core/FunctionNodes/IFunctionNode.h
@@ -12,14 +12,14 @@
 #include "Operations.h"
 
 class IFunctionNode {
-public:
-    /// Destructor.
-    virtual ~IFunctionNode() {}
+	public:
+		/// Destructor.
+		virtual ~IFunctionNode() {}
 
-    /// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
-    virtual bool invokeFunction(const Operations::op &operation) const = 0;
+		/// Invokes the stored function if the sent operation type matches the operation type the function is stored as.
+		virtual bool invokeFunction(const Operations::op& operation) const = 0;
 
-protected:
-    /// The operation type of the stored function.
-    Operations::op operationType_;
+	protected:
+		/// The operation type of the stored function.
+		Operations::op operationType_;
 };

--- a/Simulator/Core/GPUModel.cu
+++ b/Simulator/Core/GPUModel.cu
@@ -65,7 +65,7 @@ void GPUModel::allocDeviceStruct(void** allVerticesDevice, void** allEdgesDevice
 /// @param[out] allVerticesDevice          Memory location of the pointer to the neurons list on device memory.
 /// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
 void GPUModel::deleteDeviceStruct(void** allVerticesDevice, void** allEdgesDevice)
-{  
+{
   // Get neurons and synapses
   shared_ptr<AllVertices> neurons = layout_->getVertices();
   shared_ptr<AllEdges> synapses = connections_->getEdges();
@@ -216,7 +216,7 @@ void GPUModel::updateHistory()
 {
   Model::updateHistory();
   // clear spike count
-  
+
   shared_ptr<AllVertices> neurons = layout_->getVertices();
   dynamic_cast<AllSpikingNeurons*>(neurons.get())->clearNeuronSpikeCounts(allVerticesDevice_);
 }

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -70,84 +70,83 @@ inline void cudaLapTime(double& t_event) {
 class AllSpikingSynapses;
 
 class GPUModel : public Model {
-   friend class GpuSInputPoisson;
+	friend class GpuSInputPoisson;
 
-public:
-   GPUModel();
+	public:
+		GPUModel();
 
-   virtual ~GPUModel();
+		~GPUModel() override;
 
-   /// Set up model state, if anym for a specific simulation run.
-   virtual void setupSim() override;
+		/// Set up model state, if anym for a specific simulation run.
+		void setupSim() override;
 
-   /// Performs any finalization tasks on network following a simulation.
-   virtual void finish() override;
+		/// Performs any finalization tasks on network following a simulation.
+		void finish() override;
 
-   /// Advances network state one simulation step.
-   virtual void advance() override;
+		/// Advances network state one simulation step.
+		void advance() override;
 
-   /// Modifies connections between neurons based on current state of the network and behavior
-   /// over the past epoch. Should be called once every epoch.
-   virtual void updateConnections() override;
+		/// Modifies connections between neurons based on current state of the network and behavior
+		/// over the past epoch. Should be called once every epoch.
+		void updateConnections() override;
 
-   /// Copy GPU Synapse data to CPU.
-   virtual void copyGPUtoCPU() override;
+		/// Copy GPU Synapse data to CPU.
+		void copyGPUtoCPU() override;
 
-   /// Copy CPU Synapse data to GPU.
-   virtual void copyCPUtoGPU() override;
+		/// Copy CPU Synapse data to GPU.
+		void copyCPUtoGPU() override;
 
-   /// Print out SynapseProps on the GPU.
-   void printGPUSynapsesPropsModel() const;
+		/// Print out SynapseProps on the GPU.
+		void printGPUSynapsesPropsModel() const;
 
-protected:
-   /// Allocates  and initializes memories on CUDA device.
-   /// @param[out] allVerticesDevice          Memory location of the pointer to the neurons list on device memory.
-   /// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
-   void allocDeviceStruct(void **allVerticesDevice, void **allEdgesDevice);
+	protected:
+		/// Allocates  and initializes memories on CUDA device.
+		/// @param[out] allVerticesDevice          Memory location of the pointer to the neurons list on device memory.
+		/// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
+		void allocDeviceStruct(void** allVerticesDevice, void** allEdgesDevice);
 
-   /// Copies device memories to host memories and deallocates them.
-   /// @param[out] allVerticesDevice          Memory location of the pointer to the neurons list on device memory.
-   /// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
-   virtual void deleteDeviceStruct(void **allVerticesDevice, void **allEdgesDevice);
+		/// Copies device memories to host memories and deallocates them.
+		/// @param[out] allVerticesDevice          Memory location of the pointer to the neurons list on device memory.
+		/// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
+		virtual void deleteDeviceStruct(void** allVerticesDevice, void** allEdgesDevice);
 
-   /// Add psr of all incoming synapses to summation points.
-   virtual void calcSummationMap();
+		/// Add psr of all incoming synapses to summation points.
+		virtual void calcSummationMap();
 
-   /// Pointer to device random noise array.
-   float *randNoise_d;
+		/// Pointer to device random noise array.
+		float* randNoise_d;
 
-   /// Pointer to synapse index map in device memory.
-   EdgeIndexMap *synapseIndexMapDevice_;
+		/// Pointer to synapse index map in device memory.
+		EdgeIndexMap* synapseIndexMapDevice_;
 
-   /// Synapse structures in device memory.
-   AllSpikingSynapsesDeviceProperties *allEdgesDevice_;
+		/// Synapse structures in device memory.
+		AllSpikingSynapsesDeviceProperties* allEdgesDevice_;
 
-   /// Neuron structure in device memory.
-   AllSpikingNeuronsDeviceProperties *allVerticesDevice_;
+		/// Neuron structure in device memory.
+		AllSpikingNeuronsDeviceProperties* allVerticesDevice_;
 
-private:
-   void allocSynapseImap(int count);
+	private:
+		void allocSynapseImap(int count);
 
-   void deleteSynapseImap();
+		void deleteSynapseImap();
 
-public: //2020/03/14 changed to public for accessing in Driver
+	public: //2020/03/14 changed to public for accessing in Driver
 
-   void copySynapseIndexMapHostToDevice(EdgeIndexMap &synapseIndexMapHost, int numVertices);
+		void copySynapseIndexMapHostToDevice(EdgeIndexMap& synapseIndexMapHost, int numVertices);
 
-private:
+	private:
+		void updateHistory() override;
 
-   void updateHistory();
+		// TODO
+		void eraseEdge(AllEdges& synapses, const int neuronIndex, const int synapseIndex);
 
-   // TODO
-   void eraseEdge(AllEdges &synapses, const int neuronIndex, const int synapseIndex);
+		// TODO
+		void addEdge(AllEdges& synapses, edgeType type, const int srcVertex, const int destVertex,
+		             Coordinate& source, Coordinate& dest, BGFLOAT* sumPoint, BGFLOAT deltaT);
 
-   // TODO
-   void addEdge(AllEdges &synapses, edgeType type, const int srcVertex, const int destVertex,
-                   Coordinate &source, Coordinate &dest, BGFLOAT *sumPoint, BGFLOAT deltaT);
-
-   // TODO
-   void createEdge(AllEdges &synapses, const int neuronIndex, const int synapseIndex,
-                      Coordinate source, Coordinate dest, BGFLOAT *sp, BGFLOAT deltaT, edgeType type);
+		// TODO
+		void createEdge(AllEdges& synapses, const int neuronIndex, const int synapseIndex,
+		                Coordinate source, Coordinate dest, BGFLOAT* sp, BGFLOAT deltaT, edgeType type);
 };
 
 #if defined(__CUDACC__)

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -138,14 +138,14 @@ class GPUModel : public Model {
 		void updateHistory() override;
 
 		// TODO
-		void eraseEdge(AllEdges& synapses, const int neuronIndex, const int synapseIndex);
+		void eraseEdge(AllEdges& synapses, int neuronIndex, int synapseIndex);
 
 		// TODO
-		void addEdge(AllEdges& synapses, edgeType type, const int srcVertex, const int destVertex,
+		void addEdge(AllEdges& synapses, edgeType type, int srcVertex, int destVertex,
 		             Coordinate& source, Coordinate& dest, BGFLOAT* sumPoint, BGFLOAT deltaT);
 
 		// TODO
-		void createEdge(AllEdges& synapses, const int neuronIndex, const int synapseIndex,
+		void createEdge(AllEdges& synapses, int neuronIndex, int synapseIndex,
 		                Coordinate source, Coordinate dest, BGFLOAT* sp, BGFLOAT deltaT, edgeType type);
 };
 

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -116,12 +116,12 @@ void Model::logSimStep() const {
 
 		for (int x = 0; x < Simulator::getInstance().getWidth(); x++) {
 			switch (layout_->vertexTypeMap_[x + y * Simulator::getInstance().getWidth()]) {
-				case EXC: if (layout_->starterMap_[x + y * Simulator::getInstance().getWidth()]) ss << "s";
+				case vertexType::EXC: if (layout_->starterMap_[x + y * Simulator::getInstance().getWidth()]) ss << "s";
 					else ss << "e";
 					break;
-				case INH: ss << "i";
+				case vertexType::INH: ss << "i";
 					break;
-				case VTYPE_UNDEF:
+				case vertexType::VTYPE_UNDEF:
 					assert(false);
 					break;
 			}

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -14,159 +14,142 @@
  */
 
 #include "Model.h"
-#include "IRecorder.h"
 #include "Connections.h"
-#include "ConnGrowth.h"
-#include "ParameterManager.h"
-#include "LayoutFactory.h"
 #include "ConnectionsFactory.h"
+#include "ConnGrowth.h"
+#include "IRecorder.h"
+#include "LayoutFactory.h"
+#include "ParameterManager.h"
 #include "RecorderFactory.h"
 
 /// Constructor
 Model::Model() {
-   // Reference variable used to get class type from ParameterManager.
-   std::string type;
+	// Reference variable used to get class type from ParameterManager.
+	std::string type;
 
-   // Create Layout class using type definition from configuration file.
-   ParameterManager::getInstance().getStringByXpath("//LayoutParams/@class", type);
-   layout_ = LayoutFactory::getInstance()->createLayout(type);
+	// Create Layout class using type definition from configuration file.
+	ParameterManager::getInstance().getStringByXpath("//LayoutParams/@class", type);
+	layout_ = LayoutFactory::getInstance()->createLayout(type);
 
-   // Create Connections class using type definition from configuration file.
-   ParameterManager::getInstance().getStringByXpath("//ConnectionsParams/@class", type);
-   connections_ = ConnectionsFactory::getInstance()->createConnections(type);
+	// Create Connections class using type definition from configuration file.
+	ParameterManager::getInstance().getStringByXpath("//ConnectionsParams/@class", type);
+	connections_ = ConnectionsFactory::getInstance()->createConnections(type);
 
-   // Create Recorder class using type definition from configuration file.
-   ParameterManager::getInstance().getStringByXpath("//RecorderParams/@class", type);
-   recorder_ = RecorderFactory::getInstance()->createRecorder(type);
+	// Create Recorder class using type definition from configuration file.
+	ParameterManager::getInstance().getStringByXpath("//RecorderParams/@class", type);
+	recorder_ = RecorderFactory::getInstance()->createRecorder(type);
 
-   // Get a copy of the file logger to use log4cplus macros
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	// Get a copy of the file logger to use log4cplus macros
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
 /// Destructor
-Model::~Model() {
-
-}
+Model::~Model() {}
 
 /// Save simulation results to an output destination.
-void Model::saveResults() {
-   if (recorder_ != nullptr) {
-      recorder_->saveSimData(*layout_->getVertices());
-   }
-}
+void Model::saveResults() { if (recorder_ != nullptr) recorder_->saveSimData(*layout_->getVertices()); }
 
 /// Creates all the vertices and generates data for them.
 // todo: this is going to go away
 void Model::createAllVertices() {
-   LOG4CPLUS_INFO(fileLogger_, "Allocating Vertices..." );
+	LOG4CPLUS_INFO(fileLogger_, "Allocating Vertices...");
 
-   layout_->generateVertexTypeMap(Simulator::getInstance().getTotalVertices());
-   layout_->initStarterMap(Simulator::getInstance().getTotalVertices());
+	layout_->generateVertexTypeMap(Simulator::getInstance().getTotalVertices());
+	layout_->initStarterMap(Simulator::getInstance().getTotalVertices());
 
-   // set their specific types
-   layout_->getVertices()->createAllVertices(layout_.get());
+	// set their specific types
+	layout_->getVertices()->createAllVertices(layout_.get());
 }
 
 /// Sets up the Simulation.
 void Model::setupSim() {
-   LOG4CPLUS_INFO(fileLogger_, "Setting up Vertices...");
-   layout_->getVertices()->setupVertices();
-   LOG4CPLUS_INFO(fileLogger_, "Setting up Edges...");
-   connections_->getEdges()->setupEdges();
+	LOG4CPLUS_INFO(fileLogger_, "Setting up Vertices...");
+	layout_->getVertices()->setupVertices();
+	LOG4CPLUS_INFO(fileLogger_, "Setting up Edges...");
+	connections_->getEdges()->setupEdges();
 #ifdef PERFORMANCE_METRICS
    // Start timer for initialization
    Simulator::getInstance.short_timer.start();
 #endif
-   LOG4CPLUS_INFO(fileLogger_, "Setting up Layout...");
-   layout_->setupLayout();
+	LOG4CPLUS_INFO(fileLogger_, "Setting up Layout...");
+	layout_->setupLayout();
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (layout)
    t_host_initialization_layout += Simulator::getInstance().short_timer.lap() / 1000000.0;
 #endif
-   // Init radii and rates history matrices with default values
-   if (recorder_ != nullptr) {
-      recorder_->init();
-      recorder_->initDefaultValues();
-   }
+	// Init radii and rates history matrices with default values
+	if (recorder_ != nullptr) {
+		recorder_->init();
+		recorder_->initDefaultValues();
+	}
 
-   // Creates all the vertices and generates data for them.
-   createAllVertices();
+	// Creates all the vertices and generates data for them.
+	createAllVertices();
 
 #ifdef PERFORMANCE_METRICS
    // Start timer for initialization
    Simulator::getInstance().short_timer.start();
 #endif
-   LOG4CPLUS_INFO(fileLogger_, "Setting up Connections...");
-   connections_->setupConnections(layout_.get(), layout_->getVertices().get(), connections_->getEdges().get());
+	LOG4CPLUS_INFO(fileLogger_, "Setting up Connections...");
+	connections_->setupConnections(layout_.get(), layout_->getVertices().get(), connections_->getEdges().get());
 #ifdef PERFORMANCE_METRICS
    // Time to initialization (connections)
    t_host_initialization_connections += Simulator::getInstance().short_timer.lap() / 1000000.0;
 #endif
 
-   // create an edge index map
-   LOG4CPLUS_INFO(fileLogger_, "Creating EdgeIndexMap...");
-   connections_->createEdgeIndexMap();
+	// create an edge index map
+	LOG4CPLUS_INFO(fileLogger_, "Creating EdgeIndexMap...");
+	connections_->createEdgeIndexMap();
 }
 
 /// Log this simulation step.
 void Model::logSimStep() const {
-   ConnGrowth *pConnGrowth = dynamic_cast<ConnGrowth *>(connections_.get());
-   if (pConnGrowth == nullptr)
-      return;
+	auto pConnGrowth = dynamic_cast<ConnGrowth*>(connections_.get());
+	if (pConnGrowth == nullptr) return;
 
-   std::cout << "format:\ntype,radius,firing rate" << std::endl;
+	std::cout << "format:\ntype,radius,firing rate" << std::endl;
 
-   for (int y = 0; y < Simulator::getInstance().getHeight(); y++) {
-      std::stringstream ss;
-      ss << std::fixed;
-      ss.precision(1);
+	for (int y = 0; y < Simulator::getInstance().getHeight(); y++) {
+		std::stringstream ss;
+		ss << std::fixed;
+		ss.precision(1);
 
-      for (int x = 0; x < Simulator::getInstance().getWidth(); x++) {
-         switch (layout_->vertexTypeMap_[x + y * Simulator::getInstance().getWidth()]) {
-            case EXC:
-               if (layout_->starterMap_[x + y * Simulator::getInstance().getWidth()])
-                  ss << "s";
-               else
-                  ss << "e";
-               break;
-            case INH:
-               ss << "i";
-               break;
-            case VTYPE_UNDEF:
-               assert(false);
-               break;
-         }
+		for (int x = 0; x < Simulator::getInstance().getWidth(); x++) {
+			switch (layout_->vertexTypeMap_[x + y * Simulator::getInstance().getWidth()]) {
+				case EXC: if (layout_->starterMap_[x + y * Simulator::getInstance().getWidth()]) ss << "s";
+					else ss << "e";
+					break;
+				case INH: ss << "i";
+					break;
+				case VTYPE_UNDEF:
+					assert(false);
+					break;
+			}
 
-         ss << " " << (*pConnGrowth->radii_)[x + y * Simulator::getInstance().getWidth()];
+			ss << " " << (*pConnGrowth->radii_)[x + y * Simulator::getInstance().getWidth()];
 
-         if (x + 1 < Simulator::getInstance().getWidth()) {
-            ss.width(2);
-            ss << "|";
-            ss.width(2);
-         }
-      }
+			if (x + 1 < Simulator::getInstance().getWidth()) {
+				ss.width(2);
+				ss << "|";
+				ss.width(2);
+			}
+		}
 
-      ss << std::endl;
+		ss << std::endl;
 
-      for (int i = ss.str().length() - 1; i >= 0; i--) {
-         ss << "_";
-      }
+		for (int i = ss.str().length() - 1; i >= 0; i--) ss << "_";
 
-      ss << std::endl;
-      std::cout << ss.str();
-   }
+		ss << std::endl;
+		std::cout << ss.str();
+	}
 }
 
 /// Update the simulation history of every epoch.
 void Model::updateHistory() {
-   // Compile history information in every epoch
-      if(recorder_ == nullptr)
-   {
-      LOG4CPLUS_INFO(fileLogger_, "ERROR: Recorder class is null.");
-   }
-   if (recorder_ != nullptr) {
-      recorder_->compileHistories(*layout_->getVertices());
-   }
+	// Compile history information in every epoch
+	if (recorder_ == nullptr)
+	LOG4CPLUS_INFO(fileLogger_, "ERROR: Recorder class is null.");
+	if (recorder_ != nullptr) recorder_->compileHistories(*layout_->getVertices());
 }
 
 /// Get the Connections class object.

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -25,7 +25,7 @@
 /// Constructor
 Model::Model() {
    // Reference variable used to get class type from ParameterManager.
-   string type;
+   std::string type;
 
    // Create Layout class using type definition from configuration file.
    ParameterManager::getInstance().getStringByXpath("//LayoutParams/@class", type);
@@ -114,11 +114,11 @@ void Model::logSimStep() const {
    if (pConnGrowth == nullptr)
       return;
 
-   cout << "format:\ntype,radius,firing rate" << endl;
+   std::cout << "format:\ntype,radius,firing rate" << std::endl;
 
    for (int y = 0; y < Simulator::getInstance().getHeight(); y++) {
-      stringstream ss;
-      ss << fixed;
+      std::stringstream ss;
+      ss << std::fixed;
       ss.precision(1);
 
       for (int x = 0; x < Simulator::getInstance().getWidth(); x++) {
@@ -146,14 +146,14 @@ void Model::logSimStep() const {
          }
       }
 
-      ss << endl;
+      ss << std::endl;
 
       for (int i = ss.str().length() - 1; i >= 0; i--) {
          ss << "_";
       }
 
-      ss << endl;
-      cout << ss.str();
+      ss << std::endl;
+      std::cout << ss.str();
    }
 }
 
@@ -171,15 +171,12 @@ void Model::updateHistory() {
 
 /// Get the Connections class object.
 /// @return Pointer to the Connections class object.  
-// ToDo: make smart ptr
-shared_ptr<Connections> Model::getConnections() const { return connections_; }
+std::shared_ptr<Connections> Model::getConnections() const { return connections_; }
 
 /// Get the Layout class object.
 /// @return Pointer to the Layout class object. 
-// ToDo: make smart ptr
-shared_ptr<Layout> Model::getLayout() const { return layout_; }
+std::shared_ptr<Layout> Model::getLayout() const { return layout_; }
 
 /// Get the IRecorder class object.
 /// @return Pointer to the IRecorder class object. 
-// ToDo: make smart ptr
-shared_ptr<IRecorder> Model::getRecorder() const { return recorder_; }
+std::shared_ptr<IRecorder> Model::getRecorder() const { return recorder_; }

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -19,9 +19,9 @@
 
 #include <log4cplus/loggingmacros.h>
 
-#include "Layout.h"
 #include "AllVertices.h"
 #include "IRecorder.h"
+#include "Layout.h"
 
 class Connections;
 
@@ -30,74 +30,73 @@ class IRecorder;
 class Layout;
 
 class Model {
-public:
-   /// Constructor
-   Model();
+	public:
+		/// Constructor
+		Model();
 
-   /// Destructor
-   virtual ~Model();
+		/// Destructor
+		virtual ~Model();
 
-   std::shared_ptr<Connections> getConnections() const;
+		std::shared_ptr<Connections> getConnections() const;
 
-   std::shared_ptr<Layout> getLayout() const;
+		std::shared_ptr<Layout> getLayout() const;
 
-   std::shared_ptr<IRecorder> getRecorder() const;
+		std::shared_ptr<IRecorder> getRecorder() const;
 
-   /// Writes simulation results to an output destination.
-   /// Downstream from IModel saveData()
-   // todo: put in chain of responsibility.
-   virtual void saveResults();
+		/// Writes simulation results to an output destination.
+		/// Downstream from IModel saveData()
+		// todo: put in chain of responsibility.
+		virtual void saveResults();
 
-   /// Set up model state, for a specific simulation run.
-   /// Downstream from IModel setupSim()
-   virtual void setupSim();
+		/// Set up model state, for a specific simulation run.
+		/// Downstream from IModel setupSim()
+		virtual void setupSim();
 
-   /// Performs any finalization tasks on network following a simulation.
-   virtual void finish() = 0; 
+		/// Performs any finalization tasks on network following a simulation.
+		virtual void finish() = 0;
 
-   /// Update the simulation history of every epoch.
-   virtual void updateHistory();
+		/// Update the simulation history of every epoch.
+		virtual void updateHistory();
 
-   /// Advances network state one simulation step.
-   /// accessors (getVertices, etc. owned by advance.)
-   /// advance has detailed control over what does what when.
-   /// detailed, low level control. clear onn what is happening when, how much time it is taking.
-   /// If, during an advance cycle, a vertex \f$A\f$ at coordinates \f$x,y\f$ fires, every edge
-   /// which receives output is notified of the spike. Those edges then hold
-   /// the spike until their delay period is completed.  At a later advance cycle, once the delay
-   /// period has been completed, the synapses apply their PSRs (Post-Synaptic-Response) to
-   /// the summation points.
-   /// Finally, on the next advance cycle, each vertex \f$B\f$ adds the value stored
-   /// in their corresponding summation points to their \f$V_m\f$ and resets the summation points to zero.
-   virtual void advance() = 0;
+		/// Advances network state one simulation step.
+		/// accessors (getVertices, etc. owned by advance.)
+		/// advance has detailed control over what does what when.
+		/// detailed, low level control. clear onn what is happening when, how much time it is taking.
+		/// If, during an advance cycle, a vertex \f$A\f$ at coordinates \f$x,y\f$ fires, every edge
+		/// which receives output is notified of the spike. Those edges then hold
+		/// the spike until their delay period is completed.  At a later advance cycle, once the delay
+		/// period has been completed, the synapses apply their PSRs (Post-Synaptic-Response) to
+		/// the summation points.
+		/// Finally, on the next advance cycle, each vertex \f$B\f$ adds the value stored
+		/// in their corresponding summation points to their \f$V_m\f$ and resets the summation points to zero.
+		virtual void advance() = 0;
 
-   /// Modifies connections between vertices based on current state of the network and
-   /// behavior over the past epoch. Should be called once every epoch.
-   /// might be similar to advance.
-   virtual void updateConnections() = 0;
+		/// Modifies connections between vertices based on current state of the network and
+		/// behavior over the past epoch. Should be called once every epoch.
+		/// might be similar to advance.
+		virtual void updateConnections() = 0;
 
-protected:
+	protected:
+		/// Prints debug information about the current state of the network.
+		void logSimStep() const;
 
-   /// Prints debug information about the current state of the network.
-   void logSimStep() const;
+		/// Copy GPU Edge data to CPU.
+		virtual void copyGPUtoCPU() = 0;
 
-   /// Copy GPU Edge data to CPU.
-   virtual void copyGPUtoCPU() = 0;
+		/// Copy CPU Edge data to GPU.
+		virtual void copyCPUtoGPU() = 0;
 
-   /// Copy CPU Edge data to GPU.
-   virtual void copyCPUtoGPU() = 0;
+	protected:
+		std::shared_ptr<Connections> connections_;
 
-protected:
-   std::shared_ptr<Connections> connections_;
+		std::shared_ptr<Layout> layout_;
 
-   std::shared_ptr<Layout> layout_;
+		std::shared_ptr<IRecorder> recorder_;
 
-   std::shared_ptr<IRecorder> recorder_;
+		// shared_ptr<ISInput> input_;    /// Stimulus input object.
 
-   // shared_ptr<ISInput> input_;    /// Stimulus input object.
+		log4cplus::Logger fileLogger_;
 
-   log4cplus::Logger fileLogger_;
-
-   // ToDo: Find a good place for this method. Makes sense to put it in Layout
-   void createAllVertices(); /// Populate an instance of AllVertices with an initial state for each vertex.
+		// ToDo: Find a good place for this method. Makes sense to put it in Layout
+		void createAllVertices(); /// Populate an instance of AllVertices with an initial state for each vertex.
 };

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -23,8 +23,6 @@
 #include "AllVertices.h"
 #include "IRecorder.h"
 
-using namespace std;
-
 class Connections;
 
 class IRecorder;
@@ -39,11 +37,11 @@ public:
    /// Destructor
    virtual ~Model();
 
-   shared_ptr<Connections> getConnections() const;
+   std::shared_ptr<Connections> getConnections() const;
 
-   shared_ptr<Layout> getLayout() const;
+   std::shared_ptr<Layout> getLayout() const;
 
-   shared_ptr<IRecorder> getRecorder() const;
+   std::shared_ptr<IRecorder> getRecorder() const;
 
    /// Writes simulation results to an output destination.
    /// Downstream from IModel saveData()
@@ -90,11 +88,11 @@ protected:
    virtual void copyCPUtoGPU() = 0;
 
 protected:
-   shared_ptr<Connections> connections_;
+   std::shared_ptr<Connections> connections_;
 
-   shared_ptr<Layout> layout_;
+   std::shared_ptr<Layout> layout_;
 
-   shared_ptr<IRecorder> recorder_;
+   std::shared_ptr<IRecorder> recorder_;
 
    // shared_ptr<ISInput> input_;    /// Stimulus input object.
 

--- a/Simulator/Core/OperationManager.cpp
+++ b/Simulator/Core/OperationManager.cpp
@@ -31,13 +31,13 @@ OperationManager::~OperationManager() {}
 /// Called by lower level classes constructors on creation to register their operations with their operation type.
 /// This method can be overloaded to handle different function signatures.
 /// Handles function signature: void ()
-void OperationManager::registerOperation(const Operations::op &operation, const function<void()> &function) {
+void OperationManager::registerOperation(const Operations::op &operation, const std::function<void()> &function) {
    try {
-      functionList_.push_back(unique_ptr<IFunctionNode>(new GenericFunctionNode(operation, function)));
+      functionList_.push_back(std::unique_ptr<IFunctionNode>(new GenericFunctionNode(operation, function)));
    }
-   catch (exception e) {
-      LOG4CPLUS_FATAL(logger_, string(e.what()) + ". Push back failed in OperationManager::registerOperation");
-      throw runtime_error(string(e.what()) + " in OperationManager::registerOperation");
+   catch (std::exception e) {
+      LOG4CPLUS_FATAL(logger_, std::string(e.what()) + ". Push back failed in OperationManager::registerOperation");
+      throw std::runtime_error(std::string(e.what()) + " in OperationManager::registerOperation");
    }
 }
 
@@ -52,7 +52,7 @@ void OperationManager::executeOperation(const Operations::op &operation) const {
 }
 
 /// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.
-string OperationManager::operationToString(const Operations::op &operation) const {
+std::string OperationManager::operationToString(const Operations::op &operation) const {
    switch (operation) {
       case Operations::op::printParameters:
          return "printParameters";

--- a/Simulator/Core/OperationManager.cpp
+++ b/Simulator/Core/OperationManager.cpp
@@ -32,7 +32,7 @@ OperationManager::~OperationManager() {}
 /// This method can be overloaded to handle different function signatures.
 /// Handles function signature: void ()
 void OperationManager::registerOperation(const Operations::op& operation, const std::function<void()>& function) {
-	try { functionList_.push_back(std::unique_ptr<IFunctionNode>(new GenericFunctionNode(operation, function))); }
+	try { functionList_.push_back(std::make_unique<GenericFunctionNode>(operation, function)); }
 	catch (std::exception e) {
 		LOG4CPLUS_FATAL(logger_, std::string(e.what()) + ". Push back failed in OperationManager::registerOperation");
 		throw std::runtime_error(std::string(e.what()) + " in OperationManager::registerOperation");
@@ -42,9 +42,8 @@ void OperationManager::registerOperation(const Operations::op& operation, const 
 /// Takes in a operation type and invokes all registered functions that are classified as that operation type.
 void OperationManager::executeOperation(const Operations::op& operation) const {
 	LOG4CPLUS_INFO(logger_, "Executing operation " + operationToString(operation));
-	if (functionList_.size() > 0) {
-		for (auto i = functionList_.begin(); i != functionList_.end(); ++i) (*i)->invokeFunction(operation);
-	}
+	if (functionList_.size() > 0) for (auto i = functionList_.begin(); i != functionList_.end(); ++i) (*i)->
+		invokeFunction(operation);
 }
 
 /// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.

--- a/Simulator/Core/OperationManager.cpp
+++ b/Simulator/Core/OperationManager.cpp
@@ -13,16 +13,16 @@
 
 #include "OperationManager.h"
 
-#include <memory>
 #include <list>
+#include <memory>
 #include <string>
 
 #include "GenericFunctionNode.h"
 
 /// Get Instance method that returns a reference to this object.
-OperationManager &OperationManager::getInstance() {
-   static OperationManager instance;
-   return instance;
+OperationManager& OperationManager::getInstance() {
+	static OperationManager instance;
+	return instance;
 }
 
 /// Destructor.
@@ -31,46 +31,33 @@ OperationManager::~OperationManager() {}
 /// Called by lower level classes constructors on creation to register their operations with their operation type.
 /// This method can be overloaded to handle different function signatures.
 /// Handles function signature: void ()
-void OperationManager::registerOperation(const Operations::op &operation, const std::function<void()> &function) {
-   try {
-      functionList_.push_back(std::unique_ptr<IFunctionNode>(new GenericFunctionNode(operation, function)));
-   }
-   catch (std::exception e) {
-      LOG4CPLUS_FATAL(logger_, std::string(e.what()) + ". Push back failed in OperationManager::registerOperation");
-      throw std::runtime_error(std::string(e.what()) + " in OperationManager::registerOperation");
-   }
+void OperationManager::registerOperation(const Operations::op& operation, const std::function<void()>& function) {
+	try { functionList_.push_back(std::unique_ptr<IFunctionNode>(new GenericFunctionNode(operation, function))); }
+	catch (std::exception e) {
+		LOG4CPLUS_FATAL(logger_, std::string(e.what()) + ". Push back failed in OperationManager::registerOperation");
+		throw std::runtime_error(std::string(e.what()) + " in OperationManager::registerOperation");
+	}
 }
 
 /// Takes in a operation type and invokes all registered functions that are classified as that operation type.
-void OperationManager::executeOperation(const Operations::op &operation) const {
-   LOG4CPLUS_INFO(logger_, "Executing operation " + operationToString(operation));
-   if (functionList_.size() > 0) {
-      for (auto i = functionList_.begin(); i != functionList_.end(); ++i) {
-         (*i)->invokeFunction(operation);
-      }
-   }
+void OperationManager::executeOperation(const Operations::op& operation) const {
+	LOG4CPLUS_INFO(logger_, "Executing operation " + operationToString(operation));
+	if (functionList_.size() > 0) {
+		for (auto i = functionList_.begin(); i != functionList_.end(); ++i) (*i)->invokeFunction(operation);
+	}
 }
 
 /// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.
-std::string OperationManager::operationToString(const Operations::op &operation) const {
-   switch (operation) {
-      case Operations::op::printParameters:
-         return "printParameters";
-      case Operations::op::loadParameters:
-         return "loadParameters";
-      case Operations::op::serialize:
-         return "serialize";
-      case Operations::op::deserialize:
-         return "deserialize";
-      case Operations::op::deallocateGPUMemory:
-         return "deallocateGPUMemory";
-      case Operations::op::restoreToDefault:
-         return "restoreToDefault";
-      case Operations::op::copyToGPU:
-         return "copyToGPU";
-      case Operations::op::copyFromGPU:
-         return "copyFromGPU";
-      default:
-         return "Operation isn't in OperationManager::operationToString()";
-   }
+std::string OperationManager::operationToString(const Operations::op& operation) const {
+	switch (operation) {
+		case Operations::op::printParameters: return "printParameters";
+		case Operations::op::loadParameters: return "loadParameters";
+		case Operations::op::serialize: return "serialize";
+		case Operations::op::deserialize: return "deserialize";
+		case Operations::op::deallocateGPUMemory: return "deallocateGPUMemory";
+		case Operations::op::restoreToDefault: return "restoreToDefault";
+		case Operations::op::copyToGPU: return "copyToGPU";
+		case Operations::op::copyFromGPU: return "copyFromGPU";
+		default: return "Operation isn't in OperationManager::operationToString()";
+	}
 }

--- a/Simulator/Core/OperationManager.h
+++ b/Simulator/Core/OperationManager.h
@@ -23,40 +23,38 @@
 #include "Operations.h"
 
 class OperationManager {
-public:
-   /// Get Instance method that returns a reference to this object.
-   static OperationManager &getInstance();
+	public:
+		/// Get Instance method that returns a reference to this object.
+		static OperationManager& getInstance();
 
-   /// Destructor
-   ~OperationManager();
+		/// Destructor
+		~OperationManager();
 
-   /// Called by lower level classes constructors on creation to register their operations with their operation type.
-   /// This method can be overloaded to handle different function signatures.
-   /// Handles function signature: void ()
-   void registerOperation(const Operations::op &operation, const std::function<void()> &function);
+		/// Called by lower level classes constructors on creation to register their operations with their operation type.
+		/// This method can be overloaded to handle different function signatures.
+		/// Handles function signature: void ()
+		void registerOperation(const Operations::op& operation, const std::function<void()>& function);
 
-   /// Takes in a operation type and invokes all registered functions that are classified as that operation type.
-   void executeOperation(const Operations::op &operation) const;
+		/// Takes in a operation type and invokes all registered functions that are classified as that operation type.
+		void executeOperation(const Operations::op& operation) const;
 
-   /// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.
-   std::string operationToString(const Operations::op &operation) const;
+		/// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.
+		std::string operationToString(const Operations::op& operation) const;
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   OperationManager(OperationManager const &) = delete;
-   void operator=(OperationManager const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		OperationManager(const OperationManager&) = delete;
+		void operator=(const OperationManager&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   OperationManager() {
-      // Set logger_ to a reference to the rootLogger
-      logger_ = (log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file")));
-   }
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		OperationManager() {
+			// Set logger_ to a reference to the rootLogger
+			logger_ = (log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file")));
+		}
 
-   /// List of functions based containing a function and it's operation type.
-   std::list<std::unique_ptr<IFunctionNode>> functionList_;
+		/// List of functions based containing a function and it's operation type.
+		std::list<std::unique_ptr<IFunctionNode>> functionList_;
 
-   /// Logger for log4plus
-   log4cplus::Logger logger_;
+		/// Logger for log4plus
+		log4cplus::Logger logger_;
 };
-
-

--- a/Simulator/Core/OperationManager.h
+++ b/Simulator/Core/OperationManager.h
@@ -22,8 +22,6 @@
 #include "IFunctionNode.h"
 #include "Operations.h"
 
-using namespace std;
-
 class OperationManager {
 public:
    /// Get Instance method that returns a reference to this object.
@@ -35,13 +33,13 @@ public:
    /// Called by lower level classes constructors on creation to register their operations with their operation type.
    /// This method can be overloaded to handle different function signatures.
    /// Handles function signature: void ()
-   void registerOperation(const Operations::op &operation, const function<void()> &function);
+   void registerOperation(const Operations::op &operation, const std::function<void()> &function);
 
    /// Takes in a operation type and invokes all registered functions that are classified as that operation type.
    void executeOperation(const Operations::op &operation) const;
 
    /// Takes in the operation enum and returns the enum as a string. Used for debugging purposes.
-   string operationToString(const Operations::op &operation) const;
+   std::string operationToString(const Operations::op &operation) const;
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    OperationManager(OperationManager const &) = delete;
@@ -55,7 +53,7 @@ private:
    }
 
    /// List of functions based containing a function and it's operation type.
-   list<unique_ptr<IFunctionNode>> functionList_;
+   std::list<std::unique_ptr<IFunctionNode>> functionList_;
 
    /// Logger for log4plus
    log4cplus::Logger logger_;

--- a/Simulator/Core/Operations.h
+++ b/Simulator/Core/Operations.h
@@ -10,16 +10,18 @@
 #pragma once
 
 class Operations {
-public:
-    /// Available operations the OperationManager can register and execute.
-    enum op {
-       printParameters,
-       loadParameters,
-       serialize,
-       deserialize,
-       deallocateGPUMemory, // Make sure deallocate memory isn't called until all GPU memory is copied back.
-       restoreToDefault, // Not sure what this refers to.
-       copyToGPU,
-       copyFromGPU
-    };
+	public:
+		/// Available operations the OperationManager can register and execute.
+		enum op {
+			printParameters,
+			loadParameters,
+			serialize,
+			deserialize,
+			deallocateGPUMemory,
+			// Make sure deallocate memory isn't called until all GPU memory is copied back.
+			restoreToDefault,
+			// Not sure what this refers to.
+			copyToGPU,
+			copyFromGPU
+		};
 };

--- a/Simulator/Core/Operations.h
+++ b/Simulator/Core/Operations.h
@@ -12,7 +12,7 @@
 class Operations {
 	public:
 		/// Available operations the OperationManager can register and execute.
-		enum op {
+		enum class op {
 			printParameters,
 			loadParameters,
 			serialize,

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -26,9 +26,9 @@ Simulator& Simulator::getInstance() {
 };
 
 /// Constructor is private to keep a singleton instance of this class.
-Simulator::Simulator() {
+Simulator::Simulator() : deltaT_() {
 	g_simulationStep = 0; /// uint64_t g_simulationStep instantiated in Global
-	deltaT_ = DEFAULT_dt;
+
 
 	consoleLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
 	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -35,7 +35,7 @@ Simulator::Simulator() {
    edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
 
    // Register printParameters function as a printParameters operation in the OperationManager
-   function<void()> printParametersFunc = bind(&Simulator::printParameters, this);
+   std::function<void()> printParametersFunc = std::bind(&Simulator::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 }
 
@@ -54,7 +54,7 @@ void Simulator::setup() {
    t_host_advance = 0.0;
    t_host_adjustEdges = 0.0;
    timer.start();
-   cerr << "done." << endl;
+   cerr << "done." << std::endl;
 #endif
    LOG4CPLUS_INFO(fileLogger_, "Initializing models in network... ");
    model_->setupSim();
@@ -63,7 +63,7 @@ void Simulator::setup() {
    // init stimulus input object
    /* PInput not in project yet
    if (pInput != nullptr) {
-      cout << "Initializing input." << endl;
+      cout << "Initializing input." << std::endl;
       pInput->init();
    }
    */
@@ -86,7 +86,7 @@ void Simulator::loadParameters() {
    ParameterManager::getInstance().getIntByXpath("//SimConfig/maxEdgesPerVertex/text()", maxEdgesPerVertex_);
 
    // Instantiate rng object 
-   string type;
+   std::string type;
    ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGSeed/@class", type);
    noiseRNG = RNGFactory::getInstance()->createRNG(type);
 
@@ -100,15 +100,15 @@ void Simulator::loadParameters() {
 /// Prints out loaded parameters to logging file.
 void Simulator::printParameters() const {
    LOG4CPLUS_DEBUG(fileLogger_,
-                  "\nSIMULATION PARAMETERS" << endl
+                  "\nSIMULATION PARAMETERS" << std::endl
                                           << "\tpool size x:" << width_ << " y:" << height_
-                                          << endl
-                                          << "\tTime between growth updates (in seconds): " << epochDuration_ << endl
-                                          << "\tNumber of epochs to run: " << numEpochs_ << endl
-                                          << "\tMax firing rate: " << maxFiringRate_ << endl
-                                          << "\tMax edges per vertex: " << maxEdgesPerVertex_ << endl
-                                          << "\tNoise RNG Seed: " << noiseRngSeed_ << endl
-                                          << "\tInitializer RNG Seed: " << initRngSeed_ << endl);
+                                          << std::endl
+                                          << "\tTime between growth updates (in seconds): " << epochDuration_ << std::endl
+                                          << "\tNumber of epochs to run: " << numEpochs_ << std::endl
+                                          << "\tMax firing rate: " << maxFiringRate_ << std::endl
+                                          << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
+                                          << "\tNoise RNG Seed: " << noiseRngSeed_ << std::endl
+                                          << "\tInitializer RNG Seed: " << initRngSeed_ << std::endl);
 }
 
 // Code from STDPFix branch, doesn't do anything
@@ -176,9 +176,9 @@ void Simulator::simulate() {
       // Time since start of simulation
       double total_time = timer.lap() / 1000000.0;
 
-      cout << "\ntotal_time: " << total_time << " seconds" << endl;
+      cout << "\ntotal_time: " << total_time << " seconds" << std::endl;
       printPerformanceMetrics(total_time, currentEpoch);
-      cout << endl;
+      cout << std::endl;
 #endif
    }
 }
@@ -221,10 +221,10 @@ void Simulator::saveResults() const {
 /// expected objects were created correctly and returns T/F on the success of the check.
 bool Simulator::instantiateSimulatorObjects() {
    // Model Definition
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    model_ = shared_ptr<Model>(new GPUModel());
 #else
-   model_ = shared_ptr<Model>(new CPUModel());
+   model_ = std::shared_ptr<Model>(new CPUModel());
 #endif
 
    // Perform check on all instantiated objects.
@@ -247,13 +247,13 @@ bool Simulator::instantiateSimulatorObjects() {
 /// List of summation points (either host or device memory)
 void Simulator::setPSummationMap(BGFLOAT *summationMap) { pSummationMap_ = summationMap; }
 
-void Simulator::setConfigFileName(const string &fileName) { configFileName_ = fileName; }
+void Simulator::setConfigFileName(const std::string &fileName) { configFileName_ = fileName; }
 
-void Simulator::setSerializationFileName(const string &fileName) { serializationFileName_ = fileName; }
+void Simulator::setSerializationFileName(const std::string &fileName) { serializationFileName_ = fileName; }
 
-void Simulator::setDeserializationFileName(const string &fileName) { deserializationFileName_ = fileName; }
+void Simulator::setDeserializationFileName(const std::string &fileName) { deserializationFileName_ = fileName; }
 
-void Simulator::setStimulusFileName(const string &fileName) { stimulusFileName_ = fileName; }
+void Simulator::setStimulusFileName(const std::string &fileName) { stimulusFileName_ = fileName; }
 ///@}
 
 /************************************************
@@ -294,15 +294,15 @@ long Simulator::getNoiseRngSeed() const { return noiseRngSeed_; }
 
 long Simulator::getInitRngSeed() const { return initRngSeed_; }
 
-string Simulator::getConfigFileName() const { return configFileName_; }
+std::string Simulator::getConfigFileName() const { return configFileName_; }
 
-string Simulator::getSerializationFileName() const { return serializationFileName_; }
+std::string Simulator::getSerializationFileName() const { return serializationFileName_; }
 
-string Simulator::getDeserializationFileName() const { return deserializationFileName_; }
+std::string Simulator::getDeserializationFileName() const { return deserializationFileName_; }
 
-string Simulator::getStimulusFileName() const { return stimulusFileName_; }
+std::string Simulator::getStimulusFileName() const { return stimulusFileName_; }
 
-shared_ptr<Model> Simulator::getModel() const { return model_; }
+std::shared_ptr<Model> Simulator::getModel() const { return model_; }
 
 #ifdef PERFOMANCE_METRICS
 Timer Simulator::getTimer() const { return timer; }

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -20,29 +20,27 @@
 // #include "ParseParamError.h"
 
 /// Acts as constructor first time it's called, returns the instance of the singleton object
-Simulator &Simulator::getInstance() {
-   static Simulator instance;
-   return instance;
+Simulator& Simulator::getInstance() {
+	static Simulator instance;
+	return instance;
 };
 
 /// Constructor is private to keep a singleton instance of this class.
 Simulator::Simulator() {
-   g_simulationStep = 0;  /// uint64_t g_simulationStep instantiated in Global
-   deltaT_ = DEFAULT_dt;
+	g_simulationStep = 0; /// uint64_t g_simulationStep instantiated in Global
+	deltaT_ = DEFAULT_dt;
 
-   consoleLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
-   edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
+	consoleLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("console"));
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
 
-   // Register printParameters function as a printParameters operation in the OperationManager
-   std::function<void()> printParametersFunc = std::bind(&Simulator::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	// Register printParameters function as a printParameters operation in the OperationManager
+	std::function<void()> printParametersFunc = std::bind(&Simulator::printParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 }
 
 /// Destructor
-Simulator::~Simulator() {
-   freeResources();
-}
+Simulator::~Simulator() { freeResources(); }
 
 /// Initialize and prepare network for simulation.
 void Simulator::setup() {
@@ -56,86 +54,86 @@ void Simulator::setup() {
    timer.start();
    cerr << "done." << std::endl;
 #endif
-   LOG4CPLUS_INFO(fileLogger_, "Initializing models in network... ");
-   model_->setupSim();
-   LOG4CPLUS_INFO(fileLogger_, "Model initialization finished");
+	LOG4CPLUS_INFO(fileLogger_, "Initializing models in network... ");
+	model_->setupSim();
+	LOG4CPLUS_INFO(fileLogger_, "Model initialization finished");
 
-   // init stimulus input object
-   /* PInput not in project yet
-   if (pInput != nullptr) {
-      cout << "Initializing input." << std::endl;
-      pInput->init();
-   }
-   */
+	// init stimulus input object
+	/* PInput not in project yet
+	if (pInput != nullptr) {
+	   cout << "Initializing input." << std::endl;
+	   pInput->init();
+	}
+	*/
 }
 
 /// Begin terminating the simulator
 void Simulator::finish() {
-   model_->finish(); // ToDo: Can #term be removed w/ the new model architecture?  // =>ISIMULATION
+	model_->finish(); // ToDo: Can #term be removed w/ the new model architecture?  // =>ISIMULATION
 }
 
 /// Load member variables from configuration file
 void Simulator::loadParameters() {
-   ParameterManager::getInstance().getIntByXpath("//PoolSize/x/text()", width_);
-   ParameterManager::getInstance().getIntByXpath("//PoolSize/y/text()", height_);
-   totalNeurons_ = width_ * height_;
+	ParameterManager::getInstance().getIntByXpath("//PoolSize/x/text()", width_);
+	ParameterManager::getInstance().getIntByXpath("//PoolSize/y/text()", height_);
+	totalNeurons_ = width_ * height_;
 
-   ParameterManager::getInstance().getBGFloatByXpath("//SimParams/epochDuration/text()", epochDuration_);
-   ParameterManager::getInstance().getIntByXpath("//SimParams/numEpochs/text()", numEpochs_);
-   ParameterManager::getInstance().getIntByXpath("//SimConfig/maxFiringRate/text()", maxFiringRate_);
-   ParameterManager::getInstance().getIntByXpath("//SimConfig/maxEdgesPerVertex/text()", maxEdgesPerVertex_);
+	ParameterManager::getInstance().getBGFloatByXpath("//SimParams/epochDuration/text()", epochDuration_);
+	ParameterManager::getInstance().getIntByXpath("//SimParams/numEpochs/text()", numEpochs_);
+	ParameterManager::getInstance().getIntByXpath("//SimConfig/maxFiringRate/text()", maxFiringRate_);
+	ParameterManager::getInstance().getIntByXpath("//SimConfig/maxEdgesPerVertex/text()", maxEdgesPerVertex_);
 
-   // Instantiate rng object 
-   std::string type;
-   ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGSeed/@class", type);
-   noiseRNG = RNGFactory::getInstance()->createRNG(type);
+	// Instantiate rng object 
+	std::string type;
+	ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGSeed/@class", type);
+	noiseRNG = RNGFactory::getInstance()->createRNG(type);
 
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGSeed/text()", initRngSeed_);
-   ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGSeed/text()", noiseRngSeed_);
-   noiseRNG->seed(noiseRngSeed_);
-   initRNG.seed(initRngSeed_);
+	ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGSeed/text()", initRngSeed_);
+	ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGSeed/text()", noiseRngSeed_);
+	noiseRNG->seed(noiseRngSeed_);
+	initRNG.seed(initRngSeed_);
 
 }
 
 /// Prints out loaded parameters to logging file.
 void Simulator::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_,
-                  "\nSIMULATION PARAMETERS" << std::endl
-                                          << "\tpool size x:" << width_ << " y:" << height_
-                                          << std::endl
-                                          << "\tTime between growth updates (in seconds): " << epochDuration_ << std::endl
-                                          << "\tNumber of epochs to run: " << numEpochs_ << std::endl
-                                          << "\tMax firing rate: " << maxFiringRate_ << std::endl
-                                          << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
-                                          << "\tNoise RNG Seed: " << noiseRngSeed_ << std::endl
-                                          << "\tInitializer RNG Seed: " << initRngSeed_ << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_,
+	                "\nSIMULATION PARAMETERS" << std::endl
+	                << "\tpool size x:" << width_ << " y:" << height_
+	                << std::endl
+	                << "\tTime between growth updates (in seconds): " << epochDuration_ << std::endl
+	                << "\tNumber of epochs to run: " << numEpochs_ << std::endl
+	                << "\tMax firing rate: " << maxFiringRate_ << std::endl
+	                << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
+	                << "\tNoise RNG Seed: " << noiseRngSeed_ << std::endl
+	                << "\tInitializer RNG Seed: " << initRngSeed_ << std::endl);
 }
 
 // Code from STDPFix branch, doesn't do anything
 /// Copy GPU Synapse data to CPU.
 void Simulator::copyGPUSynapseToCPU() {
-   // ToDo: Delete this method and implement using OperationManager
-   // model->copyGPUSynapseToCPUModel();
+	// ToDo: Delete this method and implement using OperationManager
+	// model->copyGPUSynapseToCPUModel();
 }
 
 /// Copy CPU Synapse data to GPU.
 void Simulator::copyCPUSynapseToGPU() {
-   // ToDo: Delete this method and implement using OperationManager
-   // model->copyCPUSynapseToGPUModel();
+	// ToDo: Delete this method and implement using OperationManager
+	// model->copyCPUSynapseToGPUModel();
 }
 
 /// Resets all of the maps. Releases and re-allocates memory for each map, clearing them as necessary.
 void Simulator::reset() {
-   LOG4CPLUS_INFO(fileLogger_, "Resetting Simulator");
-   // Terminate the simulator
-   model_->finish();
-   // Clean up objects
-   freeResources();
-   // Reset global simulation Step to 0
-   g_simulationStep = 0;
-   // Initialize and prepare network for simulation
-   model_->setupSim();
-   LOG4CPLUS_INFO(fileLogger_, "Simulator Reset Finished");
+	LOG4CPLUS_INFO(fileLogger_, "Resetting Simulator");
+	// Terminate the simulator
+	model_->finish();
+	// Clean up objects
+	freeResources();
+	// Reset global simulation Step to 0
+	g_simulationStep = 0;
+	// Initialize and prepare network for simulation
+	model_->setupSim();
+	LOG4CPLUS_INFO(fileLogger_, "Simulator Reset Finished");
 }
 
 /// Clean up objects.
@@ -143,31 +141,31 @@ void Simulator::freeResources() {}
 
 /// Run simulation
 void Simulator::simulate() {
-   // Main simulation loop - execute maxGrowthSteps
-   for (int currentEpoch = 1; currentEpoch <= numEpochs_; currentEpoch++) {
-      LOG4CPLUS_TRACE(consoleLogger_, "Performing epoch number: " << currentEpoch);
-      LOG4CPLUS_TRACE(fileLogger_, "Begin network state:");
-      currentEpoch_ = currentEpoch;
+	// Main simulation loop - execute maxGrowthSteps
+	for (int currentEpoch = 1; currentEpoch <= numEpochs_; currentEpoch++) {
+		LOG4CPLUS_TRACE(consoleLogger_, "Performing epoch number: " << currentEpoch);
+		LOG4CPLUS_TRACE(fileLogger_, "Begin network state:");
+		currentEpoch_ = currentEpoch;
 #ifdef PERFORMANCE_METRICS
       // Start timer for advance
       short_timer.start();
 #endif
-      // Advance simulation to next growth cycle
-      advanceEpoch(currentEpoch);
+		// Advance simulation to next growth cycle
+		advanceEpoch(currentEpoch);
 #ifdef PERFORMANCE_METRICS
       // Time to advance
       t_host_advance += short_timer.lap() / 1000000.0;
 #endif
-      LOG4CPLUS_TRACE(consoleLogger_, "done with epoch cycle " << currentEpoch_ << ", beginning growth update");
-      LOG4CPLUS_TRACE(edgeLogger_, "Epoch: " << currentEpoch_);
+		LOG4CPLUS_TRACE(consoleLogger_, "done with epoch cycle " << currentEpoch_ << ", beginning growth update");
+		LOG4CPLUS_TRACE(edgeLogger_, "Epoch: " << currentEpoch_);
 
 #ifdef PERFORMANCE_METRICS
       // Start timer for connection update
       short_timer.start();
 #endif
-      // Update the neuron network
-      model_->updateConnections();
-      model_->updateHistory();
+		// Update the neuron network
+		model_->updateConnections();
+		model_->updateHistory();
 
 #ifdef PERFORMANCE_METRICS
       // Times converted from microseconds to seconds
@@ -180,63 +178,60 @@ void Simulator::simulate() {
       printPerformanceMetrics(total_time, currentEpoch);
       cout << std::endl;
 #endif
-   }
+	}
 }
 
 /// Helper for #simulate(). Advance simulation until ready for next growth cycle.
 /// This should simulate all neuron and synapse activity for one epoch.
 /// @param currentStep the current epoch in which the network is being simulated.
-void Simulator::advanceEpoch(const int &currentEpoch) const {
-   uint64_t count = 0;
-   // Compute step number at end of this simulation epoch
-   uint64_t endStep = g_simulationStep
-                      + static_cast<uint64_t>(epochDuration_ / deltaT_);
-   // DEBUG_MID(model->logSimStep();) // Generic model debug call
-   while (g_simulationStep < endStep) {
-      // Output status once every 10,000 steps
-      if (count % 10000 == 0) {
-         LOG4CPLUS_TRACE(consoleLogger_, "Epoch: " << currentEpoch << "/" << numEpochs_
-                                                   << " simulating time: "
-                                                   << g_simulationStep * deltaT_ << "/"
-                                                   << (epochDuration_ * numEpochs_) - 1);
-         count = 0;
-      }
-      count++;
-      // input stimulus
-      /***** S_INPUT NOT IN REPO YET *******/
-//      if (pInput != nullptr)
-//         pInput->inputStimulus();
-      // Advance the Network one time step
-      model_->advance();
-      g_simulationStep++;
-   }
+void Simulator::advanceEpoch(const int& currentEpoch) const {
+	uint64_t count = 0;
+	// Compute step number at end of this simulation epoch
+	uint64_t endStep = g_simulationStep
+		+ static_cast<uint64_t>(epochDuration_ / deltaT_);
+	// DEBUG_MID(model->logSimStep();) // Generic model debug call
+	while (g_simulationStep < endStep) {
+		// Output status once every 10,000 steps
+		if (count % 10000 == 0) {
+			LOG4CPLUS_TRACE(consoleLogger_, "Epoch: " << currentEpoch << "/" << numEpochs_
+			                << " simulating time: "
+			                << g_simulationStep * deltaT_ << "/"
+			                << (epochDuration_ * numEpochs_) - 1);
+			count = 0;
+		}
+		count++;
+		// input stimulus
+		/***** S_INPUT NOT IN REPO YET *******/
+		//      if (pInput != nullptr)
+		//         pInput->inputStimulus();
+		// Advance the Network one time step
+		model_->advance();
+		g_simulationStep++;
+	}
 }
 
 /// Writes simulation results to an output destination.
-void Simulator::saveResults() const {
-   model_->saveResults();
-}
+void Simulator::saveResults() const { model_->saveResults(); }
 
 /// Instantiates Model which causes all other lower level simulator objects to be instantiated. Checks if all
 /// expected objects were created correctly and returns T/F on the success of the check.
 bool Simulator::instantiateSimulatorObjects() {
-   // Model Definition
+	// Model Definition
 #ifdef __CUDACC__
    model_ = shared_ptr<Model>(new GPUModel());
 #else
-   model_ = std::shared_ptr<Model>(new CPUModel());
+	model_ = std::shared_ptr<Model>(new CPUModel());
 #endif
 
-   // Perform check on all instantiated objects.
-   if (!model_
-       || !model_->getConnections()
-       || !model_->getConnections()->getEdges()
-       || !model_->getLayout()
-       || !model_->getLayout()->getVertices()
-       || !model_->getRecorder()) {
-      return false;
-   }
-   return true;
+	// Perform check on all instantiated objects.
+	if (!model_
+		|| !model_->getConnections()
+		|| !model_->getConnections()->getEdges()
+		|| !model_->getLayout()
+		|| !model_->getLayout()->getVertices()
+		|| !model_->getRecorder())
+		return false;
+	return true;
 }
 
 
@@ -245,15 +240,15 @@ bool Simulator::instantiateSimulatorObjects() {
  ***********************************************/
 ///@{
 /// List of summation points (either host or device memory)
-void Simulator::setPSummationMap(BGFLOAT *summationMap) { pSummationMap_ = summationMap; }
+void Simulator::setPSummationMap(BGFLOAT* summationMap) { pSummationMap_ = summationMap; }
 
-void Simulator::setConfigFileName(const std::string &fileName) { configFileName_ = fileName; }
+void Simulator::setConfigFileName(const std::string& fileName) { configFileName_ = fileName; }
 
-void Simulator::setSerializationFileName(const std::string &fileName) { serializationFileName_ = fileName; }
+void Simulator::setSerializationFileName(const std::string& fileName) { serializationFileName_ = fileName; }
 
-void Simulator::setDeserializationFileName(const std::string &fileName) { deserializationFileName_ = fileName; }
+void Simulator::setDeserializationFileName(const std::string& fileName) { deserializationFileName_ = fileName; }
 
-void Simulator::setStimulusFileName(const std::string &fileName) { stimulusFileName_ = fileName; }
+void Simulator::setStimulusFileName(const std::string& fileName) { stimulusFileName_ = fileName; }
 ///@}
 
 /************************************************
@@ -280,15 +275,15 @@ BGFLOAT Simulator::getDeltaT() const { return deltaT_; }
 
 // ToDo: should be a vector of neuron type
 // ToDo: vector should be contiguous array, resize is used.
-vertexType *Simulator::getRgNeuronTypeMap() const { return rgNeuronTypeMap_; }
+vertexType* Simulator::getRgNeuronTypeMap() const { return rgNeuronTypeMap_; }
 
 // ToDo: make smart ptr
 /// Starter existence map (T/F).
-bool *Simulator::getRgEndogenouslyActiveNeuronMap() const { return rgEndogenouslyActiveNeuronMap_; }
+bool* Simulator::getRgEndogenouslyActiveNeuronMap() const { return rgEndogenouslyActiveNeuronMap_; }
 
 BGFLOAT Simulator::getMaxRate() const { return maxRate_; }
 
-BGFLOAT *Simulator::getPSummationMap() const { return pSummationMap_; }
+BGFLOAT* Simulator::getPSummationMap() const { return pSummationMap_; }
 
 long Simulator::getNoiseRngSeed() const { return noiseRngSeed_; }
 
@@ -310,7 +305,3 @@ Timer Simulator::getTimer() const { return timer; }
 Timer Simulator::getShort_timer() const { return short_timer; }
 #endif
 ///@}
-
-
-
-

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -35,8 +35,8 @@ Simulator::Simulator() {
 	edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
 
 	// Register printParameters function as a printParameters operation in the OperationManager
-	std::function<void()> printParametersFunc = std::bind(&Simulator::printParameters, this);
-	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	std::function<void()> printParametersFunc = [this] { printParameters(); };
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 }
 
 /// Destructor
@@ -220,7 +220,7 @@ bool Simulator::instantiateSimulatorObjects() {
 #ifdef __CUDACC__
    model_ = shared_ptr<Model>(new GPUModel());
 #else
-	model_ = std::shared_ptr<Model>(new CPUModel());
+	model_ = std::make_shared<CPUModel>();
 #endif
 
 	// Perform check on all instantiated objects.

--- a/Simulator/Core/Simulator.h
+++ b/Simulator/Core/Simulator.h
@@ -95,15 +95,15 @@ public:
 
    long getInitRngSeed() const;    /// Seed used to initialize parameters
 
-   string getConfigFileName() const;    /// File name of the parameter configuration file.
+   std::string getConfigFileName() const;    /// File name of the parameter configuration file.
 
-   string getSerializationFileName() const;    /// File name of the serialization file.
+   std::string getSerializationFileName() const;    /// File name of the serialization file.
 
-   string getDeserializationFileName() const; /// File name of the deserialization file.
+   std::string getDeserializationFileName() const; /// File name of the deserialization file.
 
-   string getStimulusFileName() const;     /// File name of the stimulus input file.
+   std::string getStimulusFileName() const;     /// File name of the stimulus input file.
 
-   shared_ptr<Model> getModel() const;    /// Neural Network Model interface.
+   std::shared_ptr<Model> getModel() const;    /// Neural Network Model interface.
 ///@}
 
 /************************************************
@@ -112,13 +112,13 @@ public:
 ///@{
    void setPSummationMap(BGFLOAT *summationMap);     /// Mutator for summation map (added late)
 
-   void setConfigFileName(const string &fileName);
+   void setConfigFileName(const std::string &fileName);
 
-   void setSerializationFileName(const string &fileName);
+   void setSerializationFileName(const std::string &fileName);
 
-   void setDeserializationFileName(const string &fileName);
+   void setDeserializationFileName(const std::string &fileName);
 
-   void setStimulusFileName(const string &fileName);
+   void setStimulusFileName(const std::string &fileName);
 
 #ifdef PERFORMANCE_METRICS
    Timer getTimer();  /// Timer measures performance of epoch. returns copy of internal timer owned by simulator.
@@ -165,15 +165,15 @@ private:
 
    long initRngSeed_;   /// Seed used to initialize parameters
 
-   string configFileName_;    /// File name of the parameter configuration file.
+   std::string configFileName_;    /// File name of the parameter configuration file.
 
-   string serializationFileName_;    /// File name of the serialization file.
+   std::string serializationFileName_;    /// File name of the serialization file.
 
-   string deserializationFileName_;    /// File name of the deserialization file.
+   std::string deserializationFileName_;    /// File name of the deserialization file.
 
-   string stimulusFileName_;    /// File name of the stimulus input file.
+   std::string stimulusFileName_;    /// File name of the stimulus input file.
 
-   shared_ptr<Model> model_;  /// Smart pointer to model class (Model is an interface class)
+   std::shared_ptr<Model> model_;  /// Smart pointer to model class (Model is an interface class)
 
    log4cplus::Logger consoleLogger_; /// Logger for printing to the console as well as the logging file
    log4cplus::Logger fileLogger_; /// Logger for printing to the logging file

--- a/Simulator/Core/Simulator.h
+++ b/Simulator/Core/Simulator.h
@@ -30,162 +30,158 @@ class Model;
 #endif
 
 class Simulator {
-public:
-   static Simulator &getInstance(); /// Acts as constructor, returns the instance of singleton object
-   virtual ~Simulator(); /// Destructor
+	public:
+		static Simulator& getInstance(); /// Acts as constructor, returns the instance of singleton object
+		virtual ~Simulator(); /// Destructor
 
-   void setup(); /// Setup simulation.
+		void setup(); /// Setup simulation.
 
-   void finish(); /// Cleanup after simulation.
+		void finish(); /// Cleanup after simulation.
 
-   void loadParameters(); /// Load member variables from configuration file
+		void loadParameters(); /// Load member variables from configuration file
 
-   void printParameters() const; /// Prints loaded parameters to logging file.
+		void printParameters() const; /// Prints loaded parameters to logging file.
 
-   // Copied over from STDPFix
-   void copyGPUSynapseToCPU(); /// Copy GPU Synapse data to CPU.
+		// Copied over from STDPFix
+		void copyGPUSynapseToCPU(); /// Copy GPU Synapse data to CPU.
 
-   // Copied over from STDPFix
-   void copyCPUSynapseToGPU(); /// Copy CPU Synapse data to GPU.
+		// Copied over from STDPFix
+		void copyCPUSynapseToGPU(); /// Copy CPU Synapse data to GPU.
 
-   void reset(); /// Reset simulation objects.
+		void reset(); /// Reset simulation objects.
 
-   void simulate();
+		void simulate();
 
-   void advanceEpoch(
-         const int &currentEpoch) const; /// Advance simulation to next growth cycle. Helper for #simulate().
+		void advanceEpoch(
+			const int& currentEpoch) const; /// Advance simulation to next growth cycle. Helper for #simulate().
 
-   void saveResults() const; /// Writes simulation results to an output destination.
+		void saveResults() const; /// Writes simulation results to an output destination.
 
-   /// Instantiates Model which causes all other lower level simulator objects to be instantiated. Checks if all
-   /// expected objects were created correctly and returns T/F on the success of the check.
-   bool instantiateSimulatorObjects();
+		/// Instantiates Model which causes all other lower level simulator objects to be instantiated. Checks if all
+		/// expected objects were created correctly and returns T/F on the success of the check.
+		bool instantiateSimulatorObjects();
 
-/************************************************
- *  Accessors
- ***********************************************/
-///@{
-   int getWidth() const;   /// Width of neuron map (assumes square)
+		/************************************************
+		 *  Accessors
+		 ***********************************************/
+		///@{
+		int getWidth() const; /// Width of neuron map (assumes square)
 
-   int getHeight() const;  /// Height of neuron map
+		int getHeight() const; /// Height of neuron map
 
-   int getTotalVertices() const;  /// Count of neurons in the simulation
+		int getTotalVertices() const; /// Count of neurons in the simulation
 
-   int getCurrentStep() const;    /// Current simulation step
+		int getCurrentStep() const; /// Current simulation step
 
-   int getNumEpochs() const;   /// Maximum number of simulation steps
+		int getNumEpochs() const; /// Maximum number of simulation steps
 
-   BGFLOAT getEpochDuration() const;    /// The length of each step in simulation time
+		BGFLOAT getEpochDuration() const; /// The length of each step in simulation time
 
-   int getMaxFiringRate() const;   /// Maximum firing rate. **GPU Only**
+		int getMaxFiringRate() const; /// Maximum firing rate. **GPU Only**
 
-   int getMaxEdgesPerVertex() const;   /// Maximum number of synapses per neuron. **GPU Only**
+		int getMaxEdgesPerVertex() const; /// Maximum number of synapses per neuron. **GPU Only**
 
-   BGFLOAT getDeltaT() const;    /// Time elapsed between the beginning and end of the simulation step
+		BGFLOAT getDeltaT() const; /// Time elapsed between the beginning and end of the simulation step
 
-   vertexType *getRgNeuronTypeMap() const;    /// The vertex type map (INH, EXC).
+		vertexType* getRgNeuronTypeMap() const; /// The vertex type map (INH, EXC).
 
-   bool *getRgEndogenouslyActiveNeuronMap() const;  /// The starter existence map (T/F).
+		bool* getRgEndogenouslyActiveNeuronMap() const; /// The starter existence map (T/F).
 
-   BGFLOAT getMaxRate() const;   /// growth variable (m_targetRate / m_epsilon) TODO: more detail here
+		BGFLOAT getMaxRate() const; /// growth variable (m_targetRate / m_epsilon) TODO: more detail here
 
-   BGFLOAT *getPSummationMap() const;   /// List of summation points (either host or device memory)
+		BGFLOAT* getPSummationMap() const; /// List of summation points (either host or device memory)
 
-   long getNoiseRngSeed() const;    /// Seed used for the simulation random **SingleThreaded Only**
+		long getNoiseRngSeed() const; /// Seed used for the simulation random **SingleThreaded Only**
 
-   long getInitRngSeed() const;    /// Seed used to initialize parameters
+		long getInitRngSeed() const; /// Seed used to initialize parameters
 
-   std::string getConfigFileName() const;    /// File name of the parameter configuration file.
+		std::string getConfigFileName() const; /// File name of the parameter configuration file.
 
-   std::string getSerializationFileName() const;    /// File name of the serialization file.
+		std::string getSerializationFileName() const; /// File name of the serialization file.
 
-   std::string getDeserializationFileName() const; /// File name of the deserialization file.
+		std::string getDeserializationFileName() const; /// File name of the deserialization file.
 
-   std::string getStimulusFileName() const;     /// File name of the stimulus input file.
+		std::string getStimulusFileName() const; /// File name of the stimulus input file.
 
-   std::shared_ptr<Model> getModel() const;    /// Neural Network Model interface.
+		std::shared_ptr<Model> getModel() const; /// Neural Network Model interface.
 ///@}
 
-/************************************************
- *  Mutators
- ***********************************************/
-///@{
-   void setPSummationMap(BGFLOAT *summationMap);     /// Mutator for summation map (added late)
+		/************************************************
+		 *  Mutators
+		 ***********************************************/
+		///@{
+		void setPSummationMap(BGFLOAT* summationMap); /// Mutator for summation map (added late)
 
-   void setConfigFileName(const std::string &fileName);
+		void setConfigFileName(const std::string& fileName);
 
-   void setSerializationFileName(const std::string &fileName);
+		void setSerializationFileName(const std::string& fileName);
 
-   void setDeserializationFileName(const std::string &fileName);
+		void setDeserializationFileName(const std::string& fileName);
 
-   void setStimulusFileName(const std::string &fileName);
+		void setStimulusFileName(const std::string& fileName);
 
 #ifdef PERFORMANCE_METRICS
    Timer getTimer();  /// Timer measures performance of epoch. returns copy of internal timer owned by simulator.
    Timer getShort_timer(); ///Timer for measuring performance of connection update.
 #endif
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   Simulator(Simulator const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		Simulator(const Simulator&) = delete;
 
-   void operator=(Simulator const &) = delete;
+		void operator=(const Simulator&) = delete;
 
-private:
-   Simulator();    /// Constructor is private to keep a singleton instance of this class.
+	private:
+		Simulator(); /// Constructor is private to keep a singleton instance of this class.
 
-   void freeResources(); /// Frees dynamically allocated memory associated with the maps.
+		void freeResources(); /// Frees dynamically allocated memory associated with the maps.
 
-   int width_; /// Width of neuron map (assumes square)
+		int width_; /// Width of neuron map (assumes square)
 
-   int height_;   /// Height of neuron map
+		int height_; /// Height of neuron map
 
-   int totalNeurons_;   /// Count of neurons in the simulation
+		int totalNeurons_; /// Count of neurons in the simulation
 
-   int currentEpoch_;   /// Current epoch step
+		int currentEpoch_; /// Current epoch step
 
-   int numEpochs_; /// Number of simulator epochs
+		int numEpochs_; /// Number of simulator epochs
 
-   BGFLOAT epochDuration_; /// The length of each step in simulation time
+		BGFLOAT epochDuration_; /// The length of each step in simulation time
 
-   int maxFiringRate_;  /// Maximum firing rate. **GPU Only**
+		int maxFiringRate_; /// Maximum firing rate. **GPU Only**
 
-   int maxEdgesPerVertex_;  /// Maximum number of synapses per neuron. **GPU Only**
+		int maxEdgesPerVertex_; /// Maximum number of synapses per neuron. **GPU Only**
 
-   BGFLOAT deltaT_;   /// Inner Simulation Step Duration, purely investigative.
+		BGFLOAT deltaT_; /// Inner Simulation Step Duration, purely investigative.
 
-   vertexType *rgNeuronTypeMap_; /// The vertex type map (INH, EXC). ToDo: become a vector
+		vertexType* rgNeuronTypeMap_; /// The vertex type map (INH, EXC). ToDo: become a vector
 
-   bool *rgEndogenouslyActiveNeuronMap_;   /// The starter existence map (T/F). ToDo: become a vector
+		bool* rgEndogenouslyActiveNeuronMap_; /// The starter existence map (T/F). ToDo: become a vector
 
-   BGFLOAT maxRate_;   /// growth variable (m_targetRate / m_epsilon) TODO: more detail here
+		BGFLOAT maxRate_; /// growth variable (m_targetRate / m_epsilon) TODO: more detail here
 
-   BGFLOAT *pSummationMap_;    /// List of summation points (either host or device memory) ToDo: make smart ptr
+		BGFLOAT* pSummationMap_; /// List of summation points (either host or device memory) ToDo: make smart ptr
 
-   long noiseRngSeed_;   /// Seed used for the simulation random SINGLE THREADED
+		long noiseRngSeed_; /// Seed used for the simulation random SINGLE THREADED
 
-   long initRngSeed_;   /// Seed used to initialize parameters
+		long initRngSeed_; /// Seed used to initialize parameters
 
-   std::string configFileName_;    /// File name of the parameter configuration file.
+		std::string configFileName_; /// File name of the parameter configuration file.
 
-   std::string serializationFileName_;    /// File name of the serialization file.
+		std::string serializationFileName_; /// File name of the serialization file.
 
-   std::string deserializationFileName_;    /// File name of the deserialization file.
+		std::string deserializationFileName_; /// File name of the deserialization file.
 
-   std::string stimulusFileName_;    /// File name of the stimulus input file.
+		std::string stimulusFileName_; /// File name of the stimulus input file.
 
-   std::shared_ptr<Model> model_;  /// Smart pointer to model class (Model is an interface class)
+		std::shared_ptr<Model> model_; /// Smart pointer to model class (Model is an interface class)
 
-   log4cplus::Logger consoleLogger_; /// Logger for printing to the console as well as the logging file
-   log4cplus::Logger fileLogger_; /// Logger for printing to the logging file
-   log4cplus::Logger edgeLogger_; /// Logger for printing to the logging file
+		log4cplus::Logger consoleLogger_; /// Logger for printing to the console as well as the logging file
+		log4cplus::Logger fileLogger_; /// Logger for printing to the logging file
+		log4cplus::Logger edgeLogger_; /// Logger for printing to the logging file
 
 #ifdef PERFORMANCE_METRICS
    Timer timer;   /// Timer for measuring performance of an epoch.
    Timer short_timer; /// Timer for measuring performance of connection update.
 #endif
-///@}
+		///@}
 };
-
-
-
- 

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -32,7 +32,7 @@ AllEdges::AllEdges() :
 	// OperationManager. This will register the appropriate overridden method
 	// for the actual (sub)class of the object being created.
 	std::function<void()> printParametersFunc = std::bind(&AllEdges::printParameters, this);
-	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
 	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 	edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
@@ -146,7 +146,7 @@ void AllEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
 	output << sourceVertexIndex_[iEdg] << std::ends;
 	output << destVertexIndex_[iEdg] << std::ends;
 	output << W_[iEdg] << std::ends;
-	output << type_[iEdg] << std::ends;
+	output << static_cast<int>(type_[iEdg]) << std::ends;
 	output << inUse_[iEdg] << std::ends;
 }
 
@@ -156,15 +156,15 @@ void AllEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
 ///  @return the SynapseType that corresponds with the given integer.
 edgeType AllEdges::edgeOrdinalToType(const int typeOrdinal) {
 	switch (typeOrdinal) {
-		case 0: return II;
-		case 1: return IE;
-		case 2: return EI;
-		case 3: return EE;
-		case 4: return CP;
-		case 5: return PR;
-		case 6: return RC;
-		case 7: return PP;
-		default: return ETYPE_UNDEF;
+		case 0: return edgeType::II;
+		case 1: return edgeType::IE;
+		case 2: return edgeType::EI;
+		case 3: return edgeType::EE;
+		case 4: return edgeType::CP;
+		case 5: return edgeType::PR;
+		case 6: return edgeType::RC;
+		case 7: return edgeType::PP;
+		default: return edgeType::ETYPE_UNDEF;
 	}
 }
 
@@ -223,8 +223,10 @@ void AllEdges::createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap) {
 		edgeIndexMap->outgoingEdgeBegin_[i] = edg_i;
 		edgeIndexMap->outgoingEdgeCount_[i] = rgEdgeEdgeIndexMap[i].size();
 
-		for (BGSIZE j = 0; j < rgEdgeEdgeIndexMap[i].size(); j++, edg_i++) edgeIndexMap->outgoingEdgeIndexMap_[edg_i] =
-			rgEdgeEdgeIndexMap[i][j];
+		for (BGSIZE j = 0; j < rgEdgeEdgeIndexMap[i].size(); j++, edg_i++) {
+			edgeIndexMap->outgoingEdgeIndexMap_[edg_i] =
+				rgEdgeEdgeIndexMap[i][j];
+		}
 	}
 }
 

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -11,81 +11,79 @@
 #include "OperationManager.h"
 
 AllEdges::AllEdges() :
-      totalEdgeCount_(0),
-      maxEdgesPerVertex_(0),
-      countVertices_(0) {
-   destVertexIndex_ = nullptr;
-   W_ = nullptr;
-   summationPoint_ = nullptr;
-   sourceVertexIndex_ = nullptr;
-   type_ = nullptr;
-   inUse_ = nullptr;
-   edgeCounts_ = nullptr;
+	totalEdgeCount_(0),
+	maxEdgesPerVertex_(0),
+	countVertices_(0) {
+	destVertexIndex_ = nullptr;
+	W_ = nullptr;
+	summationPoint_ = nullptr;
+	sourceVertexIndex_ = nullptr;
+	type_ = nullptr;
+	inUse_ = nullptr;
+	edgeCounts_ = nullptr;
 
-   // Register loadParameters function as a loadParameters operation in the
-   // OperationManager. This will register the appropriate overridden method
-   // for the actual (sub)class of the object being created.
-   std::function<void()> loadParametersFunc = std::bind(&AllEdges::loadParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
+	// Register loadParameters function as a loadParameters operation in the
+	// OperationManager. This will register the appropriate overridden method
+	// for the actual (sub)class of the object being created.
+	std::function<void()> loadParametersFunc = std::bind(&AllEdges::loadParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
-   // Register printParameters function as a printParameters operation in the
-   // OperationManager. This will register the appropriate overridden method
-   // for the actual (sub)class of the object being created.
-   std::function<void()> printParametersFunc = std::bind(&AllEdges::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	// Register printParameters function as a printParameters operation in the
+	// OperationManager. This will register the appropriate overridden method
+	// for the actual (sub)class of the object being created.
+	std::function<void()> printParametersFunc = std::bind(&AllEdges::printParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
-   edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
 }
 
-AllEdges::AllEdges(const int numVertices, const int maxEdges) {
-   setupEdges(numVertices, maxEdges);
-}
+AllEdges::AllEdges(const int numVertices, const int maxEdges) { setupEdges(numVertices, maxEdges); }
 
 AllEdges::~AllEdges() {
-   BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;
+	BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;
 
-   if (maxTotalEdges != 0) {
-      delete[] destVertexIndex_;
-      delete[] W_;
-      delete[] summationPoint_;
-      delete[] sourceVertexIndex_;
-      delete[] type_;
-      delete[] inUse_;
-      delete[] edgeCounts_;
-   }
+	if (maxTotalEdges != 0) {
+		delete[] destVertexIndex_;
+		delete[] W_;
+		delete[] summationPoint_;
+		delete[] sourceVertexIndex_;
+		delete[] type_;
+		delete[] inUse_;
+		delete[] edgeCounts_;
+	}
 
-   destVertexIndex_ = nullptr;
-   W_ = nullptr;
-   summationPoint_ = nullptr;
-   sourceVertexIndex_ = nullptr;
-   type_ = nullptr;
-   inUse_ = nullptr;
-   edgeCounts_ = nullptr;
+	destVertexIndex_ = nullptr;
+	W_ = nullptr;
+	summationPoint_ = nullptr;
+	sourceVertexIndex_ = nullptr;
+	type_ = nullptr;
+	inUse_ = nullptr;
+	edgeCounts_ = nullptr;
 
-   countVertices_ = 0;
-   maxEdgesPerVertex_ = 0;
+	countVertices_ = 0;
+	maxEdgesPerVertex_ = 0;
 }
 
 /// Load member variables from configuration file.
 /// Registered to OperationManager as Operation::op::loadParameters
 void AllEdges::loadParameters() {
-   // Nothing to load from configuration file besides SynapseType in the current implementation.
+	// Nothing to load from configuration file besides SynapseType in the current implementation.
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllEdges::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nEDGES PARAMETERS" << std::endl
-    << "\t---AllEdges Parameters---" << std::endl
-    << "\tTotal edge counts: " << totalEdgeCount_ << std::endl
-    << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
-    << "\tVertex count: " << countVertices_ << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nEDGES PARAMETERS" << std::endl
+	                << "\t---AllEdges Parameters---" << std::endl
+	                << "\tTotal edge counts: " << totalEdgeCount_ << std::endl
+	                << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
+	                << "\tVertex count: " << countVertices_ << std::endl << std::endl);
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllEdges::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+	setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -93,65 +91,63 @@ void AllEdges::setupEdges() {
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of edges per vertex.
 void AllEdges::setupEdges(const int numVertices, const int maxEdges) {
-   BGSIZE maxTotalEdges = maxEdges * numVertices;
+	BGSIZE maxTotalEdges = maxEdges * numVertices;
 
-   maxEdgesPerVertex_ = maxEdges;
-   totalEdgeCount_ = 0;
-   countVertices_ = numVertices;
+	maxEdgesPerVertex_ = maxEdges;
+	totalEdgeCount_ = 0;
+	countVertices_ = numVertices;
 
-   if (maxTotalEdges != 0) {
-      destVertexIndex_ = new int[maxTotalEdges];
-      W_ = new BGFLOAT[maxTotalEdges];
-      summationPoint_ = new BGFLOAT *[maxTotalEdges];
-      sourceVertexIndex_ = new int[maxTotalEdges];
-      type_ = new edgeType[maxTotalEdges];
-      inUse_ = new bool[maxTotalEdges];
-      edgeCounts_ = new BGSIZE[numVertices];
+	if (maxTotalEdges != 0) {
+		destVertexIndex_ = new int[maxTotalEdges];
+		W_ = new BGFLOAT[maxTotalEdges];
+		summationPoint_ = new BGFLOAT*[maxTotalEdges];
+		sourceVertexIndex_ = new int[maxTotalEdges];
+		type_ = new edgeType[maxTotalEdges];
+		inUse_ = new bool[maxTotalEdges];
+		edgeCounts_ = new BGSIZE[numVertices];
 
-      for (BGSIZE i = 0; i < maxTotalEdges; i++) {
-         summationPoint_[i] = nullptr;
-         inUse_[i] = false;
-         W_[i] = 0;
-      }
+		for (BGSIZE i = 0; i < maxTotalEdges; i++) {
+			summationPoint_[i] = nullptr;
+			inUse_[i] = false;
+			W_[i] = 0;
+		}
 
-      for (int i = 0; i < numVertices; i++) {
-         edgeCounts_[i] = 0;
-      }
-   }
+		for (int i = 0; i < numVertices; i++) edgeCounts_[i] = 0;
+	}
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the edge to set.
-void AllEdges::readEdge(std::istream &input, const BGSIZE iEdg) {
-   int synapse_type(0);
+void AllEdges::readEdge(std::istream& input, const BGSIZE iEdg) {
+	int synapse_type(0);
 
-   // input.ignore() so input skips over end-of-line characters.
-   input >> sourceVertexIndex_[iEdg];
-   input.ignore();
-   input >> destVertexIndex_[iEdg];
-   input.ignore();
-   input >> W_[iEdg];
-   input.ignore();
-   input >> synapse_type;
-   input.ignore();
-   input >> inUse_[iEdg];
-   input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> sourceVertexIndex_[iEdg];
+	input.ignore();
+	input >> destVertexIndex_[iEdg];
+	input.ignore();
+	input >> W_[iEdg];
+	input.ignore();
+	input >> synapse_type;
+	input.ignore();
+	input >> inUse_[iEdg];
+	input.ignore();
 
-   type_[iEdg] = edgeOrdinalToType(synapse_type);
+	type_[iEdg] = edgeOrdinalToType(synapse_type);
 }
 
 ///  Write the edge data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the edge to print out.
-void AllEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-   output << sourceVertexIndex_[iEdg] << std::ends;
-   output << destVertexIndex_[iEdg] << std::ends;
-   output << W_[iEdg] << std::ends;
-   output << type_[iEdg] << std::ends;
-   output << inUse_[iEdg] << std::ends;
+void AllEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	output << sourceVertexIndex_[iEdg] << std::ends;
+	output << destVertexIndex_[iEdg] << std::ends;
+	output << W_[iEdg] << std::ends;
+	output << type_[iEdg] << std::ends;
+	output << inUse_[iEdg] << std::ends;
 }
 
 ///  Returns an appropriate edgeType object for the given integer.
@@ -159,89 +155,77 @@ void AllEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
 ///  @param  typeOrdinal    Integer that correspond with a edgeType.
 ///  @return the SynapseType that corresponds with the given integer.
 edgeType AllEdges::edgeOrdinalToType(const int typeOrdinal) {
-   switch (typeOrdinal) {
-      case 0:
-         return II;
-      case 1:
-         return IE;
-      case 2:
-         return EI;
-      case 3:
-         return EE;
-      case 4:
-         return CP;
-      case 5:
-         return PR;
-      case 6:
-         return RC;
-      case 7:
-         return PP;
-      default:
-         return ETYPE_UNDEF;
-   }
+	switch (typeOrdinal) {
+		case 0: return II;
+		case 1: return IE;
+		case 2: return EI;
+		case 3: return EE;
+		case 4: return CP;
+		case 5: return PR;
+		case 6: return RC;
+		case 7: return PP;
+		default: return ETYPE_UNDEF;
+	}
 }
 
 ///  Create a edge index map.
 void AllEdges::createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap) {
-   Simulator& simulator = Simulator::getInstance();
-   const int vertexCount = simulator.getTotalVertices();
-   int totalEdgeCount = 0;
+	Simulator& simulator = Simulator::getInstance();
+	const int vertexCount = simulator.getTotalVertices();
+	int totalEdgeCount = 0;
 
-   // count the total edges
-   for (int i = 0; i < vertexCount; i++) {
-      assert(static_cast<int>(edgeCounts_[i]) < simulator.getMaxEdgesPerVertex());
-      totalEdgeCount += edgeCounts_[i];
-   }
+	// count the total edges
+	for (int i = 0; i < vertexCount; i++) {
+		assert(static_cast<int>(edgeCounts_[i]) < simulator.getMaxEdgesPerVertex());
+		totalEdgeCount += edgeCounts_[i];
+	}
 
-   LOG4CPLUS_TRACE(fileLogger_,std::endl<<"totalEdgeCount: in edgeIndexMap " << totalEdgeCount << std::endl);
+	LOG4CPLUS_TRACE(fileLogger_, std::endl<<"totalEdgeCount: in edgeIndexMap " << totalEdgeCount << std::endl);
 
-   // Create vector for edge forwarding map
-   std::vector<std::vector<BGSIZE>> rgEdgeEdgeIndexMap(vertexCount);
-   BGSIZE edg_i = 0;
-   int curr = 0;
+	// Create vector for edge forwarding map
+	std::vector<std::vector<BGSIZE>> rgEdgeEdgeIndexMap(vertexCount);
+	BGSIZE edg_i = 0;
+	int curr = 0;
 
-   LOG4CPLUS_TRACE(edgeLogger_, "\nSize of edge Index Map "<< vertexCount << "," << totalEdgeCount << std::endl);
-   
-   for (int i = 0; i < vertexCount; i++) {
-      BGSIZE edge_count = 0;
-      edgeIndexMap->incomingEdgeBegin_[i] = curr;
-      for (int j = 0; j < simulator.getMaxEdgesPerVertex(); j++, edg_i++) {
-         if (inUse_[edg_i]) {
-            int idx = sourceVertexIndex_[edg_i];
-            rgEdgeEdgeIndexMap[idx].push_back(edg_i);
+	LOG4CPLUS_TRACE(edgeLogger_, "\nSize of edge Index Map "<< vertexCount << "," << totalEdgeCount << std::endl);
 
-            edgeIndexMap->incomingEdgeIndexMap_[curr] = edg_i;
-            curr++;
-            edge_count++;
-         }
-      }
-      
-      if(edge_count != edgeCounts_[i])
-      {
-         LOG4CPLUS_FATAL(edgeLogger_, "\nedge_count does not match edgeCounts_" << edge_count << std::endl);
-         throw std::runtime_error("createEdgeIndexMap: edge_count does not match edgeCounts_.");
-      }
+	for (int i = 0; i < vertexCount; i++) {
+		BGSIZE edge_count = 0;
+		edgeIndexMap->incomingEdgeBegin_[i] = curr;
+		for (int j = 0; j < simulator.getMaxEdgesPerVertex(); j++, edg_i++) {
+			if (inUse_[edg_i]) {
+				int idx = sourceVertexIndex_[edg_i];
+				rgEdgeEdgeIndexMap[idx].push_back(edg_i);
 
-      edgeIndexMap->incomingEdgeCount_[i] = edge_count;
-   }
-   
-   if(totalEdgeCount != curr)
-   {
-      LOG4CPLUS_FATAL(edgeLogger_,"Curr does not match the totalEdgeCount. curr are " << curr << std::endl);
-      throw std::runtime_error("createEdgeIndexMap: Curr does not match the totalEdgeCount.");
-   }
-   totalEdgeCount_ = totalEdgeCount;
-   LOG4CPLUS_DEBUG(edgeLogger_,std::endl<<"totalEdgeCount: " << totalEdgeCount_ << std::endl);
-   
-   edg_i = 0;
-   for (int i = 0; i < vertexCount; i++) {
-      edgeIndexMap->outgoingEdgeBegin_[i] = edg_i;
-      edgeIndexMap->outgoingEdgeCount_[i] = rgEdgeEdgeIndexMap[i].size();
+				edgeIndexMap->incomingEdgeIndexMap_[curr] = edg_i;
+				curr++;
+				edge_count++;
+			}
+		}
 
-      for (BGSIZE j = 0; j < rgEdgeEdgeIndexMap[i].size(); j++, edg_i++) {
-         edgeIndexMap->outgoingEdgeIndexMap_[edg_i] = rgEdgeEdgeIndexMap[i][j];
-      }
-   }
+		if (edge_count != edgeCounts_[i]) {
+			LOG4CPLUS_FATAL(edgeLogger_, "\nedge_count does not match edgeCounts_" << edge_count << std::endl);
+			throw std::runtime_error("createEdgeIndexMap: edge_count does not match edgeCounts_.");
+		}
+
+		edgeIndexMap->incomingEdgeCount_[i] = edge_count;
+	}
+
+	if (totalEdgeCount != curr) {
+		LOG4CPLUS_FATAL(edgeLogger_, "Curr does not match the totalEdgeCount. curr are " << curr << std::endl);
+		throw std::runtime_error("createEdgeIndexMap: Curr does not match the totalEdgeCount.");
+	}
+	totalEdgeCount_ = totalEdgeCount;
+	LOG4CPLUS_DEBUG(edgeLogger_, std::endl<<"totalEdgeCount: " << totalEdgeCount_ << std::endl);
+
+	edg_i = 0;
+	for (int i = 0; i < vertexCount; i++) {
+		edgeIndexMap->outgoingEdgeBegin_[i] = edg_i;
+		edgeIndexMap->outgoingEdgeCount_[i] = rgEdgeEdgeIndexMap[i].size();
+
+		for (BGSIZE j = 0; j < rgEdgeEdgeIndexMap[i].size(); j++, edg_i++) edgeIndexMap->outgoingEdgeIndexMap_[edg_i] =
+			rgEdgeEdgeIndexMap[i][j];
+	}
 }
 
 
@@ -251,11 +235,11 @@ void AllEdges::createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap) {
 ///
 ///  @param  vertices           The vertices.
 ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-void AllEdges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap) {
-   for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
-      BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
-      advanceEdge(iEdg, vertices);
-   }
+void AllEdges::advanceEdges(AllVertices* vertices, EdgeIndexMap* edgeIndexMap) {
+	for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
+		BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
+		advanceEdge(iEdg, vertices);
+	}
 }
 
 ///  Remove a edge from the network.
@@ -263,10 +247,10 @@ void AllEdges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap) {
 ///  @param  iVert    Index of a vertex to remove from.
 ///  @param  iEdg           Index of a edge to remove.
 void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg) {
-   edgeCounts_[iVert]--;
-   inUse_[iEdg] = false;
-   summationPoint_[iEdg] = nullptr;
-   W_[iEdg] = 0;
+	edgeCounts_[iVert]--;
+	inUse_[iEdg] = false;
+	summationPoint_[iEdg] = nullptr;
+	W_[iEdg] = 0;
 }
 
 #endif
@@ -280,24 +264,23 @@ void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg) {
 ///  @param  destVertex The Vertex that receives from the edge.
 ///  @param  sumPoint   Summation point address.
 ///  @param  deltaT      Inner simulation step duration
-void AllEdges::addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT *sumPoint,
-                        const BGFLOAT deltaT) {
-   if (edgeCounts_[destVertex] >= maxEdgesPerVertex_) {
-      LOG4CPLUS_FATAL(edgeLogger_, "Vertex : " << destVertex << " ran out of space for new edges.");
-      throw std::runtime_error("Vertex : " + std::to_string(destVertex) + std::string(" ran out of space for new edges."));
-   }
+void AllEdges::addEdge(BGSIZE& iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT* sumPoint,
+                       const BGFLOAT deltaT) {
+	if (edgeCounts_[destVertex] >= maxEdgesPerVertex_) {
+		LOG4CPLUS_FATAL(edgeLogger_, "Vertex : " << destVertex << " ran out of space for new edges.");
+		throw std::runtime_error(
+			"Vertex : " + std::to_string(destVertex) + std::string(" ran out of space for new edges."));
+	}
 
-   // add it to the list: find first edge location for vertex destVertex
-   // that isn't in use.
-   for (BGSIZE i = 0; i < maxEdgesPerVertex_; i++) {
-      iEdg = maxEdgesPerVertex_ * destVertex + i;
-      if (!inUse_[iEdg]) {
-         break;
-      }
-   }
+	// add it to the list: find first edge location for vertex destVertex
+	// that isn't in use.
+	for (BGSIZE i = 0; i < maxEdgesPerVertex_; i++) {
+		iEdg = maxEdgesPerVertex_ * destVertex + i;
+		if (!inUse_[iEdg]) break;
+	}
 
-   edgeCounts_[destVertex]++;
+	edgeCounts_[destVertex]++;
 
-   // create an edge
-   createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
+	// create an edge
+	createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
 }

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -11,16 +11,10 @@
 #include "OperationManager.h"
 
 AllEdges::AllEdges() :
-	totalEdgeCount_(0),
+	edgeCounts_(nullptr), inUse_(nullptr), type_(nullptr), sourceVertexIndex_(nullptr), summationPoint_(nullptr), W_(nullptr), destVertexIndex_(nullptr), totalEdgeCount_(0),
 	maxEdgesPerVertex_(0),
 	countVertices_(0) {
-	destVertexIndex_ = nullptr;
-	W_ = nullptr;
-	summationPoint_ = nullptr;
-	sourceVertexIndex_ = nullptr;
-	type_ = nullptr;
-	inUse_ = nullptr;
-	edgeCounts_ = nullptr;
+
 
 	// Register loadParameters function as a loadParameters operation in the
 	// OperationManager. This will register the appropriate overridden method

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -25,13 +25,13 @@ AllEdges::AllEdges() :
    // Register loadParameters function as a loadParameters operation in the
    // OperationManager. This will register the appropriate overridden method
    // for the actual (sub)class of the object being created.
-   function<void()> loadParametersFunc = std::bind(&AllEdges::loadParameters, this);
+   std::function<void()> loadParametersFunc = std::bind(&AllEdges::loadParameters, this);
    OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
    // Register printParameters function as a printParameters operation in the
    // OperationManager. This will register the appropriate overridden method
    // for the actual (sub)class of the object being created.
-   function<void()> printParametersFunc = bind(&AllEdges::printParameters, this);
+   std::function<void()> printParametersFunc = std::bind(&AllEdges::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
@@ -76,11 +76,11 @@ void AllEdges::loadParameters() {
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllEdges::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nEDGES PARAMETERS" << endl
-    << "\t---AllEdges Parameters---" << endl
-    << "\tTotal edge counts: " << totalEdgeCount_ << endl
-    << "\tMax edges per vertex: " << maxEdgesPerVertex_ << endl
-    << "\tVertex count: " << countVertices_ << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nEDGES PARAMETERS" << std::endl
+    << "\t---AllEdges Parameters---" << std::endl
+    << "\tTotal edge counts: " << totalEdgeCount_ << std::endl
+    << "\tMax edges per vertex: " << maxEdgesPerVertex_ << std::endl
+    << "\tVertex count: " << countVertices_ << std::endl << std::endl);
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -124,7 +124,7 @@ void AllEdges::setupEdges(const int numVertices, const int maxEdges) {
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the edge to set.
-void AllEdges::readEdge(istream &input, const BGSIZE iEdg) {
+void AllEdges::readEdge(std::istream &input, const BGSIZE iEdg) {
    int synapse_type(0);
 
    // input.ignore() so input skips over end-of-line characters.
@@ -146,12 +146,12 @@ void AllEdges::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the edge to print out.
-void AllEdges::writeEdge(ostream &output, const BGSIZE iEdg) const {
-   output << sourceVertexIndex_[iEdg] << ends;
-   output << destVertexIndex_[iEdg] << ends;
-   output << W_[iEdg] << ends;
-   output << type_[iEdg] << ends;
-   output << inUse_[iEdg] << ends;
+void AllEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
+   output << sourceVertexIndex_[iEdg] << std::ends;
+   output << destVertexIndex_[iEdg] << std::ends;
+   output << W_[iEdg] << std::ends;
+   output << type_[iEdg] << std::ends;
+   output << inUse_[iEdg] << std::ends;
 }
 
 ///  Returns an appropriate edgeType object for the given integer.
@@ -182,9 +182,9 @@ edgeType AllEdges::edgeOrdinalToType(const int typeOrdinal) {
 }
 
 ///  Create a edge index map.
-void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
+void AllEdges::createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap) {
    Simulator& simulator = Simulator::getInstance();
-   int vertexCount = simulator.getTotalVertices();
+   const int vertexCount = simulator.getTotalVertices();
    int totalEdgeCount = 0;
 
    // count the total edges
@@ -193,15 +193,14 @@ void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
       totalEdgeCount += edgeCounts_[i];
    }
 
-   LOG4CPLUS_TRACE(fileLogger_,endl<<"totalEdgeCount: in edgeIndexMap " << totalEdgeCount << endl);
+   LOG4CPLUS_TRACE(fileLogger_,std::endl<<"totalEdgeCount: in edgeIndexMap " << totalEdgeCount << std::endl);
 
    // Create vector for edge forwarding map
-   vector<BGSIZE> rgEdgeEdgeIndexMap[vertexCount];
-
+   std::vector<std::vector<BGSIZE>> rgEdgeEdgeIndexMap(vertexCount);
    BGSIZE edg_i = 0;
    int curr = 0;
 
-   LOG4CPLUS_TRACE(edgeLogger_, "\nSize of edge Index Map "<< vertexCount << "," << totalEdgeCount << endl);
+   LOG4CPLUS_TRACE(edgeLogger_, "\nSize of edge Index Map "<< vertexCount << "," << totalEdgeCount << std::endl);
    
    for (int i = 0; i < vertexCount; i++) {
       BGSIZE edge_count = 0;
@@ -219,8 +218,8 @@ void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
       
       if(edge_count != edgeCounts_[i])
       {
-         LOG4CPLUS_FATAL(edgeLogger_, "\nedge_count does not match edgeCounts_" << edge_count << endl);
-         throw runtime_error("createEdgeIndexMap: edge_count does not match edgeCounts_.");
+         LOG4CPLUS_FATAL(edgeLogger_, "\nedge_count does not match edgeCounts_" << edge_count << std::endl);
+         throw std::runtime_error("createEdgeIndexMap: edge_count does not match edgeCounts_.");
       }
 
       edgeIndexMap->incomingEdgeCount_[i] = edge_count;
@@ -228,11 +227,11 @@ void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
    
    if(totalEdgeCount != curr)
    {
-      LOG4CPLUS_FATAL(edgeLogger_,"Curr does not match the totalEdgeCount. curr are " << curr << endl);
-      throw runtime_error("createEdgeIndexMap: Curr does not match the totalEdgeCount.");
+      LOG4CPLUS_FATAL(edgeLogger_,"Curr does not match the totalEdgeCount. curr are " << curr << std::endl);
+      throw std::runtime_error("createEdgeIndexMap: Curr does not match the totalEdgeCount.");
    }
    totalEdgeCount_ = totalEdgeCount;
-   LOG4CPLUS_DEBUG(edgeLogger_,endl<<"totalEdgeCount: " << totalEdgeCount_ << endl);
+   LOG4CPLUS_DEBUG(edgeLogger_,std::endl<<"totalEdgeCount: " << totalEdgeCount_ << std::endl);
    
    edg_i = 0;
    for (int i = 0; i < vertexCount; i++) {
@@ -246,7 +245,7 @@ void AllEdges::createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap) {
 }
 
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Advance all the edges in the simulation.
 ///
@@ -270,7 +269,7 @@ void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg) {
    W_[iEdg] = 0;
 }
 
-#endif // !defined(USE_GPU)
+#endif
 
 
 ///  Adds an edge to the model, connecting two Vertices.
@@ -285,7 +284,7 @@ void AllEdges::addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const i
                         const BGFLOAT deltaT) {
    if (edgeCounts_[destVertex] >= maxEdgesPerVertex_) {
       LOG4CPLUS_FATAL(edgeLogger_, "Vertex : " << destVertex << " ran out of space for new edges.");
-      throw runtime_error("Vertex : " + destVertex + string(" ran out of space for new edges."));
+      throw std::runtime_error("Vertex : " + std::to_string(destVertex) + std::string(" ran out of space for new edges."));
    }
 
    // add it to the list: find first edge location for vertex destVertex

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -59,7 +59,7 @@ public:
                               edgeType type) = 0;
 
    ///  Populate a edge index map.
-   virtual void createEdgeIndexMap(shared_ptr<EdgeIndexMap> edgeIndexMap);
+   virtual void createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap);
 
    ///  Cereal serialization method
    ///  (Serializes edge weights, source vertices, and destination vertices)
@@ -82,13 +82,13 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the edge to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg);
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg);
 
    ///  Write the edge data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the edge to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const;
    
    ///  Returns an appropriate edgeType object for the given integer.
    ///
@@ -100,7 +100,7 @@ protected:
    log4cplus::Logger fileLogger_;
    log4cplus::Logger edgeLogger_;
  
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all edges' states,
        ///  and copy them from host to GPU memory.
@@ -174,7 +174,7 @@ protected:
        ///  @param  allEdgesDeviceProps   GPU address of the corresponding SynapsesDeviceProperties struct on device memory.
        virtual void printGPUEdgesProps( void* allEdgesDeviceProps ) const = 0;
 
-#else // !defined(USE_GPU)
+#else
 public:
    ///  Advance all the edges in the simulation.
    ///  Update the state of all edges for a time step.
@@ -194,7 +194,7 @@ public:
    ///  @param  neuronIndex   Index of a vertex to remove from.
    ///  @param  iEdg          Index of a edge to remove.
    virtual void eraseEdge(const int neuronIndex, const BGSIZE iEdg);
-#endif // defined(USE_GPU)
+#endif 
 
    ///  The location of the edge.
    int *sourceVertexIndex_;
@@ -236,9 +236,9 @@ public:
 template<class Archive>
 void AllEdges::save(Archive &archive) const {
    // uses vector to save edge weights, source vertices, and destination vertices
-   vector<BGFLOAT> WVector;
-   vector<int> sourceVertexLayoutIndexVector;
-   vector<int> destVertexLayoutIndexVector;
+   std::vector<BGFLOAT> WVector;
+   std::vector<int> sourceVertexLayoutIndexVector;
+   std::vector<int> destVertexLayoutIndexVector;
 
    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
       WVector.push_back(W_[i]);
@@ -255,18 +255,18 @@ void AllEdges::save(Archive &archive) const {
 template<class Archive>
 void AllEdges::load(Archive &archive) {
    // uses vectors to load edge weights, source vertices, and destination vertices
-   vector<BGFLOAT> WVector;
-   vector<int> sourceVertexLayoutIndexVector;
-   vector<int> destVertexLayoutIndexVector;
+   std::vector<BGFLOAT> WVector;
+   std::vector<int> sourceVertexLayoutIndexVector;
+   std::vector<int> destVertexLayoutIndexVector;
 
    // deserializing data to these vectors
    archive(WVector, sourceVertexLayoutIndexVector, destVertexLayoutIndexVector);
 
    // check to see if serialized data sizes matches object sizes
    if (WVector.size() != maxEdgesPerVertex_ * countVertices_) {
-      cerr
+      std::cerr
             << "Failed deserializing edge weights, source vertices, and/or destination vertices. Please verify maxEdgesPerVertex and count_neurons data members in AllEdges class."
-            << endl;
+            << std::endl;
       throw cereal::Exception("Deserialization Error");
    }
 

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -21,7 +21,7 @@ class AllVertices;
 class AllEdges {
 	public:
 		AllEdges();
-		AllEdges(const int numVertices, const int maxEdges);
+		AllEdges(int numVertices, int maxEdges);
 		virtual ~AllEdges();
 
 		///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -44,8 +44,8 @@ class AllEdges {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration
 		virtual void
-			addEdge(BGSIZE& iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT* sumPoint,
-			        const BGFLOAT deltaT);
+			addEdge(BGSIZE& iEdg, edgeType type, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+			        BGFLOAT deltaT);
 
 		///  Create a Edge and connect it to the model.
 		///
@@ -55,8 +55,8 @@ class AllEdges {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Edge to create.
-		virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
-		                        const BGFLOAT deltaT,
+		virtual void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+		                        BGFLOAT deltaT,
 		                        edgeType type) = 0;
 
 		///  Populate a edge index map.
@@ -77,25 +77,25 @@ class AllEdges {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of edges per vertex.
-		virtual void setupEdges(const int numVertices, const int maxEdges);
+		virtual void setupEdges(int numVertices, int maxEdges);
 
 		///  Sets the data for Edge to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the edge to set.
-		virtual void readEdge(std::istream& input, const BGSIZE iEdg);
+		virtual void readEdge(std::istream& input, BGSIZE iEdg);
 
 		///  Write the edge data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the edge to print out.
-		virtual void writeEdge(std::ostream& output, const BGSIZE iEdg) const;
+		virtual void writeEdge(std::ostream& output, BGSIZE iEdg) const;
 
 		///  Returns an appropriate edgeType object for the given integer.
 		///
 		///  @param  typeOrdinal    Integer that correspond with a edgeType.
 		///  @return the SynapseType that corresponds with the given integer.
-		edgeType edgeOrdinalToType(const int typeOrdinal);
+		edgeType edgeOrdinalToType(int typeOrdinal);
 
 		/// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
 		log4cplus::Logger fileLogger_;
@@ -188,13 +188,13 @@ class AllEdges {
 		///
 		///  @param  iEdg      Index of the Edge to connect to.
 		///  @param  vertices  The Vertex list to search from.
-		virtual void advanceEdge(const BGSIZE iEdg, AllVertices* vertices) = 0;
+		virtual void advanceEdge(BGSIZE iEdg, AllVertices* vertices) = 0;
 
 		///  Remove a edge from the network.
 		///
 		///  @param  neuronIndex   Index of a vertex to remove from.
 		///  @param  iEdg          Index of a edge to remove.
-		virtual void eraseEdge(const int neuronIndex, const BGSIZE iEdg);
+		virtual void eraseEdge(int neuronIndex, BGSIZE iEdg);
 #endif
 
 		///  The location of the edge.

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -10,96 +10,97 @@
 
 #include <vector>
 
+#include "EdgeIndexMap.h"
 #include "Global.h"
 #include "Simulator.h"
-#include "EdgeIndexMap.h"
-#include "log4cplus/loggingmacros.h"
 #include "cereal/types/vector.hpp"
+#include "log4cplus/loggingmacros.h"
 
 class AllVertices;
 
 class AllEdges {
-public:
-   AllEdges();
-   AllEdges(const int numVertices, const int maxEdges);
-   virtual ~AllEdges();
+	public:
+		AllEdges();
+		AllEdges(const int numVertices, const int maxEdges);
+		virtual ~AllEdges();
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges();
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		virtual void setupEdges();
 
-   /// Load member variables from configuration file.
-   /// Registered to OperationManager as Operation::op::loadParameters
-   virtual void loadParameters();
+		/// Load member variables from configuration file.
+		/// Registered to OperationManager as Operation::op::loadParameters
+		virtual void loadParameters();
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		virtual void printParameters() const;
 
-   ///  Adds a Edge to the model, connecting two Vertices.
-   ///
-   ///  @param  iEdg        Index of the edge to be added.
-   ///  @param  type        The type of the Edge to add.
-   ///  @param  srcVertex   The Vertex that sends to this Edge.
-   ///  @param  destVertex  The Vertex that receives from the Edge.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration
-   virtual void
-   addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT *sumPoint,
-              const BGFLOAT deltaT);
+		///  Adds a Edge to the model, connecting two Vertices.
+		///
+		///  @param  iEdg        Index of the edge to be added.
+		///  @param  type        The type of the Edge to add.
+		///  @param  srcVertex   The Vertex that sends to this Edge.
+		///  @param  destVertex  The Vertex that receives from the Edge.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration
+		virtual void
+			addEdge(BGSIZE& iEdg, edgeType type, const int srcVertex, const int destVertex, BGFLOAT* sumPoint,
+			        const BGFLOAT deltaT);
 
-   ///  Create a Edge and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the edge to set.
-   ///  @param  srcVertex   Coordinates of the source Vertex.
-   ///  @param  destVertex  Coordinates of the destination Vertex.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Edge to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) = 0;
+		///  Create a Edge and connect it to the model.
+		///
+		///  @param  iEdg        Index of the edge to set.
+		///  @param  srcVertex   Coordinates of the source Vertex.
+		///  @param  destVertex  Coordinates of the destination Vertex.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Edge to create.
+		virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+		                        const BGFLOAT deltaT,
+		                        edgeType type) = 0;
 
-   ///  Populate a edge index map.
-   virtual void createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap);
+		///  Populate a edge index map.
+		virtual void createEdgeIndexMap(std::shared_ptr<EdgeIndexMap> edgeIndexMap);
 
-   ///  Cereal serialization method
-   ///  (Serializes edge weights, source vertices, and destination vertices)
-   template<class Archive>
-   void save(Archive &archive) const;
+		///  Cereal serialization method
+		///  (Serializes edge weights, source vertices, and destination vertices)
+		template <class Archive>
+		void save(Archive& archive) const;
 
-   ///  Cereal deserialization method
-   ///  (Deserializes edge weights, source vertices, and destination vertices)
-   template<class Archive>
-   void load(Archive &archive);
+		///  Cereal deserialization method
+		///  (Deserializes edge weights, source vertices, and destination vertices)
+		template <class Archive>
+		void load(Archive& archive);
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of edges per vertex.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of edges per vertex.
+		virtual void setupEdges(const int numVertices, const int maxEdges);
 
-   ///  Sets the data for Edge to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the edge to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg);
+		///  Sets the data for Edge to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the edge to set.
+		virtual void readEdge(std::istream& input, const BGSIZE iEdg);
 
-   ///  Write the edge data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the edge to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const;
-   
-   ///  Returns an appropriate edgeType object for the given integer.
-   ///
-   ///  @param  typeOrdinal    Integer that correspond with a edgeType.
-   ///  @return the SynapseType that corresponds with the given integer.
-   edgeType edgeOrdinalToType(const int typeOrdinal);
+		///  Write the edge data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the edge to print out.
+		virtual void writeEdge(std::ostream& output, const BGSIZE iEdg) const;
 
-   /// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
-   log4cplus::Logger fileLogger_;
-   log4cplus::Logger edgeLogger_;
- 
+		///  Returns an appropriate edgeType object for the given integer.
+		///
+		///  @param  typeOrdinal    Integer that correspond with a edgeType.
+		///  @return the SynapseType that corresponds with the given integer.
+		edgeType edgeOrdinalToType(const int typeOrdinal);
+
+		/// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
+		log4cplus::Logger fileLogger_;
+		log4cplus::Logger edgeLogger_;
+
 #ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all edges' states,
@@ -175,105 +176,105 @@ protected:
        virtual void printGPUEdgesProps( void* allEdgesDeviceProps ) const = 0;
 
 #else
-public:
-   ///  Advance all the edges in the simulation.
-   ///  Update the state of all edges for a time step.
-   ///
-   ///  @param  vertices       The Vertex list to search from.
-   ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-   virtual void advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap);
+	public:
+		///  Advance all the edges in the simulation.
+		///  Update the state of all edges for a time step.
+		///
+		///  @param  vertices       The Vertex list to search from.
+		///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
+		virtual void advanceEdges(AllVertices* vertices, EdgeIndexMap* edgeIndexMap);
 
-   ///  Advance one specific Edge.
-   ///
-   ///  @param  iEdg      Index of the Edge to connect to.
-   ///  @param  vertices  The Vertex list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *vertices) = 0;
+		///  Advance one specific Edge.
+		///
+		///  @param  iEdg      Index of the Edge to connect to.
+		///  @param  vertices  The Vertex list to search from.
+		virtual void advanceEdge(const BGSIZE iEdg, AllVertices* vertices) = 0;
 
-   ///  Remove a edge from the network.
-   ///
-   ///  @param  neuronIndex   Index of a vertex to remove from.
-   ///  @param  iEdg          Index of a edge to remove.
-   virtual void eraseEdge(const int neuronIndex, const BGSIZE iEdg);
-#endif 
+		///  Remove a edge from the network.
+		///
+		///  @param  neuronIndex   Index of a vertex to remove from.
+		///  @param  iEdg          Index of a edge to remove.
+		virtual void eraseEdge(const int neuronIndex, const BGSIZE iEdg);
+#endif
 
-   ///  The location of the edge.
-   int *sourceVertexIndex_;
+		///  The location of the edge.
+		int* sourceVertexIndex_;
 
-   ///  The coordinates of the summation point.
-   int *destVertexIndex_;
+		///  The coordinates of the summation point.
+		int* destVertexIndex_;
 
-   ///   The weight (scaling factor, strength, maximal amplitude) of the edge.
-   BGFLOAT *W_;
+		///   The weight (scaling factor, strength, maximal amplitude) of the edge.
+		BGFLOAT* W_;
 
-   ///  This edge's summation point's address.
-   BGFLOAT **summationPoint_;
+		///  This edge's summation point's address.
+		BGFLOAT** summationPoint_;
 
-   ///   Synapse type
-   edgeType *type_;
+		///   Synapse type
+		edgeType* type_;
 
-   ///  The boolean value indicating the entry in the array is in use.
-   bool *inUse_;
+		///  The boolean value indicating the entry in the array is in use.
+		bool* inUse_;
 
-   ///  The number of (incoming) edges for each vertex.
-   ///  Note: Likely under a different name in GpuSim_struct, see edge_count. -Aaron
-   BGSIZE *edgeCounts_;
+		///  The number of (incoming) edges for each vertex.
+		///  Note: Likely under a different name in GpuSim_struct, see edge_count. -Aaron
+		BGSIZE* edgeCounts_;
 
-   ///  The total number of active edges.
-   BGSIZE totalEdgeCount_;
+		///  The total number of active edges.
+		BGSIZE totalEdgeCount_;
 
-   ///  The maximum number of edges for each vertex.
-   BGSIZE maxEdgesPerVertex_;
+		///  The maximum number of edges for each vertex.
+		BGSIZE maxEdgesPerVertex_;
 
-   ///  The number of vertices
-   ///  Aaron: Is this even supposed to be here?!
-   ///  Usage: Used by destructor
-   int countVertices_;
+		///  The number of vertices
+		///  Aaron: Is this even supposed to be here?!
+		///  Usage: Used by destructor
+		int countVertices_;
 
 };
 
 ///  Cereal serialization method
 ///  (Serializes edge weights, source vertices, and destination vertices)
-template<class Archive>
-void AllEdges::save(Archive &archive) const {
-   // uses vector to save edge weights, source vertices, and destination vertices
-   std::vector<BGFLOAT> WVector;
-   std::vector<int> sourceVertexLayoutIndexVector;
-   std::vector<int> destVertexLayoutIndexVector;
+template <class Archive>
+void AllEdges::save(Archive& archive) const {
+	// uses vector to save edge weights, source vertices, and destination vertices
+	std::vector<BGFLOAT> WVector;
+	std::vector<int> sourceVertexLayoutIndexVector;
+	std::vector<int> destVertexLayoutIndexVector;
 
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      WVector.push_back(W_[i]);
-      sourceVertexLayoutIndexVector.push_back(sourceVertexIndex_[i]);
-      destVertexLayoutIndexVector.push_back(destVertexIndex_[i]);
-   }
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		WVector.push_back(W_[i]);
+		sourceVertexLayoutIndexVector.push_back(sourceVertexIndex_[i]);
+		destVertexLayoutIndexVector.push_back(destVertexIndex_[i]);
+	}
 
-   // serialization
-   archive(WVector, sourceVertexLayoutIndexVector, destVertexLayoutIndexVector);
+	// serialization
+	archive(WVector, sourceVertexLayoutIndexVector, destVertexLayoutIndexVector);
 }
 
 ///  Cereal deserialization method
 ///  (Deserializes edge weights, source vertices, and destination vertices)
-template<class Archive>
-void AllEdges::load(Archive &archive) {
-   // uses vectors to load edge weights, source vertices, and destination vertices
-   std::vector<BGFLOAT> WVector;
-   std::vector<int> sourceVertexLayoutIndexVector;
-   std::vector<int> destVertexLayoutIndexVector;
+template <class Archive>
+void AllEdges::load(Archive& archive) {
+	// uses vectors to load edge weights, source vertices, and destination vertices
+	std::vector<BGFLOAT> WVector;
+	std::vector<int> sourceVertexLayoutIndexVector;
+	std::vector<int> destVertexLayoutIndexVector;
 
-   // deserializing data to these vectors
-   archive(WVector, sourceVertexLayoutIndexVector, destVertexLayoutIndexVector);
+	// deserializing data to these vectors
+	archive(WVector, sourceVertexLayoutIndexVector, destVertexLayoutIndexVector);
 
-   // check to see if serialized data sizes matches object sizes
-   if (WVector.size() != maxEdgesPerVertex_ * countVertices_) {
-      std::cerr
-            << "Failed deserializing edge weights, source vertices, and/or destination vertices. Please verify maxEdgesPerVertex and count_neurons data members in AllEdges class."
-            << std::endl;
-      throw cereal::Exception("Deserialization Error");
-   }
+	// check to see if serialized data sizes matches object sizes
+	if (WVector.size() != maxEdgesPerVertex_ * countVertices_) {
+		std::cerr
+			<< "Failed deserializing edge weights, source vertices, and/or destination vertices. Please verify maxEdgesPerVertex and count_neurons data members in AllEdges class."
+			<< std::endl;
+		throw cereal::Exception("Deserialization Error");
+	}
 
-   // assigns serialized data to objects
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      W_[i] = WVector[i];
-      sourceVertexIndex_[i] = sourceVertexLayoutIndexVector[i];
-      destVertexIndex_[i] = destVertexLayoutIndexVector[i];
-   }
+	// assigns serialized data to objects
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		W_[i] = WVector[i];
+		sourceVertexIndex_[i] = sourceVertexLayoutIndexVector[i];
+		destVertexIndex_[i] = destVertexLayoutIndexVector[i];
+	}
 }

--- a/Simulator/Edges/EdgesFactory.cpp
+++ b/Simulator/Edges/EdgesFactory.cpp
@@ -46,8 +46,7 @@ std::shared_ptr<AllEdges> EdgesFactory::createEdges(const std::string& className
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
 AllEdges* EdgesFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Edges/EdgesFactory.cpp
+++ b/Simulator/Edges/EdgesFactory.cpp
@@ -8,49 +8,46 @@
 
 #include "EdgesFactory.h"
 
-#include "AllSpikingSynapses.h"
-#include "AllSTDPSynapses.h"
+#include "All911Edges.h"
 #include "AllDSSynapses.h"
 #include "AllDynamicSTDPSynapses.h"
-#include "All911Edges.h"
+#include "AllSpikingSynapses.h"
+#include "AllSTDPSynapses.h"
 
 /// Constructor is private to keep a singleton instance of this class.
 EdgesFactory::EdgesFactory() {
-   // register neurons classes
-   registerClass("AllSpikingSynapses", &AllSpikingSynapses::Create);
-   registerClass("AllSTDPSynapses", &AllSTDPSynapses::Create);
-   registerClass("AllDSSynapses", &AllDSSynapses::Create);
-   registerClass("AllDynamicSTDPSynapses", &AllDynamicSTDPSynapses::Create);
-   registerClass("All911Edges", &All911Edges::Create);
+	// register neurons classes
+	registerClass("AllSpikingSynapses", &AllSpikingSynapses::Create);
+	registerClass("AllSTDPSynapses", &AllSTDPSynapses::Create);
+	registerClass("AllDSSynapses", &AllDSSynapses::Create);
+	registerClass("AllDynamicSTDPSynapses", &AllDynamicSTDPSynapses::Create);
+	registerClass("All911Edges", &All911Edges::Create);
 }
 
-EdgesFactory::~EdgesFactory() {
-   createFunctions.clear();
-}
+EdgesFactory::~EdgesFactory() { createFunctions.clear(); }
 
 ///  Register edges class and its creation function to the factory.
 ///
 ///  @param  className  neurons class name.
 ///  @param  Pointer to the class creation function.
-void EdgesFactory::registerClass(const std::string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void EdgesFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired neurons class.
-std::shared_ptr<AllEdges> EdgesFactory::createEdges(const std::string &className) {
-   edgesInstance_ = std::shared_ptr<AllEdges>(invokeCreateFunction(className));
-   return edgesInstance_;
+std::shared_ptr<AllEdges> EdgesFactory::createEdges(const std::string& className) {
+	edgesInstance_ = std::shared_ptr<AllEdges>(invokeCreateFunction(className));
+	return edgesInstance_;
 }
 
 /// Create an instance of the edges class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-AllEdges *EdgesFactory::invokeCreateFunction(const std::string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+AllEdges* EdgesFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Edges/EdgesFactory.cpp
+++ b/Simulator/Edges/EdgesFactory.cpp
@@ -32,14 +32,14 @@ EdgesFactory::~EdgesFactory() {
 ///
 ///  @param  className  neurons class name.
 ///  @param  Pointer to the class creation function.
-void EdgesFactory::registerClass(const string &className, CreateFunction function) {
+void EdgesFactory::registerClass(const std::string &className, CreateFunction function) {
    createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired neurons class.
-shared_ptr<AllEdges> EdgesFactory::createEdges(const string &className) {
-   edgesInstance_ = shared_ptr<AllEdges>(invokeCreateFunction(className));
+std::shared_ptr<AllEdges> EdgesFactory::createEdges(const std::string &className) {
+   edgesInstance_ = std::shared_ptr<AllEdges>(invokeCreateFunction(className));
    return edgesInstance_;
 }
 
@@ -47,7 +47,7 @@ shared_ptr<AllEdges> EdgesFactory::createEdges(const string &className) {
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-AllEdges *EdgesFactory::invokeCreateFunction(const string &className) {
+AllEdges *EdgesFactory::invokeCreateFunction(const std::string &className) {
    for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
       if (className == i->first)
          return i->second();

--- a/Simulator/Edges/EdgesFactory.h
+++ b/Simulator/Edges/EdgesFactory.h
@@ -12,45 +12,45 @@
 #include <memory>
 #include <string>
 
-#include "Global.h"
 #include "AllEdges.h"
+#include "Global.h"
 
 class EdgesFactory {
 
-public:
-   ~EdgesFactory();
+	public:
+		~EdgesFactory();
 
-   static EdgesFactory *getInstance() {
-      static EdgesFactory instance;
-      return &instance;
-   }
+		static EdgesFactory* getInstance() {
+			static EdgesFactory instance;
+			return &instance;
+		}
 
-   // Invokes constructor for desired concrete class
-   std::shared_ptr<AllEdges> createEdges(const std::string &className);
+		// Invokes constructor for desired concrete class
+		std::shared_ptr<AllEdges> createEdges(const std::string& className);
 
-   // Delete these methods because they can cause copy instances of the singleton when using threads.
-   EdgesFactory(EdgesFactory const &) = delete;
-   void operator=(EdgesFactory const &) = delete;
+		// Delete these methods because they can cause copy instances of the singleton when using threads.
+		EdgesFactory(const EdgesFactory&) = delete;
+		void operator=(const EdgesFactory&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   EdgesFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		EdgesFactory();
 
-   /// Pointer to edges instance
-   std::shared_ptr<AllEdges> edgesInstance_;
+		/// Pointer to edges instance
+		std::shared_ptr<AllEdges> edgesInstance_;
 
-   /// Defines function type for usage in internal map
-   using CreateFunction =  AllEdges *(*)(void);
+		/// Defines function type for usage in internal map
+		using CreateFunction = AllEdges *(*)(void);
 
-   /// Defines map between class name and corresponding ::Create() function.
-   using EdgesFunctionMap =  std::map<std::string, CreateFunction>;
+		/// Defines map between class name and corresponding ::Create() function.
+		using EdgesFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   EdgesFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		EdgesFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   AllEdges *invokeCreateFunction(const std::string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		AllEdges* invokeCreateFunction(const std::string& className);
 
-   /// Register edges class and it's create function to the factory.
-   void registerClass(const std::string &className, CreateFunction function);
+		/// Register edges class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Simulator/Edges/EdgesFactory.h
+++ b/Simulator/Edges/EdgesFactory.h
@@ -15,8 +15,6 @@
 #include "Global.h"
 #include "AllEdges.h"
 
-using namespace std;
-
 class EdgesFactory {
 
 public:
@@ -28,7 +26,7 @@ public:
    }
 
    // Invokes constructor for desired concrete class
-   shared_ptr<AllEdges> createEdges(const string &className);
+   std::shared_ptr<AllEdges> createEdges(const std::string &className);
 
    // Delete these methods because they can cause copy instances of the singleton when using threads.
    EdgesFactory(EdgesFactory const &) = delete;
@@ -39,20 +37,20 @@ private:
    EdgesFactory();
 
    /// Pointer to edges instance
-   shared_ptr<AllEdges> edgesInstance_;
+   std::shared_ptr<AllEdges> edgesInstance_;
 
    /// Defines function type for usage in internal map
-   typedef AllEdges *(*CreateFunction)(void);
+   using CreateFunction =  AllEdges *(*)(void);
 
    /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> EdgesFunctionMap;
+   using EdgesFunctionMap =  std::map<std::string, CreateFunction>;
 
    /// Makes class-to-function map an internal factory member.
    EdgesFunctionMap createFunctions;
 
    /// Retrieves and invokes correct ::Create() function.
-   AllEdges *invokeCreateFunction(const string &className);
+   AllEdges *invokeCreateFunction(const std::string &className);
 
    /// Register edges class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+   void registerClass(const std::string &className, CreateFunction function);
 };

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -8,59 +8,51 @@
 
 #include "All911Edges.h"
 
-All911Edges::All911Edges() : AllEdges() {
+All911Edges::All911Edges() : AllEdges() {}
 
-}
+All911Edges::All911Edges(const int numVertices, const int maxEdges) {}
 
-All911Edges::All911Edges(const int numVertices, const int maxEdges) {
-
-}
-
-All911Edges::~All911Edges() {
-
-}
+All911Edges::~All911Edges() {}
 
 void All911Edges::setupEdges() {
-   int numVertices = Simulator::getInstance().getTotalVertices();
-   int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
+	int numVertices = Simulator::getInstance().getTotalVertices();
+	int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
 
-   BGSIZE maxTotalEdges = maxEdges * numVertices;
+	BGSIZE maxTotalEdges = maxEdges * numVertices;
 
-   maxEdgesPerVertex_ = maxEdges;
-   totalEdgeCount_ = 0;
-   countVertices_ = numVertices;
+	maxEdgesPerVertex_ = maxEdges;
+	totalEdgeCount_ = 0;
+	countVertices_ = numVertices;
 
-   // To do: Figure out whether we need all of these
-   if (maxTotalEdges != 0) {
-      destVertexIndex_ = new int[maxTotalEdges];
-      W_ = new BGFLOAT[maxTotalEdges];
-      summationPoint_ = new BGFLOAT *[maxTotalEdges];
-      sourceVertexIndex_ = new int[maxTotalEdges];
-      // psr_ = new BGFLOAT[maxTotalEdges];
-      type_ = new edgeType[maxTotalEdges];
-      inUse_ = new bool[maxTotalEdges];
-      edgeCounts_ = new BGSIZE[numVertices];
+	// To do: Figure out whether we need all of these
+	if (maxTotalEdges != 0) {
+		destVertexIndex_ = new int[maxTotalEdges];
+		W_ = new BGFLOAT[maxTotalEdges];
+		summationPoint_ = new BGFLOAT*[maxTotalEdges];
+		sourceVertexIndex_ = new int[maxTotalEdges];
+		// psr_ = new BGFLOAT[maxTotalEdges];
+		type_ = new edgeType[maxTotalEdges];
+		inUse_ = new bool[maxTotalEdges];
+		edgeCounts_ = new BGSIZE[numVertices];
 
-      for (BGSIZE i = 0; i < maxTotalEdges; i++) {
-         summationPoint_[i] = nullptr;
-         inUse_[i] = false;
-         W_[i] = 0;
-      }
+		for (BGSIZE i = 0; i < maxTotalEdges; i++) {
+			summationPoint_[i] = nullptr;
+			inUse_[i] = false;
+			W_[i] = 0;
+		}
 
-      for (int i = 0; i < numVertices; i++) {
-         edgeCounts_[i] = 0;
-      }
-   }
+		for (int i = 0; i < numVertices; i++) edgeCounts_[i] = 0;
+	}
 }
 
-void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) {
-   inUse_[iEdg] = true;
-   summationPoint_[iEdg] = sumPoint;
-   destVertexIndex_[iEdg] = destVertex;
-   sourceVertexIndex_[iEdg] = srcVertex;
-   W_[iEdg] = 10; // Figure this out
-   this->type_[iEdg] = type;
+void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+                             edgeType type) {
+	inUse_[iEdg] = true;
+	summationPoint_[iEdg] = sumPoint;
+	destVertexIndex_[iEdg] = destVertex;
+	sourceVertexIndex_[iEdg] = srcVertex;
+	W_[iEdg] = 10; // Figure this out
+	this->type_[iEdg] = type;
 }
 
 #ifndef __CUDACC__
@@ -69,74 +61,73 @@ void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, B
 ///
 ///  @param  vertices           The vertex list to search from.
 ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-void All911Edges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap) {
-   All911Vertices *allVertices = dynamic_cast<All911Vertices *>(vertices);
-   for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
-      if(!inUse_[i]) {continue;}
-      // if the edge is in use...
-      BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
-      advance911Edge(iEdg, allVertices);
-
-   }
+void All911Edges::advanceEdges(AllVertices* vertices, EdgeIndexMap* edgeIndexMap) {
+	auto allVertices = dynamic_cast<All911Vertices*>(vertices);
+	for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
+		if (!inUse_[i]) continue;
+		// if the edge is in use...
+		BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
+		advance911Edge(iEdg, allVertices);
+	}
 }
 
 ///  Advance one specific edge.
 ///
 ///  @param  iEdg      Index of the edge to connect to.
 ///  @param  vertices   The vertex list to search from.
-void All911Edges::advance911Edge(const BGSIZE iEdg, All911Vertices *vertices) {
-   
-  // edge
-  // source node   -->   destination node 
+void All911Edges::advance911Edge(const BGSIZE iEdg, All911Vertices* vertices) {
 
-   // // is an input in the queue?
-   // bool fPre = isSpikeQueue(iEdg);
-   // bool fPost = isSpikeQueuePost(iEdg);
+	// edge
+	// source node   -->   destination node 
 
-   // if (fPre || fPost) {
+	// // is an input in the queue?
+	// bool fPre = isSpikeQueue(iEdg);
+	// bool fPost = isSpikeQueuePost(iEdg);
 
-   //    BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
+	// if (fPre || fPost) {
 
-   //    // pre and post vertices index
-   //    int idxPre = sourceVertexIndex_[iEdg];
-   //    int idxPost = destVertexIndex_[iEdg];
-   //    uint64_t spikeHistory, spikeHistory2;
-   //    BGFLOAT delta;
-   //    BGFLOAT epre, epost;
+	//    BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
 
-   //    if (fPre) {   // preSpikeHit
-   //       // spikeCount points to the next available position of spike_history,
-   //       // so the getSpikeHistory w/offset = -2 will return the spike time
-   //       // just one before the last spike.
-   //       spikeHistory = allVertices->getSpikeHistory(idxPre, -2);
-   //       if (spikeHistory != ULONG_MAX && useFroemkeDanSTDP_) {
-   //          // delta will include the transmission delay
-   //          delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
-   //          epre = 1.0 - exp(-delta / tauspre_);
-   //       } else {
-   //          epre = 1.0;
-   //       }
+	//    // pre and post vertices index
+	//    int idxPre = sourceVertexIndex_[iEdg];
+	//    int idxPost = destVertexIndex_[iEdg];
+	//    uint64_t spikeHistory, spikeHistory2;
+	//    BGFLOAT delta;
+	//    BGFLOAT epre, epost;
 
-   //    }
+	//    if (fPre) {   // preSpikeHit
+	//       // spikeCount points to the next available position of spike_history,
+	//       // so the getSpikeHistory w/offset = -2 will return the spike time
+	//       // just one before the last spike.
+	//       spikeHistory = allVertices->getSpikeHistory(idxPre, -2);
+	//       if (spikeHistory != ULONG_MAX && useFroemkeDanSTDP_) {
+	//          // delta will include the transmission delay
+	//          delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
+	//          epre = 1.0 - exp(-delta / tauspre_);
+	//       } else {
+	//          epre = 1.0;
+	//       }
 
-   //    if (fPost) {   // postSpikeHit
-   //       // spikeCount points to the next available position of spike_history,
-   //       // so the getSpikeHistory w/offset = -2 will return the spike time
-   //       // just one before the last spike.
-   //       spikeHistory = allVertices->getSpikeHistory(idxPost, -2);
-   //       if (spikeHistory != ULONG_MAX && useFroemkeDanSTDP_) {
-   //          // delta will include the transmission delay
-   //          delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
-   //          epost = 1.0 - exp(-delta / tauspost_);
-   //       } else {
-   //          epost = 1.0;
-   //       }
+	//    }
 
-   //       // call the learning function stdpLearning() for each pair of
-   //       // post-pre spikes
-   //       int offIndex = -1;   // last spike
-   //    }
-   // }
+	//    if (fPost) {   // postSpikeHit
+	//       // spikeCount points to the next available position of spike_history,
+	//       // so the getSpikeHistory w/offset = -2 will return the spike time
+	//       // just one before the last spike.
+	//       spikeHistory = allVertices->getSpikeHistory(idxPost, -2);
+	//       if (spikeHistory != ULONG_MAX && useFroemkeDanSTDP_) {
+	//          // delta will include the transmission delay
+	//          delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
+	//          epost = 1.0 - exp(-delta / tauspost_);
+	//       } else {
+	//          epost = 1.0;
+	//       }
+
+	//       // call the learning function stdpLearning() for each pair of
+	//       // post-pre spikes
+	//       int offIndex = -1;   // last spike
+	//    }
+	// }
 
 }
 

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -63,7 +63,7 @@ void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, B
    this->type_[iEdg] = type;
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Advance all the edges in the simulation.
 ///

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -21,41 +21,40 @@
  */
 #pragma once
 
-#include "AllEdges.h"
 #include "All911Vertices.h"
+#include "AllEdges.h"
 
 
 struct All911EdgeDeviceProperties;
 
 class All911Edges : public AllEdges {
-public:
-   All911Edges();
+	public:
+		All911Edges();
 
-   All911Edges(const int numVertices, const int maxEdges);
+		All911Edges(const int numVertices, const int maxEdges);
 
-   virtual ~All911Edges();
+		~All911Edges() override;
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static AllEdges *Create() { return new All911Edges(); }
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static AllEdges* Create() { return new All911Edges(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Create a Edge and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the edge to set.
-   ///  @param  srcVertex   Coordinates of the source Neuron.
-   ///  @param  destVertex  Coordinates of the destination Neuron.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Edge to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) override;
+		///  Create a Edge and connect it to the model.
+		///
+		///  @param  iEdg        Index of the edge to set.
+		///  @param  srcVertex   Coordinates of the source Neuron.
+		///  @param  destVertex  Coordinates of the destination Neuron.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Edge to create.
+		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		                edgeType type) override;
 
-protected:
-
+	protected:
 #ifdef __CUDACC__
    // GPU functionality for 911 simulation is unimplemented.
    // These signatures are required to make the class non-abstract
@@ -74,22 +73,21 @@ protected:
        virtual void printGPUEdgesProps( void* allEdgesDeviceProps ) const {};
 
 #else
-public:
+	public:
+		///  Advance all the edges in the simulation.
+		///
+		///  @param  vertices           The vertex list to search from.
+		///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
+		void advanceEdges(AllVertices* vertices, EdgeIndexMap* edgeIndexMap) override;
 
-   ///  Advance all the edges in the simulation.
-   ///
-   ///  @param  vertices           The vertex list to search from.
-   ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-   virtual void advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap);
+		///  Advance one specific Edge.
+		///
+		///  @param  iEdg      Index of the Edge to connect to.
+		///  @param  vertices  The Neuron list to search from.
+		void advance911Edge(const BGSIZE iEdg, All911Vertices* vertices);
 
-   ///  Advance one specific Edge.
-   ///
-   ///  @param  iEdg      Index of the Edge to connect to.
-   ///  @param  vertices  The Neuron list to search from.
-   void advance911Edge(const BGSIZE iEdg, All911Vertices *vertices);
-
-   /// unused virtual function placeholder
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *vertices) override {};
+		/// unused virtual function placeholder
+		void advanceEdge(const BGSIZE iEdg, AllVertices* vertices) override {};
 
 #endif
 };

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -31,7 +31,7 @@ class All911Edges : public AllEdges {
 	public:
 		All911Edges();
 
-		All911Edges(const int numVertices, const int maxEdges);
+		All911Edges(int numVertices, int maxEdges);
 
 		~All911Edges() override;
 
@@ -51,7 +51,7 @@ class All911Edges : public AllEdges {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Edge to create.
-		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, BGFLOAT deltaT,
 		                edgeType type) override;
 
 	protected:
@@ -84,7 +84,7 @@ class All911Edges : public AllEdges {
 		///
 		///  @param  iEdg      Index of the Edge to connect to.
 		///  @param  vertices  The Neuron list to search from.
-		void advance911Edge(const BGSIZE iEdg, All911Vertices* vertices);
+		void advance911Edge(BGSIZE iEdg, All911Vertices* vertices);
 
 		/// unused virtual function placeholder
 		void advanceEdge(const BGSIZE iEdg, AllVertices* vertices) override {};

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -56,7 +56,7 @@ public:
 
 protected:
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    // GPU functionality for 911 simulation is unimplemented.
    // These signatures are required to make the class non-abstract
    public:
@@ -73,7 +73,7 @@ protected:
        virtual void setEdgeClassID() {};
        virtual void printGPUEdgesProps( void* allEdgesDeviceProps ) const {};
 
-#else // !defined(USE_GPU)
+#else
 public:
 
    ///  Advance all the edges in the simulation.

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -8,13 +8,7 @@
 
 #include "AllDSSynapses.h"
 
-AllDSSynapses::AllDSSynapses() : AllSpikingSynapses() {
-	lastSpike_ = nullptr;
-	r_ = nullptr;
-	u_ = nullptr;
-	D_ = nullptr;
-	U_ = nullptr;
-	F_ = nullptr;
+AllDSSynapses::AllDSSynapses() : AllSpikingSynapses(), F_(nullptr), U_(nullptr), D_(nullptr), u_(nullptr), r_(nullptr), lastSpike_(nullptr) {
 }
 
 AllDSSynapses::AllDSSynapses(const int numVertices, const int maxEdges) :

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -140,19 +140,19 @@ void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
 	BGFLOAT D;
 	BGFLOAT F;
 	switch (type) {
-		case II: U = 0.32;
+		case edgeType::II: U = 0.32;
 			D = 0.144;
 			F = 0.06;
 			break;
-		case IE: U = 0.25;
+		case edgeType::IE: U = 0.25;
 			D = 0.7;
 			F = 0.02;
 			break;
-		case EI: U = 0.05;
+		case edgeType::EI: U = 0.05;
 			D = 0.125;
 			F = 1.2;
 			break;
-		case EE: U = 0.5;
+		case edgeType::EE: U = 0.5;
 			D = 1.1;
 			F = 0.05;
 			break;
@@ -173,24 +173,24 @@ void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
 ///  @param  iEdg        Index of the synapse to set.
 ///  @param  deltaT      Inner simulation step duration.
 void AllDSSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &W = W_[iEdg];
-   BGFLOAT &decay = decay_[iEdg];
-   uint64_t &lastSpike = lastSpike_[iEdg];
-   BGFLOAT &r = r_[iEdg];
-   BGFLOAT &u = u_[iEdg];
-   BGFLOAT &D = D_[iEdg];
-   BGFLOAT &F = F_[iEdg];
-   BGFLOAT &U = U_[iEdg];
+	BGFLOAT& psr = psr_[iEdg];
+	BGFLOAT& W = W_[iEdg];
+	BGFLOAT& decay = decay_[iEdg];
+	uint64_t& lastSpike = lastSpike_[iEdg];
+	BGFLOAT& r = r_[iEdg];
+	BGFLOAT& u = u_[iEdg];
+	BGFLOAT& D = D_[iEdg];
+	BGFLOAT& F = F_[iEdg];
+	BGFLOAT& U = U_[iEdg];
 
-   // adjust synapse parameters
-   if (lastSpike != ULONG_MAX) {
-      BGFLOAT isi = (g_simulationStep - lastSpike) * deltaT;
-      r = 1 + (r * (1 - u) - 1) * exp(-isi / D);
-      u = U + u * (1 - U) * exp(-isi / F);
-   }
-   psr += ((W / decay) * u * r);    // calculate psr
-   lastSpike = g_simulationStep;        // record the time of the spike
+	// adjust synapse parameters
+	if (lastSpike != ULONG_MAX) {
+		BGFLOAT isi = (g_simulationStep - lastSpike) * deltaT;
+		r = 1 + (r * (1 - u) - 1) * exp(-isi / D);
+		u = U + u * (1 - U) * exp(-isi / F);
+	}
+	psr += ((W / decay) * u * r); // calculate psr
+	lastSpike = g_simulationStep; // record the time of the spike
 }
 
 #endif

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -71,15 +71,15 @@ void AllDSSynapses::setupEdges(const int numVertices, const int maxEdges) {
 void AllDSSynapses::printParameters() const {
    AllSpikingSynapses::printParameters();
 
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllDSSynapses Parameters---" << endl
-                                          << "\tEdges type: AllDSSynapses" << endl << endl);
+   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllDSSynapses Parameters---" << std::endl
+                                          << "\tEdges type: AllDSSynapses" << std::endl << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllDSSynapses::readEdge(istream &input, const BGSIZE iEdg) {
+void AllDSSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
    AllSpikingSynapses::readEdge(input, iEdg);
 
    // input.ignore() so input skips over end-of-line characters.
@@ -101,15 +101,15 @@ void AllDSSynapses::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllDSSynapses::writeEdge(ostream &output, const BGSIZE iEdg) const {
+void AllDSSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
    AllSpikingSynapses::writeEdge(output, iEdg);
 
-   output << lastSpike_[iEdg] << ends;
-   output << r_[iEdg] << ends;
-   output << u_[iEdg] << ends;
-   output << D_[iEdg] << ends;
-   output << U_[iEdg] << ends;
-   output << F_[iEdg] << ends;
+   output << lastSpike_[iEdg] << std::ends;
+   output << r_[iEdg] << std::ends;
+   output << u_[iEdg] << std::ends;
+   output << D_[iEdg] << std::ends;
+   output << U_[iEdg] << std::ends;
+   output << F_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -172,7 +172,7 @@ void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
    F_[iEdg] = F;
 }
 
-#if !defined(USE_GPU)
+#ifdef __CUDACC__
 
 ///  Calculate the post synapse response after a spike.
 ///
@@ -199,20 +199,20 @@ void AllDSSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
    lastSpike = g_simulationStep;        // record the time of the spike
 }
 
-#endif // !defined(USE_GPU)
+#endif
 
 ///  Prints SynapsesProps data to console.
 void AllDSSynapses::printSynapsesProps() const {
    AllSpikingSynapses::printSynapsesProps();
    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
       if (W_[i] != 0.0) {
-         cout << "lastSpike[" << i << "] = " << lastSpike_[i];
-         cout << " r: " << r_[i];
-         cout << " u: " << u_[i];
-         cout << " D: " << D_[i];
-         cout << " U: " << U_[i];
-         cout << " F: " << F_[i] << endl;
+         std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
+         std::cout << " r: " << r_[i];
+         std::cout << " u: " << u_[i];
+         std::cout << " D: " << D_[i];
+         std::cout << " U: " << U_[i];
+         std::cout << " F: " << F_[i] << std::endl;
       }
    }
-   cout << endl;
+   std::cout << std::endl;
 }

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -9,42 +9,40 @@
 #include "AllDSSynapses.h"
 
 AllDSSynapses::AllDSSynapses() : AllSpikingSynapses() {
-   lastSpike_ = nullptr;
-   r_ = nullptr;
-   u_ = nullptr;
-   D_ = nullptr;
-   U_ = nullptr;
-   F_ = nullptr;
+	lastSpike_ = nullptr;
+	r_ = nullptr;
+	u_ = nullptr;
+	D_ = nullptr;
+	U_ = nullptr;
+	F_ = nullptr;
 }
 
 AllDSSynapses::AllDSSynapses(const int numVertices, const int maxEdges) :
-      AllSpikingSynapses(numVertices, maxEdges) {
-   setupEdges(numVertices, maxEdges);
-}
+	AllSpikingSynapses(numVertices, maxEdges) { setupEdges(numVertices, maxEdges); }
 
 AllDSSynapses::~AllDSSynapses() {
-   BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
+	BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
 
-   if (maxTotalSynapses != 0) {
-      delete[] lastSpike_;
-      delete[] r_;
-      delete[] u_;
-      delete[] D_;
-      delete[] U_;
-      delete[] F_;
-   }
+	if (maxTotalSynapses != 0) {
+		delete[] lastSpike_;
+		delete[] r_;
+		delete[] u_;
+		delete[] D_;
+		delete[] U_;
+		delete[] F_;
+	}
 
-   lastSpike_ = nullptr;
-   r_ = nullptr;
-   u_ = nullptr;
-   D_ = nullptr;
-   U_ = nullptr;
-   F_ = nullptr;
+	lastSpike_ = nullptr;
+	r_ = nullptr;
+	u_ = nullptr;
+	D_ = nullptr;
+	U_ = nullptr;
+	F_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllDSSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+	setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -52,64 +50,64 @@ void AllDSSynapses::setupEdges() {
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
 void AllDSSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllSpikingSynapses::setupEdges(numVertices, maxEdges);
+	AllSpikingSynapses::setupEdges(numVertices, maxEdges);
 
-   BGSIZE maxTotalSynapses = maxEdges * numVertices;
+	BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
-   if (maxTotalSynapses != 0) {
-      lastSpike_ = new uint64_t[maxTotalSynapses];
-      r_ = new BGFLOAT[maxTotalSynapses];
-      u_ = new BGFLOAT[maxTotalSynapses];
-      D_ = new BGFLOAT[maxTotalSynapses];
-      U_ = new BGFLOAT[maxTotalSynapses];
-      F_ = new BGFLOAT[maxTotalSynapses];
-   }
+	if (maxTotalSynapses != 0) {
+		lastSpike_ = new uint64_t[maxTotalSynapses];
+		r_ = new BGFLOAT[maxTotalSynapses];
+		u_ = new BGFLOAT[maxTotalSynapses];
+		D_ = new BGFLOAT[maxTotalSynapses];
+		U_ = new BGFLOAT[maxTotalSynapses];
+		F_ = new BGFLOAT[maxTotalSynapses];
+	}
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllDSSynapses::printParameters() const {
-   AllSpikingSynapses::printParameters();
+	AllSpikingSynapses::printParameters();
 
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllDSSynapses Parameters---" << std::endl
-                                          << "\tEdges type: AllDSSynapses" << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllDSSynapses Parameters---" << std::endl
+	                << "\tEdges type: AllDSSynapses" << std::endl << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllDSSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
-   AllSpikingSynapses::readEdge(input, iEdg);
+void AllDSSynapses::readEdge(std::istream& input, const BGSIZE iEdg) {
+	AllSpikingSynapses::readEdge(input, iEdg);
 
-   // input.ignore() so input skips over end-of-line characters.
-   input >> lastSpike_[iEdg];
-   input.ignore();
-   input >> r_[iEdg];
-   input.ignore();
-   input >> u_[iEdg];
-   input.ignore();
-   input >> D_[iEdg];
-   input.ignore();
-   input >> U_[iEdg];
-   input.ignore();
-   input >> F_[iEdg];
-   input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> lastSpike_[iEdg];
+	input.ignore();
+	input >> r_[iEdg];
+	input.ignore();
+	input >> u_[iEdg];
+	input.ignore();
+	input >> D_[iEdg];
+	input.ignore();
+	input >> U_[iEdg];
+	input.ignore();
+	input >> F_[iEdg];
+	input.ignore();
 }
 
 ///  Write the synapse data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllDSSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-   AllSpikingSynapses::writeEdge(output, iEdg);
+void AllDSSynapses::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	AllSpikingSynapses::writeEdge(output, iEdg);
 
-   output << lastSpike_[iEdg] << std::ends;
-   output << r_[iEdg] << std::ends;
-   output << u_[iEdg] << std::ends;
-   output << D_[iEdg] << std::ends;
-   output << U_[iEdg] << std::ends;
-   output << F_[iEdg] << std::ends;
+	output << lastSpike_[iEdg] << std::ends;
+	output << r_[iEdg] << std::ends;
+	output << u_[iEdg] << std::ends;
+	output << D_[iEdg] << std::ends;
+	output << U_[iEdg] << std::ends;
+	output << F_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -117,11 +115,11 @@ void AllDSSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
 ///  @param  iEdg            Index of the synapse to set.
 ///  @param  deltaT          Inner simulation step duration
 void AllDSSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   AllSpikingSynapses::resetEdge(iEdg, deltaT);
+	AllSpikingSynapses::resetEdge(iEdg, deltaT);
 
-   u_[iEdg] = DEFAULT_U;
-   r_[iEdg] = 1.0;
-   lastSpike_[iEdg] = ULONG_MAX;
+	u_[iEdg] = DEFAULT_U;
+	r_[iEdg] = 1.0;
+	lastSpike_[iEdg] = ULONG_MAX;
 }
 
 ///  Create a Synapse and connect it to the model.
@@ -132,47 +130,43 @@ void AllDSSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
 ///  @param  sumPoint   Summation point address.
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
-void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
-                                  const BGFLOAT deltaT, edgeType type) {
-   AllSpikingSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
+void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+                               const BGFLOAT deltaT, edgeType type) {
+	AllSpikingSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
 
-   U_[iEdg] = DEFAULT_U;
+	U_[iEdg] = DEFAULT_U;
 
-   BGFLOAT U;
-   BGFLOAT D;
-   BGFLOAT F;
-   switch (type) {
-      case II:
-         U = 0.32;
-         D = 0.144;
-         F = 0.06;
-         break;
-      case IE:
-         U = 0.25;
-         D = 0.7;
-         F = 0.02;
-         break;
-      case EI:
-         U = 0.05;
-         D = 0.125;
-         F = 1.2;
-         break;
-      case EE:
-         U = 0.5;
-         D = 1.1;
-         F = 0.05;
-         break;
-      default:
-         assert(false);
-         break;
-   }
+	BGFLOAT U;
+	BGFLOAT D;
+	BGFLOAT F;
+	switch (type) {
+		case II: U = 0.32;
+			D = 0.144;
+			F = 0.06;
+			break;
+		case IE: U = 0.25;
+			D = 0.7;
+			F = 0.02;
+			break;
+		case EI: U = 0.05;
+			D = 0.125;
+			F = 1.2;
+			break;
+		case EE: U = 0.5;
+			D = 1.1;
+			F = 0.05;
+			break;
+		default:
+			assert(false);
+			break;
+	}
 
-   U_[iEdg] = U;
-   D_[iEdg] = D;
-   F_[iEdg] = F;
+	U_[iEdg] = U;
+	D_[iEdg] = D;
+	F_[iEdg] = F;
 }
 
-#ifdef __CUDACC__
+#ifndef __CUDACC__
 
 ///  Calculate the post synapse response after a spike.
 ///
@@ -203,16 +197,16 @@ void AllDSSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
 
 ///  Prints SynapsesProps data to console.
 void AllDSSynapses::printSynapsesProps() const {
-   AllSpikingSynapses::printSynapsesProps();
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      if (W_[i] != 0.0) {
-         std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
-         std::cout << " r: " << r_[i];
-         std::cout << " u: " << u_[i];
-         std::cout << " D: " << D_[i];
-         std::cout << " U: " << U_[i];
-         std::cout << " F: " << F_[i] << std::endl;
-      }
-   }
-   std::cout << std::endl;
+	AllSpikingSynapses::printSynapsesProps();
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		if (W_[i] != 0.0) {
+			std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
+			std::cout << " r: " << r_[i];
+			std::cout << " u: " << u_[i];
+			std::cout << " D: " << D_[i];
+			std::cout << " U: " << U_[i];
+			std::cout << " F: " << F_[i] << std::endl;
+		}
+	}
+	std::cout << std::endl;
 }

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -51,60 +51,60 @@
 struct AllDSSynapsesDeviceProperties;
 
 class AllDSSynapses : public AllSpikingSynapses {
-public:
-   AllDSSynapses();
+	public:
+		AllDSSynapses();
 
-   AllDSSynapses(const int numVertices, const int maxEdges);
+		AllDSSynapses(const int numVertices, const int maxEdges);
 
-   virtual ~AllDSSynapses();
+		~AllDSSynapses() override;
 
-   static AllEdges *Create() { return new AllDSSynapses(); }
+		static AllEdges* Create() { return new AllDSSynapses(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Reset time varying state vars and recompute decay.
-   ///
-   ///  @param  iEdg     Index of the synapse to set.
-   ///  @param  deltaT   Inner simulation step duration
-   virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		///  Reset time varying state vars and recompute decay.
+		///
+		///  @param  iEdg     Index of the synapse to set.
+		///  @param  deltaT   Inner simulation step duration
+		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Create a Synapse and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  srcVertex     Coordinates of the source Neuron.
-   ///  @param  destVertex        Coordinates of the destination Neuron.
-   ///  @param  sumPoint   Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) override;
+		///  Create a Synapse and connect it to the model.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  srcVertex     Coordinates of the source Neuron.
+		///  @param  destVertex        Coordinates of the destination Neuron.
+		///  @param  sumPoint   Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Synapse to create.
+		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		                edgeType type) override;
 
-   ///  Prints SynapsesProps data to console.
-   virtual void printSynapsesProps() const override;
+		///  Prints SynapsesProps data to console.
+		void printSynapsesProps() const override;
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges) override;
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of synapses per neuron.
+		void setupEdges(const int numVertices, const int maxEdges) override;
 
-   ///  Sets the data for Synapse to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
+		///  Sets the data for Synapse to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the synapse to set.
+		void readEdge(std::istream& input, const BGSIZE iEdg) override;
 
-   ///  Write the synapse data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
+		///  Write the synapse data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the synapse to print out.
+		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -190,33 +190,32 @@ protected:
        ///  @param  allEdgesDeviceProps  GPU address of the allEdges struct on device memory.
        void copyDeviceToHost( AllDSSynapsesDeviceProperties& allEdgesDeviceProps);
 #else
-protected:
-   ///  Calculate the post synapse response after a spike.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  deltaT      Inner simulation step duration.
-   virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+	protected:
+		///  Calculate the post synapse response after a spike.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  deltaT      Inner simulation step duration.
+		void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
 #endif
-public:
+	public:
+		///  The time of the last spike.
+		uint64_t* lastSpike_;
 
-   ///  The time of the last spike.
-   uint64_t *lastSpike_;
+		///  The time varying state variable \f$r\f$ for depression.
+		BGFLOAT* r_;
 
-   ///  The time varying state variable \f$r\f$ for depression.
-   BGFLOAT *r_;
+		///  The time varying state variable \f$u\f$ for facilitation.
+		BGFLOAT* u_;
 
-   ///  The time varying state variable \f$u\f$ for facilitation.
-   BGFLOAT *u_;
+		///  The time constant of the depression of the dynamic synapse [range=(0,10); units=sec].
+		BGFLOAT* D_;
 
-   ///  The time constant of the depression of the dynamic synapse [range=(0,10); units=sec].
-   BGFLOAT *D_;
+		///  The use parameter of the dynamic synapse [range=(1e-5,1)].
+		BGFLOAT* U_;
 
-   ///  The use parameter of the dynamic synapse [range=(1e-5,1)].
-   BGFLOAT *U_;
-
-   ///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
-   BGFLOAT *F_;
+		///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
+		BGFLOAT* F_;
 };
 
 #ifdef __CUDACC__
@@ -241,4 +240,3 @@ struct AllDSSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperties
         BGFLOAT *F_;
 };
 #endif
-

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -98,15 +98,15 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg) override;
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
 
    ///  Write the synapse data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const override;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all synapses' states,
        ///  and copy them from host to GPU memory.
@@ -189,7 +189,7 @@ protected:
        ///
        ///  @param  allEdgesDeviceProps  GPU address of the allEdges struct on device memory.
        void copyDeviceToHost( AllDSSynapsesDeviceProperties& allEdgesDeviceProps);
-#else // !defined(USE_GPU)
+#else
 protected:
    ///  Calculate the post synapse response after a spike.
    ///
@@ -197,7 +197,7 @@ protected:
    ///  @param  deltaT      Inner simulation step duration.
    virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-#endif // defined(USE_GPU)
+#endif
 public:
 
    ///  The time of the last spike.
@@ -219,7 +219,7 @@ public:
    BGFLOAT *F_;
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllDSSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperties
 {
         ///  The time of the last spike.
@@ -240,5 +240,5 @@ struct AllDSSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperties
         ///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
         BGFLOAT *F_;
 };
-#endif // defined(USE_GPU)
+#endif
 

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -54,7 +54,7 @@ class AllDSSynapses : public AllSpikingSynapses {
 	public:
 		AllDSSynapses();
 
-		AllDSSynapses(const int numVertices, const int maxEdges);
+		AllDSSynapses(int numVertices, int maxEdges);
 
 		~AllDSSynapses() override;
 
@@ -67,7 +67,7 @@ class AllDSSynapses : public AllSpikingSynapses {
 		///
 		///  @param  iEdg     Index of the synapse to set.
 		///  @param  deltaT   Inner simulation step duration
-		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void resetEdge(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 		///  Prints out all parameters to logging file.
 		///  Registered to OperationManager as Operation::printParameters
@@ -81,7 +81,7 @@ class AllDSSynapses : public AllSpikingSynapses {
 		///  @param  sumPoint   Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Synapse to create.
-		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, BGFLOAT deltaT,
 		                edgeType type) override;
 
 		///  Prints SynapsesProps data to console.
@@ -92,19 +92,19 @@ class AllDSSynapses : public AllSpikingSynapses {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of synapses per neuron.
-		void setupEdges(const int numVertices, const int maxEdges) override;
+		void setupEdges(int numVertices, int maxEdges) override;
 
 		///  Sets the data for Synapse to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the synapse to set.
-		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+		void readEdge(std::istream& input, BGSIZE iEdg) override;
 
 		///  Write the synapse data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the synapse to print out.
-		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+		void writeEdge(std::ostream& output, BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -195,7 +195,7 @@ class AllDSSynapses : public AllSpikingSynapses {
 		///
 		///  @param  iEdg        Index of the synapse to set.
 		///  @param  deltaT      Inner simulation step duration.
-		void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void changePSR(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 #endif
 	public:

--- a/Simulator/Edges/Neuro/AllDSSynapses_d.cu
+++ b/Simulator/Edges/Neuro/AllDSSynapses_d.cu
@@ -174,7 +174,7 @@ void AllDSSynapses::copyDeviceToHost( AllDSSynapsesDeviceProperties& allEdgesDev
         HANDLE_ERROR( cudaMemcpy ( F_, allEdgesDeviceProps.F_,
                 maxTotalSynapses * sizeof( BGFLOAT ), cudaMemcpyDeviceToHost ) );
 }
-    
+
 ///  Set synapse class ID defined by enumClassSynapses for the caller's Synapse class.
 ///  The class ID will be set to classSynapses_d in device memory,
 ///  and the classSynapses_d will be referred to call a device function for the

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -140,19 +140,19 @@ void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int de
 	BGFLOAT D;
 	BGFLOAT F;
 	switch (type) {
-		case II: U = 0.32;
+		case edgeType::II: U = 0.32;
 			D = 0.144;
 			F = 0.06;
 			break;
-		case IE: U = 0.25;
+		case edgeType::IE: U = 0.25;
 			D = 0.7;
 			F = 0.02;
 			break;
-		case EI: U = 0.05;
+		case edgeType::EI: U = 0.05;
 			D = 0.125;
 			F = 1.2;
 			break;
-		case EE: U = 0.5;
+		case edgeType::EE: U = 0.5;
 			D = 1.1;
 			F = 0.05;
 			break;

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -9,42 +9,40 @@
 #include "AllDynamicSTDPSynapses.h"
 
 AllDynamicSTDPSynapses::AllDynamicSTDPSynapses() : AllSTDPSynapses() {
-    lastSpike_ = nullptr;
-    r_ = nullptr;
-    u_ = nullptr;
-    D_ = nullptr;
-    U_ = nullptr;
-    F_ = nullptr;
+	lastSpike_ = nullptr;
+	r_ = nullptr;
+	u_ = nullptr;
+	D_ = nullptr;
+	U_ = nullptr;
+	F_ = nullptr;
 }
 
 AllDynamicSTDPSynapses::AllDynamicSTDPSynapses(const int numVertices, const int maxEdges) :
-      AllSTDPSynapses(numVertices, maxEdges) {
-    setupEdges(numVertices, maxEdges);
-}
+	AllSTDPSynapses(numVertices, maxEdges) { setupEdges(numVertices, maxEdges); }
 
 AllDynamicSTDPSynapses::~AllDynamicSTDPSynapses() {
-    BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
+	BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
 
-    if (maxTotalSynapses != 0) {
-        delete[] lastSpike_;
-        delete[] r_;
-        delete[] u_;
-        delete[] D_;
-        delete[] U_;
-        delete[] F_;
-    }
+	if (maxTotalSynapses != 0) {
+		delete[] lastSpike_;
+		delete[] r_;
+		delete[] u_;
+		delete[] D_;
+		delete[] U_;
+		delete[] F_;
+	}
 
-    lastSpike_ = nullptr;
-    r_ = nullptr;
-    u_ = nullptr;
-    D_ = nullptr;
-    U_ = nullptr;
-    F_ = nullptr;
+	lastSpike_ = nullptr;
+	r_ = nullptr;
+	u_ = nullptr;
+	D_ = nullptr;
+	U_ = nullptr;
+	F_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllDynamicSTDPSynapses::setupEdges() {
-    setupEdges(Simulator::getInstance().getDeltaT(), Simulator::getInstance().getMaxEdgesPerVertex());
+	setupEdges(Simulator::getInstance().getDeltaT(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -52,64 +50,64 @@ void AllDynamicSTDPSynapses::setupEdges() {
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
 void AllDynamicSTDPSynapses::setupEdges(const int numVertices, const int maxEdges) {
-    AllSTDPSynapses::setupEdges(numVertices, maxEdges);
+	AllSTDPSynapses::setupEdges(numVertices, maxEdges);
 
-    BGSIZE maxTotalSynapses = maxEdges * numVertices;
+	BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
-    if (maxTotalSynapses != 0) {
-        lastSpike_ = new uint64_t[maxTotalSynapses];
-        r_ = new BGFLOAT[maxTotalSynapses];
-        u_ = new BGFLOAT[maxTotalSynapses];
-        D_ = new BGFLOAT[maxTotalSynapses];
-        U_ = new BGFLOAT[maxTotalSynapses];
-        F_ = new BGFLOAT[maxTotalSynapses];
-    }
+	if (maxTotalSynapses != 0) {
+		lastSpike_ = new uint64_t[maxTotalSynapses];
+		r_ = new BGFLOAT[maxTotalSynapses];
+		u_ = new BGFLOAT[maxTotalSynapses];
+		D_ = new BGFLOAT[maxTotalSynapses];
+		U_ = new BGFLOAT[maxTotalSynapses];
+		F_ = new BGFLOAT[maxTotalSynapses];
+	}
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllDynamicSTDPSynapses::printParameters() const {
-   AllSTDPSynapses::printParameters();
+	AllSTDPSynapses::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDynamicSTDPSynapses Parameters---" << std::endl
-   << "\tEdges type: AllDynamicSTDPSynapses" << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDynamicSTDPSynapses Parameters---" << std::endl
+	                << "\tEdges type: AllDynamicSTDPSynapses" << std::endl << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllDynamicSTDPSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
-    AllSTDPSynapses::readEdge(input, iEdg);
+void AllDynamicSTDPSynapses::readEdge(std::istream& input, const BGSIZE iEdg) {
+	AllSTDPSynapses::readEdge(input, iEdg);
 
-    // input.ignore() so input skips over end-of-line characters.
-    input >> lastSpike_[iEdg];
-    input.ignore();
-    input >> r_[iEdg];
-    input.ignore();
-    input >> u_[iEdg];
-    input.ignore();
-    input >> D_[iEdg];
-    input.ignore();
-    input >> U_[iEdg];
-    input.ignore();
-    input >> F_[iEdg];
-    input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> lastSpike_[iEdg];
+	input.ignore();
+	input >> r_[iEdg];
+	input.ignore();
+	input >> u_[iEdg];
+	input.ignore();
+	input >> D_[iEdg];
+	input.ignore();
+	input >> U_[iEdg];
+	input.ignore();
+	input >> F_[iEdg];
+	input.ignore();
 }
 
 ///  Write the synapse data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllDynamicSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-    AllSTDPSynapses::writeEdge(output, iEdg);
+void AllDynamicSTDPSynapses::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	AllSTDPSynapses::writeEdge(output, iEdg);
 
-    output << lastSpike_[iEdg] << std::ends;
-    output << r_[iEdg] << std::ends;
-    output << u_[iEdg] << std::ends;
-    output << D_[iEdg] << std::ends;
-    output << U_[iEdg] << std::ends;
-    output << F_[iEdg] << std::ends;
+	output << lastSpike_[iEdg] << std::ends;
+	output << r_[iEdg] << std::ends;
+	output << u_[iEdg] << std::ends;
+	output << D_[iEdg] << std::ends;
+	output << U_[iEdg] << std::ends;
+	output << F_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -117,11 +115,11 @@ void AllDynamicSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) 
 ///  @param  iEdg            Index of the synapse to set.
 ///  @param  deltaT          Inner simulation step duration
 void AllDynamicSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
-    AllSTDPSynapses::resetEdge(iEdg, deltaT);
+	AllSTDPSynapses::resetEdge(iEdg, deltaT);
 
-    u_[iEdg] = DEFAULT_U;
-    r_[iEdg] = 1.0;
-    lastSpike_[iEdg] = ULONG_MAX;
+	u_[iEdg] = DEFAULT_U;
+	r_[iEdg] = 1.0;
+	lastSpike_[iEdg] = ULONG_MAX;
 }
 
 ///  Create a Synapse and connect it to the model.
@@ -132,44 +130,40 @@ void AllDynamicSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) 
 ///  @param  sumPoint    Summation point address.
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
-void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
-                                           const BGFLOAT deltaT, edgeType type) {
-    AllSTDPSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
+void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+                                        const BGFLOAT deltaT, edgeType type) {
+	AllSTDPSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
 
-    U_[iEdg] = DEFAULT_U;
+	U_[iEdg] = DEFAULT_U;
 
-    BGFLOAT U;
-    BGFLOAT D;
-    BGFLOAT F;
-    switch (type) {
-        case II:
-            U = 0.32;
-            D = 0.144;
-            F = 0.06;
-            break;
-        case IE:
-            U = 0.25;
-            D = 0.7;
-            F = 0.02;
-            break;
-        case EI:
-            U = 0.05;
-            D = 0.125;
-            F = 1.2;
-            break;
-        case EE:
-            U = 0.5;
-            D = 1.1;
-            F = 0.05;
-            break;
-        default:
-            assert(false);
-            break;
-    }
+	BGFLOAT U;
+	BGFLOAT D;
+	BGFLOAT F;
+	switch (type) {
+		case II: U = 0.32;
+			D = 0.144;
+			F = 0.06;
+			break;
+		case IE: U = 0.25;
+			D = 0.7;
+			F = 0.02;
+			break;
+		case EI: U = 0.05;
+			D = 0.125;
+			F = 1.2;
+			break;
+		case EE: U = 0.5;
+			D = 1.1;
+			F = 0.05;
+			break;
+		default:
+			assert(false);
+			break;
+	}
 
-    this->U_[iEdg] = U;
-    this->D_[iEdg] = D;
-    this->F_[iEdg] = F;
+	this->U_[iEdg] = U;
+	this->D_[iEdg] = D;
+	this->F_[iEdg] = F;
 }
 
 #ifndef __CUDACC__
@@ -179,40 +173,39 @@ void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int de
 ///  @param  iEdg        Index of the synapse to set.
 ///  @param  deltaT      Inner simulation step duration.
 void AllDynamicSTDPSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
-    BGFLOAT &psr = this->psr_[iEdg];
-    BGFLOAT &W = this->W_[iEdg];
-    BGFLOAT &decay = this->decay_[iEdg];
-    uint64_t &lastSpike = this->lastSpike_[iEdg];
-    BGFLOAT &r = this->r_[iEdg];
-    BGFLOAT &u = this->u_[iEdg];
-    BGFLOAT &D = this->D_[iEdg];
-    BGFLOAT &F = this->F_[iEdg];
-    BGFLOAT &U = this->U_[iEdg];
+	BGFLOAT& psr = this->psr_[iEdg];
+	BGFLOAT& W = this->W_[iEdg];
+	BGFLOAT& decay = this->decay_[iEdg];
+	uint64_t& lastSpike = this->lastSpike_[iEdg];
+	BGFLOAT& r = this->r_[iEdg];
+	BGFLOAT& u = this->u_[iEdg];
+	BGFLOAT& D = this->D_[iEdg];
+	BGFLOAT& F = this->F_[iEdg];
+	BGFLOAT& U = this->U_[iEdg];
 
-    // adjust synapse parameters
-    if (lastSpike != ULONG_MAX) {
-        BGFLOAT isi = (g_simulationStep - lastSpike) * deltaT;
-        r = 1 + (r * (1 - u) - 1) * exp(-isi / D);
-        u = U + u * (1 - U) * exp(-isi / F);
-    }
-    psr += ((W / decay) * u * r);    // calculate psr
-    lastSpike = g_simulationStep;        // record the time of the spike
+	// adjust synapse parameters
+	if (lastSpike != ULONG_MAX) {
+		BGFLOAT isi = (g_simulationStep - lastSpike) * deltaT;
+		r = 1 + (r * (1 - u) - 1) * exp(-isi / D);
+		u = U + u * (1 - U) * exp(-isi / F);
+	}
+	psr += ((W / decay) * u * r); // calculate psr
+	lastSpike = g_simulationStep; // record the time of the spike
 }
 
-#endif // !defined(USE_GPU)
+#endif // !defined(__CUDACC__)
 
 ///  Prints SynapsesProps data.
 void AllDynamicSTDPSynapses::printSynapsesProps() const {
-    AllSTDPSynapses::printSynapsesProps();
-    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-        if (W_[i] != 0.0) {
-            std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
-            std::cout << " r: " << r_[i];
-            std::cout << " u: " << u_[i];
-            std::cout << " D: " << D_[i];
-            std::cout << " U: " << U_[i];
-            std::cout << " F: " << F_[i] << std::endl;
-        }
-    }
+	AllSTDPSynapses::printSynapsesProps();
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		if (W_[i] != 0.0) {
+			std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
+			std::cout << " r: " << r_[i];
+			std::cout << " u: " << u_[i];
+			std::cout << " D: " << D_[i];
+			std::cout << " U: " << U_[i];
+			std::cout << " F: " << F_[i] << std::endl;
+		}
+	}
 }
-

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -8,13 +8,7 @@
 
 #include "AllDynamicSTDPSynapses.h"
 
-AllDynamicSTDPSynapses::AllDynamicSTDPSynapses() : AllSTDPSynapses() {
-	lastSpike_ = nullptr;
-	r_ = nullptr;
-	u_ = nullptr;
-	D_ = nullptr;
-	U_ = nullptr;
-	F_ = nullptr;
+AllDynamicSTDPSynapses::AllDynamicSTDPSynapses() : AllSTDPSynapses(), F_(nullptr), U_(nullptr), D_(nullptr), u_(nullptr), r_(nullptr), lastSpike_(nullptr) {
 }
 
 AllDynamicSTDPSynapses::AllDynamicSTDPSynapses(const int numVertices, const int maxEdges) :

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -71,15 +71,15 @@ void AllDynamicSTDPSynapses::setupEdges(const int numVertices, const int maxEdge
 void AllDynamicSTDPSynapses::printParameters() const {
    AllSTDPSynapses::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDynamicSTDPSynapses Parameters---" << endl
-   << "\tEdges type: AllDynamicSTDPSynapses" << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\t---AllDynamicSTDPSynapses Parameters---" << std::endl
+   << "\tEdges type: AllDynamicSTDPSynapses" << std::endl << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllDynamicSTDPSynapses::readEdge(istream &input, const BGSIZE iEdg) {
+void AllDynamicSTDPSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
     AllSTDPSynapses::readEdge(input, iEdg);
 
     // input.ignore() so input skips over end-of-line characters.
@@ -101,15 +101,15 @@ void AllDynamicSTDPSynapses::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllDynamicSTDPSynapses::writeEdge(ostream &output, const BGSIZE iEdg) const {
+void AllDynamicSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
     AllSTDPSynapses::writeEdge(output, iEdg);
 
-    output << lastSpike_[iEdg] << ends;
-    output << r_[iEdg] << ends;
-    output << u_[iEdg] << ends;
-    output << D_[iEdg] << ends;
-    output << U_[iEdg] << ends;
-    output << F_[iEdg] << ends;
+    output << lastSpike_[iEdg] << std::ends;
+    output << r_[iEdg] << std::ends;
+    output << u_[iEdg] << std::ends;
+    output << D_[iEdg] << std::ends;
+    output << U_[iEdg] << std::ends;
+    output << F_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -172,7 +172,7 @@ void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int de
     this->F_[iEdg] = F;
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Calculate the post synapse response after a spike.
 ///
@@ -206,12 +206,12 @@ void AllDynamicSTDPSynapses::printSynapsesProps() const {
     AllSTDPSynapses::printSynapsesProps();
     for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
         if (W_[i] != 0.0) {
-            cout << "lastSpike[" << i << "] = " << lastSpike_[i];
-            cout << " r: " << r_[i];
-            cout << " u: " << u_[i];
-            cout << " D: " << D_[i];
-            cout << " U: " << U_[i];
-            cout << " F: " << F_[i] << endl;
+            std::cout << "lastSpike[" << i << "] = " << lastSpike_[i];
+            std::cout << " r: " << r_[i];
+            std::cout << " u: " << u_[i];
+            std::cout << " D: " << D_[i];
+            std::cout << " U: " << U_[i];
+            std::cout << " F: " << F_[i] << std::endl;
         }
     }
 }

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -57,60 +57,60 @@
 struct AllDynamicSTDPSynapsesDeviceProperties;
 
 class AllDynamicSTDPSynapses : public AllSTDPSynapses {
-public:
-   AllDynamicSTDPSynapses();
+	public:
+		AllDynamicSTDPSynapses();
 
-   AllDynamicSTDPSynapses(const int numVertices, const int maxEdges);
+		AllDynamicSTDPSynapses(const int numVertices, const int maxEdges);
 
-   virtual ~AllDynamicSTDPSynapses();
+		~AllDynamicSTDPSynapses() override;
 
-   static AllEdges *Create() { return new AllDynamicSTDPSynapses(); }
+		static AllEdges* Create() { return new AllDynamicSTDPSynapses(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Reset time varying state vars and recompute decay.
-   ///
-   ///  @param  iEdg     Index of the synapse to set.
-   ///  @param  deltaT   Inner simulation step duration
-   virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		///  Reset time varying state vars and recompute decay.
+		///
+		///  @param  iEdg     Index of the synapse to set.
+		///  @param  deltaT   Inner simulation step duration
+		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Create a Synapse and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  srcVertex   Coordinates of the source Neuron.
-   ///  @param  destVertex  Coordinates of the destination Neuron.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) override;
+		///  Create a Synapse and connect it to the model.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  srcVertex   Coordinates of the source Neuron.
+		///  @param  destVertex  Coordinates of the destination Neuron.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Synapse to create.
+		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		                edgeType type) override;
 
-   ///  Prints SynapsesProps data.
-   virtual void printSynapsesProps() const override;
+		///  Prints SynapsesProps data.
+		void printSynapsesProps() const override;
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges) override;
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of synapses per neuron.
+		void setupEdges(const int numVertices, const int maxEdges) override;
 
-   ///  Sets the data for Synapse to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
+		///  Sets the data for Synapse to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the synapse to set.
+		void readEdge(std::istream& input, const BGSIZE iEdg) override;
 
-   ///  Write the synapse data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
+		///  Write the synapse data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the synapse to print out.
+		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -197,32 +197,32 @@ protected:
        ///  @param  maxEdgesPerVertex       Maximum number of synapses per neuron.
        void copyDeviceToHost(AllDynamicSTDPSynapsesDeviceProperties& allEdgesDeviceProps);
 #else
-protected:
-   ///  Calculate the post synapse response after a spike.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  deltaT      Inner simulation step duration.
-   virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT);
+	protected:
+		///  Calculate the post synapse response after a spike.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  deltaT      Inner simulation step duration.
+		void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-#endif // defined(USE_GPU)
-public:
-   ///  The time of the last spike.
-   uint64_t *lastSpike_;
+#endif // defined(__CUDACC__)
+	public:
+		///  The time of the last spike.
+		uint64_t* lastSpike_;
 
-   ///  The time varying state variable \f$r\f$ for depression.
-   BGFLOAT *r_;
+		///  The time varying state variable \f$r\f$ for depression.
+		BGFLOAT* r_;
 
-   ///  The time varying state variable \f$u\f$ for facilitation.
-   BGFLOAT *u_;
+		///  The time varying state variable \f$u\f$ for facilitation.
+		BGFLOAT* u_;
 
-   ///  The time constant of the depression of the dynamic synapse [range=(0,10); units=sec].
-   BGFLOAT *D_;
+		///  The time constant of the depression of the dynamic synapse [range=(0,10); units=sec].
+		BGFLOAT* D_;
 
-   ///  The use parameter of the dynamic synapse [range=(1e-5,1)].
-   BGFLOAT *U_;
+		///  The use parameter of the dynamic synapse [range=(1e-5,1)].
+		BGFLOAT* U_;
 
-   ///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
-   BGFLOAT *F_;
+		///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
+		BGFLOAT* F_;
 };
 
 #ifdef __CUDACC__
@@ -247,4 +247,3 @@ struct AllDynamicSTDPSynapsesDeviceProperties : public AllSTDPSynapsesDeviceProp
         BGFLOAT *F_;
 };
 #endif
-

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -104,15 +104,15 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg) override;
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
 
    ///  Write the synapse data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const override;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all synapses' states,
        ///  and copy them from host to GPU memory.
@@ -196,7 +196,7 @@ protected:
        ///  @param  numVertices                 Number of vertices.
        ///  @param  maxEdgesPerVertex       Maximum number of synapses per neuron.
        void copyDeviceToHost(AllDynamicSTDPSynapsesDeviceProperties& allEdgesDeviceProps);
-#else // !defined(USE_GPU)
+#else
 protected:
    ///  Calculate the post synapse response after a spike.
    ///
@@ -225,7 +225,7 @@ public:
    BGFLOAT *F_;
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllDynamicSTDPSynapsesDeviceProperties : public AllSTDPSynapsesDeviceProperties
 {
         ///  The time of the last spike.
@@ -246,5 +246,5 @@ struct AllDynamicSTDPSynapsesDeviceProperties : public AllSTDPSynapsesDeviceProp
         ///  The time constant of the facilitation of the dynamic synapse [range=(0,10); units=sec].
         BGFLOAT *F_;
 };
-#endif // defined(USE_GPU)
+#endif
 

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -60,7 +60,7 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 	public:
 		AllDynamicSTDPSynapses();
 
-		AllDynamicSTDPSynapses(const int numVertices, const int maxEdges);
+		AllDynamicSTDPSynapses(int numVertices, int maxEdges);
 
 		~AllDynamicSTDPSynapses() override;
 
@@ -73,7 +73,7 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 		///
 		///  @param  iEdg     Index of the synapse to set.
 		///  @param  deltaT   Inner simulation step duration
-		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void resetEdge(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 		///  Prints out all parameters to logging file.
 		///  Registered to OperationManager as Operation::printParameters
@@ -87,7 +87,7 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Synapse to create.
-		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, BGFLOAT deltaT,
 		                edgeType type) override;
 
 		///  Prints SynapsesProps data.
@@ -98,19 +98,19 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of synapses per neuron.
-		void setupEdges(const int numVertices, const int maxEdges) override;
+		void setupEdges(int numVertices, int maxEdges) override;
 
 		///  Sets the data for Synapse to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the synapse to set.
-		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+		void readEdge(std::istream& input, BGSIZE iEdg) override;
 
 		///  Write the synapse data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the synapse to print out.
-		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+		void writeEdge(std::ostream& output, BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -202,7 +202,7 @@ class AllDynamicSTDPSynapses : public AllSTDPSynapses {
 		///
 		///  @param  iEdg        Index of the synapse to set.
 		///  @param  deltaT      Inner simulation step duration.
-		void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void changePSR(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 #endif // defined(__CUDACC__)
 	public:

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -70,7 +70,7 @@ void AllNeuroEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
 	output << destVertexIndex_[iEdg] << std::ends;
 	output << W_[iEdg] << std::ends;
 	output << psr_[iEdg] << std::ends;
-	output << type_[iEdg] << std::ends;
+	output << static_cast<int>(type_[iEdg]) << std::ends;
 	output << inUse_[iEdg] << std::ends;
 }
 
@@ -80,11 +80,11 @@ void AllNeuroEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
 ///  @return   1 or -1, or 0 if error
 int AllNeuroEdges::edgSign(const edgeType type) {
 	switch (type) {
-		case II:
-		case IE: return -1;
-		case EI:
-		case EE: return 1;
-		case ETYPE_UNDEF:
+		case edgeType::II:
+		case edgeType::IE: return -1;
+		case edgeType::EI:
+		case edgeType::EE: return 1;
+		case edgeType::ETYPE_UNDEF:
 			// TODO error.
 			return 0;
 	}
@@ -100,7 +100,7 @@ void AllNeuroEdges::printSynapsesProps() const {
 			std::cout << "W[" << i << "] = " << W_[i];
 			std::cout << " sourNeuron: " << sourceVertexIndex_[i];
 			std::cout << " desNeuron: " << destVertexIndex_[i];
-			std::cout << " type: " << type_[i];
+			std::cout << " type: " << static_cast<int>(type_[i]);
 			std::cout << " psr: " << psr_[i];
 			std::cout << " in_use:" << inUse_[i];
 			if (summationPoint_[i] != nullptr) std::cout << " summationPoint: is created!" << std::endl;
@@ -108,8 +108,10 @@ void AllNeuroEdges::printSynapsesProps() const {
 		}
 	}
 
-	for (int i = 0; i < countVertices_; i++) std::cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] <<
-		std::endl;
+	for (int i = 0; i < countVertices_; i++) {
+		std::cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] <<
+			std::endl;
+	}
 
 	std::cout << "totalEdgeCount:" << totalEdgeCount_ << std::endl;
 	std::cout << "maxEdgesPerVertex:" << maxEdgesPerVertex_ << std::endl;

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -49,7 +49,7 @@ void AllNeuroEdges::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the edge to set.
-void AllNeuroEdges::readEdge(istream &input, const BGSIZE iEdg) {
+void AllNeuroEdges::readEdge(std::istream &input, const BGSIZE iEdg) {
    int synapse_type(0);
 
    // input.ignore() so input skips over end-of-line characters.
@@ -73,13 +73,13 @@ void AllNeuroEdges::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the edge to print out.
-void AllNeuroEdges::writeEdge(ostream &output, const BGSIZE iEdg) const {
-   output << sourceVertexIndex_[iEdg] << ends;
-   output << destVertexIndex_[iEdg] << ends;
-   output << W_[iEdg] << ends;
-   output << psr_[iEdg] << ends;
-   output << type_[iEdg] << ends;
-   output << inUse_[iEdg] << ends;
+void AllNeuroEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
+   output << sourceVertexIndex_[iEdg] << std::ends;
+   output << destVertexIndex_[iEdg] << std::ends;
+   output << W_[iEdg] << std::ends;
+   output << psr_[iEdg] << std::ends;
+   output << type_[iEdg] << std::ends;
+   output << inUse_[iEdg] << std::ends;
 }
 
 ///  Get the sign of the edgeType.
@@ -104,30 +104,30 @@ int AllNeuroEdges::edgSign(const edgeType type) {
 
 ///  Prints SynapsesProps data to console.
 void AllNeuroEdges::printSynapsesProps() const {
-   cout << "This is SynapsesProps data:" << endl;
+   std::cout << "This is SynapsesProps data:" << std::endl;
    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
       if (W_[i] != 0.0) {
-         cout << "W[" << i << "] = " << W_[i];
-         cout << " sourNeuron: " << sourceVertexIndex_[i];
-         cout << " desNeuron: " << destVertexIndex_[i];
-         cout << " type: " << type_[i];
-         cout << " psr: " << psr_[i];
-         cout << " in_use:" << inUse_[i];
+         std::cout << "W[" << i << "] = " << W_[i];
+         std::cout << " sourNeuron: " << sourceVertexIndex_[i];
+         std::cout << " desNeuron: " << destVertexIndex_[i];
+         std::cout << " type: " << type_[i];
+         std::cout << " psr: " << psr_[i];
+         std::cout << " in_use:" << inUse_[i];
          if (summationPoint_[i] != nullptr) {
-            cout << " summationPoint: is created!" << endl;
+            std::cout << " summationPoint: is created!" << std::endl;
          } else {
-            cout << " summationPoint: is EMPTY!!!!!" << endl;
+            std::cout << " summationPoint: is EMPTY!!!!!" << std::endl;
          }
       }
    }
 
    for (int i = 0; i < countVertices_; i++) {
-      cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] << endl;
+      std::cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] << std::endl;
    }
 
-   cout << "totalEdgeCount:" << totalEdgeCount_ << endl;
-   cout << "maxEdgesPerVertex:" << maxEdgesPerVertex_ << endl;
-   cout << "count_neurons:" << countVertices_ << endl;
+   std::cout << "totalEdgeCount:" << totalEdgeCount_ << std::endl;
+   std::cout << "maxEdgesPerVertex:" << maxEdgesPerVertex_ << std::endl;
+   std::cout << "count_neurons:" << countVertices_ << std::endl;
 }
 
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -8,7 +8,7 @@
 
 #include "AllNeuroEdges.h"
 
-AllNeuroEdges::AllNeuroEdges() : AllEdges() { psr_ = nullptr; }
+AllNeuroEdges::AllNeuroEdges() : AllEdges(), psr_(nullptr) { }
 
 AllNeuroEdges::~AllNeuroEdges() {
 	BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -8,78 +8,70 @@
 
 #include "AllNeuroEdges.h"
 
-AllNeuroEdges::AllNeuroEdges() : AllEdges() {
-   psr_ = nullptr;
-}
+AllNeuroEdges::AllNeuroEdges() : AllEdges() { psr_ = nullptr; }
 
 AllNeuroEdges::~AllNeuroEdges() {
-   BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;
-   if (maxTotalEdges != 0) {
-     delete[] psr_;
-     }
+	BGSIZE maxTotalEdges = maxEdgesPerVertex_ * countVertices_;
+	if (maxTotalEdges != 0) delete[] psr_;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllNeuroEdges::setupEdges() {
-   int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
-   int numVertices = Simulator::getInstance().getTotalVertices();
-   setupEdges(numVertices, maxEdges);
+	int maxEdges = Simulator::getInstance().getMaxEdgesPerVertex();
+	int numVertices = Simulator::getInstance().getTotalVertices();
+	setupEdges(numVertices, maxEdges);
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllNeuroEdges::setupEdges(const int numVertices, const int maxEdges) {
-   AllEdges::setupEdges(numVertices, maxEdges);
+	AllEdges::setupEdges(numVertices, maxEdges);
 
-   BGSIZE maxTotalEdges = maxEdges * numVertices;
-   
-   if (maxTotalEdges != 0) {
-      psr_ = new BGFLOAT[maxTotalEdges];
-   }
+	BGSIZE maxTotalEdges = maxEdges * numVertices;
+
+	if (maxTotalEdges != 0) psr_ = new BGFLOAT[maxTotalEdges];
 }
 
 ///  Reset time varying state vars and recompute decay.
 ///
 ///  @param  iEdg     Index of the edge to set.
 ///  @param  deltaT   Inner simulation step duration
-void AllNeuroEdges::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   psr_[iEdg] = 0.0;
-}
+void AllNeuroEdges::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) { psr_[iEdg] = 0.0; }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the edge to set.
-void AllNeuroEdges::readEdge(std::istream &input, const BGSIZE iEdg) {
-   int synapse_type(0);
+void AllNeuroEdges::readEdge(std::istream& input, const BGSIZE iEdg) {
+	int synapse_type(0);
 
-   // input.ignore() so input skips over end-of-line characters.
-   input >> sourceVertexIndex_[iEdg];
-   input.ignore();
-   input >> destVertexIndex_[iEdg];
-   input.ignore();
-   input >> W_[iEdg];
-   input.ignore();
-   input >> psr_[iEdg];
-   input.ignore();
-   input >> synapse_type;
-   input.ignore();
-   input >> inUse_[iEdg];
-   input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> sourceVertexIndex_[iEdg];
+	input.ignore();
+	input >> destVertexIndex_[iEdg];
+	input.ignore();
+	input >> W_[iEdg];
+	input.ignore();
+	input >> psr_[iEdg];
+	input.ignore();
+	input >> synapse_type;
+	input.ignore();
+	input >> inUse_[iEdg];
+	input.ignore();
 
-   type_[iEdg] = edgeOrdinalToType(synapse_type);
+	type_[iEdg] = edgeOrdinalToType(synapse_type);
 }
 
 ///  Write the edge data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the edge to print out.
-void AllNeuroEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-   output << sourceVertexIndex_[iEdg] << std::ends;
-   output << destVertexIndex_[iEdg] << std::ends;
-   output << W_[iEdg] << std::ends;
-   output << psr_[iEdg] << std::ends;
-   output << type_[iEdg] << std::ends;
-   output << inUse_[iEdg] << std::ends;
+void AllNeuroEdges::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	output << sourceVertexIndex_[iEdg] << std::ends;
+	output << destVertexIndex_[iEdg] << std::ends;
+	output << W_[iEdg] << std::ends;
+	output << psr_[iEdg] << std::ends;
+	output << type_[iEdg] << std::ends;
+	output << inUse_[iEdg] << std::ends;
 }
 
 ///  Get the sign of the edgeType.
@@ -87,50 +79,39 @@ void AllNeuroEdges::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
 ///  @param    type    edgeType I to I, I to E, E to I, or E to E
 ///  @return   1 or -1, or 0 if error
 int AllNeuroEdges::edgSign(const edgeType type) {
-   switch (type) {
-      case II:
-      case IE:
-         return -1;
-      case EI:
-      case EE:
-         return 1;
-      case ETYPE_UNDEF:
-         // TODO error.
-         return 0;
-   }
+	switch (type) {
+		case II:
+		case IE: return -1;
+		case EI:
+		case EE: return 1;
+		case ETYPE_UNDEF:
+			// TODO error.
+			return 0;
+	}
 
-   return 0;
+	return 0;
 }
 
 ///  Prints SynapsesProps data to console.
 void AllNeuroEdges::printSynapsesProps() const {
-   std::cout << "This is SynapsesProps data:" << std::endl;
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      if (W_[i] != 0.0) {
-         std::cout << "W[" << i << "] = " << W_[i];
-         std::cout << " sourNeuron: " << sourceVertexIndex_[i];
-         std::cout << " desNeuron: " << destVertexIndex_[i];
-         std::cout << " type: " << type_[i];
-         std::cout << " psr: " << psr_[i];
-         std::cout << " in_use:" << inUse_[i];
-         if (summationPoint_[i] != nullptr) {
-            std::cout << " summationPoint: is created!" << std::endl;
-         } else {
-            std::cout << " summationPoint: is EMPTY!!!!!" << std::endl;
-         }
-      }
-   }
+	std::cout << "This is SynapsesProps data:" << std::endl;
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		if (W_[i] != 0.0) {
+			std::cout << "W[" << i << "] = " << W_[i];
+			std::cout << " sourNeuron: " << sourceVertexIndex_[i];
+			std::cout << " desNeuron: " << destVertexIndex_[i];
+			std::cout << " type: " << type_[i];
+			std::cout << " psr: " << psr_[i];
+			std::cout << " in_use:" << inUse_[i];
+			if (summationPoint_[i] != nullptr) std::cout << " summationPoint: is created!" << std::endl;
+			else std::cout << " summationPoint: is EMPTY!!!!!" << std::endl;
+		}
+	}
 
-   for (int i = 0; i < countVertices_; i++) {
-      std::cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] << std::endl;
-   }
+	for (int i = 0; i < countVertices_; i++) std::cout << "edge_counts:" << "vertex[" << i << "]" << edgeCounts_[i] <<
+		std::endl;
 
-   std::cout << "totalEdgeCount:" << totalEdgeCount_ << std::endl;
-   std::cout << "maxEdgesPerVertex:" << maxEdgesPerVertex_ << std::endl;
-   std::cout << "count_neurons:" << countVertices_ << std::endl;
+	std::cout << "totalEdgeCount:" << totalEdgeCount_ << std::endl;
+	std::cout << "maxEdgesPerVertex:" << maxEdgesPerVertex_ << std::endl;
+	std::cout << "count_neurons:" << countVertices_ << std::endl;
 }
-
-
-
-
-

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -32,7 +32,7 @@ class AllVertices;
 // typedef void (*fpCreateSynapse_t)(void*, const int, const int, int, int, BGFLOAT*, const BGFLOAT, edgeType);
 
 // enumerate all non-abstract edge classes.
-enum enumClassSynapses {
+enum class enumClassSynapses {
 	classAllSpikingSynapses,
 	classAllDSSynapses,
 	classAllSTDPSynapses,
@@ -53,7 +53,7 @@ class AllNeuroEdges : public AllEdges {
 		///
 		///  @param  iEdg     Index of the edge to set.
 		///  @param  deltaT   Inner simulation step duration
-		virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT);
+		virtual void resetEdge(BGSIZE iEdg, BGFLOAT deltaT);
 
 		// ///  Create a Synapse and connect it to the model.
 		// ///
@@ -70,7 +70,7 @@ class AllNeuroEdges : public AllEdges {
 		///
 		///  @param    type    edgeType I to I, I to E, E to I, or E to E
 		///  @return   1 or -1, or 0 if error
-		int edgSign(const edgeType type);
+		int edgSign(edgeType type);
 
 		///  Prints SynapsesProps data to console.
 		virtual void printSynapsesProps() const;
@@ -80,19 +80,19 @@ class AllNeuroEdges : public AllEdges {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of edges per vertex.
-		void setupEdges(const int numVertices, const int maxEdges) override;
+		void setupEdges(int numVertices, int maxEdges) override;
 
 		///  Sets the data for Synapse to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the edge to set.
-		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+		void readEdge(std::istream& input, BGSIZE iEdg) override;
 
 		///  Write the edge data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the edge to print out.
-		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+		void writeEdge(std::ostream& output, BGSIZE iEdg) const override;
 
 	public:
 		/// The factor to adjust overlapping area to edge weight.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -27,10 +27,6 @@
 
 #include "AllEdges.h"
 
-#ifdef _WIN32
-typedef unsigned _int8 uint8_t;
-#endif
-
 class AllVertices;
 
 // typedef void (*fpCreateSynapse_t)(void*, const int, const int, int, int, BGFLOAT*, const BGFLOAT, edgeType);
@@ -84,13 +80,13 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the edge to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg) override;
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
 
    ///  Write the edge data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the edge to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const override;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
 
 public:
    /// The factor to adjust overlapping area to edge weight.
@@ -100,7 +96,7 @@ public:
    BGFLOAT *psr_;
 };
 
-#if defined(USE_GPU)
+#if __CUDACC__
 struct AllEdgesDeviceProperties
 {
         ///  The location of the edge.
@@ -137,5 +133,5 @@ struct AllEdgesDeviceProperties
         ///  Usage: Used by destructor
         int countVertices_;
 };
-#endif // defined(USE_GPU)
+#endif 
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -32,68 +32,74 @@ class AllVertices;
 // typedef void (*fpCreateSynapse_t)(void*, const int, const int, int, int, BGFLOAT*, const BGFLOAT, edgeType);
 
 // enumerate all non-abstract edge classes.
-enum enumClassSynapses {classAllSpikingSynapses, classAllDSSynapses, classAllSTDPSynapses, classAllDynamicSTDPSynapses, undefClassSynapses};
+enum enumClassSynapses {
+	classAllSpikingSynapses,
+	classAllDSSynapses,
+	classAllSTDPSynapses,
+	classAllDynamicSTDPSynapses,
+	undefClassSynapses
+};
 
 class AllNeuroEdges : public AllEdges {
-public:
-   AllNeuroEdges();
+	public:
+		AllNeuroEdges();
 
-   virtual ~AllNeuroEdges();
+		~AllNeuroEdges() override;
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Reset time varying state vars and recompute decay.
-   ///
-   ///  @param  iEdg     Index of the edge to set.
-   ///  @param  deltaT   Inner simulation step duration
-   virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT);
+		///  Reset time varying state vars and recompute decay.
+		///
+		///  @param  iEdg     Index of the edge to set.
+		///  @param  deltaT   Inner simulation step duration
+		virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT);
 
-   // ///  Create a Synapse and connect it to the model.
-   // ///
-   // ///  @param  iEdg        Index of the edge to set.
-   // ///  @param  source      Coordinates of the source Neuron.
-   // ///  @param  dest        Coordinates of the destination Neuron.
-   // ///  @param  sumPoint    Summation point address.
-   // ///  @param  deltaT      Inner simulation step duration.
-   // ///  @param  type        Type of the Synapse to create.
-   // virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-   //                            edgeType type) override;
+		// ///  Create a Synapse and connect it to the model.
+		// ///
+		// ///  @param  iEdg        Index of the edge to set.
+		// ///  @param  source      Coordinates of the source Neuron.
+		// ///  @param  dest        Coordinates of the destination Neuron.
+		// ///  @param  sumPoint    Summation point address.
+		// ///  @param  deltaT      Inner simulation step duration.
+		// ///  @param  type        Type of the Synapse to create.
+		// virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
+		//                            edgeType type) override;
 
-   ///  Get the sign of the edgeType.
-   ///
-   ///  @param    type    edgeType I to I, I to E, E to I, or E to E
-   ///  @return   1 or -1, or 0 if error
-   int edgSign(const edgeType type);
+		///  Get the sign of the edgeType.
+		///
+		///  @param    type    edgeType I to I, I to E, E to I, or E to E
+		///  @return   1 or -1, or 0 if error
+		int edgSign(const edgeType type);
 
-   ///  Prints SynapsesProps data to console.
-   virtual void printSynapsesProps() const;
+		///  Prints SynapsesProps data to console.
+		virtual void printSynapsesProps() const;
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of edges per vertex.
-   virtual void setupEdges(const int numVertices, const int maxEdges) override;
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of edges per vertex.
+		void setupEdges(const int numVertices, const int maxEdges) override;
 
-   ///  Sets the data for Synapse to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the edge to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
+		///  Sets the data for Synapse to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the edge to set.
+		void readEdge(std::istream& input, const BGSIZE iEdg) override;
 
-   ///  Write the edge data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the edge to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
+		///  Write the edge data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the edge to print out.
+		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
 
-public:
-   /// The factor to adjust overlapping area to edge weight.
-   static constexpr BGFLOAT SYNAPSE_STRENGTH_ADJUSTMENT = 1.0e-8;
-      ///  The post-synaptic response is the result of whatever computation
-   ///  is going on in the edge.
-   BGFLOAT *psr_;
+	public:
+		/// The factor to adjust overlapping area to edge weight.
+		static constexpr BGFLOAT SYNAPSE_STRENGTH_ADJUSTMENT = 1.0e-8;
+		///  The post-synaptic response is the result of whatever computation
+	 ///  is going on in the edge.
+		BGFLOAT* psr_;
 };
 
 #if __CUDACC__
@@ -133,5 +139,4 @@ struct AllEdgesDeviceProperties
         ///  Usage: Used by destructor
         int countVertices_;
 };
-#endif 
-
+#endif

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -160,17 +160,17 @@ void AllSTDPSynapses::loadParameters() {
 void AllSTDPSynapses::printParameters() const {
    AllSpikingSynapses::printParameters();
    
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSTDPSynapses Parameters---" << endl
-                   << "\tEdges type: AllSTDPSynapses" << endl << endl
+   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSTDPSynapses Parameters---" << std::endl
+                   << "\tEdges type: AllSTDPSynapses" << std::endl << std::endl
                    
-                   <<"\tSTDP gap" << defaultSTDPgap_ << endl
-                   << "\n\tTauspost value: [" << " I: " << tauspost_I_ << ", " << " E: " << tauspost_E_  << "]"<< endl
-                   << "\n\tTauspre value: [" << " I: " << tauspre_I_ << ", " << " E: " << tauspre_E_ << "]"<< endl
-                   << "\n\tTaupos value: [" << " I: " << taupos_I_ << ", " << " E: " << taupos_E_  << "]"<< endl
-                   << "\n\tTau negvalue: [" << " I: " << tauneg_I_ << ", " << " E: " << tauneg_E_  << "]"<< endl
-                   << "\n\tWex value: [" << " I: " << Wex_I_ << ", " << " E: " << Wex_E_  << "]"<< endl
-                   << "\n\tAneg value: [" << " I: " << Aneg_I_ << ", " << " E: " << Aneg_E_  << "]"<< endl
-                   << "\n\tApos value: [" << " I: " << Apos_I_ << ", " << " E: " << Apos_E_  << "]"<< endl
+                   <<"\tSTDP gap" << defaultSTDPgap_ << std::endl
+                   << "\n\tTauspost value: [" << " I: " << tauspost_I_ << ", " << " E: " << tauspost_E_  << "]"<< std::endl
+                   << "\n\tTauspre value: [" << " I: " << tauspre_I_ << ", " << " E: " << tauspre_E_ << "]"<< std::endl
+                   << "\n\tTaupos value: [" << " I: " << taupos_I_ << ", " << " E: " << taupos_E_  << "]"<< std::endl
+                   << "\n\tTau negvalue: [" << " I: " << tauneg_I_ << ", " << " E: " << tauneg_E_  << "]"<< std::endl
+                   << "\n\tWex value: [" << " I: " << Wex_I_ << ", " << " E: " << Wex_E_  << "]"<< std::endl
+                   << "\n\tAneg value: [" << " I: " << Aneg_I_ << ", " << " E: " << Aneg_E_  << "]"<< std::endl
+                   << "\n\tApos value: [" << " I: " << Apos_I_ << ", " << " E: " << Apos_E_  << "]"<< std::endl
                    );
 }
 
@@ -178,7 +178,7 @@ void AllSTDPSynapses::printParameters() const {
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllSTDPSynapses::readEdge(istream &input, const BGSIZE iEdg) {
+void AllSTDPSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
    AllSpikingSynapses::readEdge(input, iEdg);
 
    // input.ignore() so input skips over end-of-line characters.
@@ -216,23 +216,23 @@ void AllSTDPSynapses::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllSTDPSynapses::writeEdge(ostream &output, const BGSIZE iEdg) const {
+void AllSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
    AllSpikingSynapses::writeEdge(output, iEdg);
 
-   output << totalDelayPost_[iEdg] << ends;
-   output << delayQueuePost_[iEdg] << ends;
-   output << delayIndexPost_[iEdg] << ends;
-   output << delayQueuePostLength_[iEdg] << ends;
-   output << tauspost_[iEdg] << ends;
-   output << tauspre_[iEdg] << ends;
-   output << taupos_[iEdg] << ends;
-   output << tauneg_[iEdg] << ends;
-   output << STDPgap_[iEdg] << ends;
-   output << Wex_[iEdg] << ends;
-   output << Aneg_[iEdg] << ends;
-   output << Apos_[iEdg] << ends;
-   output << mupos_[iEdg] << ends;
-   output << muneg_[iEdg] << ends;
+   output << totalDelayPost_[iEdg] << std::ends;
+   output << delayQueuePost_[iEdg] << std::ends;
+   output << delayIndexPost_[iEdg] << std::ends;
+   output << delayQueuePostLength_[iEdg] << std::ends;
+   output << tauspost_[iEdg] << std::ends;
+   output << tauspre_[iEdg] << std::ends;
+   output << taupos_[iEdg] << std::ends;
+   output << tauneg_[iEdg] << std::ends;
+   output << STDPgap_[iEdg] << std::ends;
+   output << Wex_[iEdg] << std::ends;
+   output << Aneg_[iEdg] << std::ends;
+   output << Apos_[iEdg] << std::ends;
+   output << mupos_[iEdg] << std::ends;
+   output << muneg_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -275,7 +275,7 @@ void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVerte
    muneg_[iEdg] = 0;
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Advance one specific Synapse.
 ///
@@ -335,15 +335,15 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons) {
             // (include pre-synaptic transmission delay)
             delta = -static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
             /*
-             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPre" << endl
-             << "\tiEdg: " << iEdg << endl
-             << "\tidxPre: " << idxPre << endl
-             << "\tidxPost: " << idxPost << endl
-             << "\tspikeHistory: " << spikeHistory << endl
-             << "\tepre: " << epre << endl
-             << "\tepost: " << epost << endl
-             << "\tg_simulationStep: " << g_simulationStep << endl
-             << "\tdelta: " << delta << endl << endl);
+             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPre" << std::endl
+             << "\tiEdg: " << iEdg << std::endl
+             << "\tidxPre: " << idxPre << std::endl
+             << "\tidxPost: " << idxPost << std::endl
+             << "\tspikeHistory: " << spikeHistory << std::endl
+             << "\tepre: " << epre << std::endl
+             << "\tepost: " << epost << std::endl
+             << "\tg_simulationStep: " << g_simulationStep << std::endl
+             << "\tdelta: " << delta << std::endl << std::endl);
              */
             
             if (delta <= -3.0 * tauneg)
@@ -380,15 +380,15 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons) {
             // delta is the spike interval between post-pre spikes
             delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory - total_delay) * deltaT;
             /*
-             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPost" << endl
-             << "\tiEdg: " << iEdg << endl
-             << "\tidxPre: " << idxPre << endl
-             << "\tidxPost: " << idxPost << endl
-             << "\tspikeHistory: " << spikeHistory << endl
-             << "\tg_simulationStep: " << g_simulationStep << endl
-             << "\tepre: " << epre << endl
-             << "\tepost: " << epost << endl
-             << "\tdelta: " << delta << endl << endl);
+             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPost" << std::endl
+             << "\tiEdg: " << iEdg << std::endl
+             << "\tidxPre: " << idxPre << std::endl
+             << "\tidxPost: " << idxPost << std::endl
+             << "\tspikeHistory: " << spikeHistory << std::endl
+             << "\tg_simulationStep: " << g_simulationStep << std::endl
+             << "\tepre: " << epre << std::endl
+             << "\tepost: " << epost << std::endl
+             << "\tdelta: " << delta << std::endl << std::endl);
              */
             if (delta >= 3.0 * taupos)
                break;
@@ -489,14 +489,14 @@ void AllSTDPSynapses::stdpLearning(const BGSIZE iEdg, double delta, double epost
       W = edgSign(type) * Wex;
    }
    /*
-    LOG4CPLUS_DEBUG(edgeLogger_, endl <<
+    LOG4CPLUS_DEBUG(edgeLogger_, std::endl <<
     "iEdg value " << iEdg
     << "; source:" << srcVertex
     << "; dest:" << destVertex
     << "; delta:" << delta
     << "; oldW:" << oldW
     << " ;W:" << W
-    << endl);
+    << std::endl);
     
     */
 }
@@ -540,7 +540,7 @@ void AllSTDPSynapses::postSpikeHit(const BGSIZE iEdg) {
    delay_queue |= (0x1 << idx);
 }
 
-#endif // !defined(USE_GPU)
+#endif
 
 ///  Check if the back propagation (notify a spike event to the pre neuron)
 ///  is allowed in the synapse class.
@@ -555,17 +555,17 @@ void AllSTDPSynapses::printSynapsesProps() const {
    AllSpikingSynapses::printSynapsesProps();
    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
       if (W_[i] != 0.0) {
-         cout << "total_delayPost[" << i << "] = " << totalDelayPost_[i];
-         cout << " tauspost_: " << tauspost_[i];
-         cout << " tauspre_: " << tauspre_[i];
-         cout << " taupos_: " << taupos_[i];
-         cout << " tauneg_: " << tauneg_[i];
-         cout << " STDPgap_: " << STDPgap_[i];
-         cout << " Wex_: " << Wex_[i];
-         cout << " Aneg_: " << Aneg_[i];
-         cout << " Apos_: " << Apos_[i];
-         cout << " mupos_: " << mupos_[i];
-         cout << " muneg_: " << muneg_[i] << endl;
+         std::cout << "total_delayPost[" << i << "] = " << totalDelayPost_[i];
+         std::cout << " tauspost_: " << tauspost_[i];
+         std::cout << " tauspre_: " << tauspre_[i];
+         std::cout << " taupos_: " << taupos_[i];
+         std::cout << " tauneg_: " << tauneg_[i];
+         std::cout << " STDPgap_: " << STDPgap_[i];
+         std::cout << " Wex_: " << Wex_[i];
+         std::cout << " Aneg_: " << Aneg_[i];
+         std::cout << " Apos_: " << Apos_[i];
+         std::cout << " mupos_: " << mupos_[i];
+         std::cout << " muneg_: " << muneg_[i] << std::endl;
       }
    }
 }

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -11,36 +11,7 @@
 #include "AllVertices.h"
 #include "ParameterManager.h"
 
-AllSTDPSynapses::AllSTDPSynapses() : AllSpikingSynapses() {
-	totalDelayPost_ = nullptr;
-	delayQueuePost_ = nullptr;
-	delayIndexPost_ = nullptr;
-	delayQueuePostLength_ = nullptr;
-	tauspost_ = nullptr;
-	tauspre_ = nullptr;
-	taupos_ = nullptr;
-	tauneg_ = nullptr;
-	STDPgap_ = nullptr;
-	Wex_ = nullptr;
-	Aneg_ = nullptr;
-	Apos_ = nullptr;
-	mupos_ = nullptr;
-	muneg_ = nullptr;
-	defaultSTDPgap_ = 0;
-	tauspost_I_ = 0;
-	tauspre_I_ = 0;
-	tauspost_E_ = 0;
-	tauspre_E_ = 0;
-	taupos_I_ = 0;
-	tauneg_I_ = 0;
-	taupos_E_ = 0;
-	tauneg_E_ = 0;
-	Wex_I_ = 0;
-	Wex_E_ = 0;
-	Aneg_I_ = 0;
-	Aneg_E_ = 0;
-	Apos_I_ = 0;
-	Apos_E_ = 0;
+AllSTDPSynapses::AllSTDPSynapses() : AllSpikingSynapses(), Apos_E_(0), Apos_I_(0), Aneg_E_(0), Aneg_I_(0), Wex_E_(0), Wex_I_(0), tauneg_E_(0), taupos_E_(0), tauneg_I_(0), taupos_I_(0), tauspre_E_(0), tauspost_E_(0), tauspre_I_(0), tauspost_I_(0), defaultSTDPgap_(0), muneg_(nullptr), mupos_(nullptr), Apos_(nullptr), Aneg_(nullptr), Wex_(nullptr), STDPgap_(nullptr), tauneg_(nullptr), taupos_(nullptr), tauspre_(nullptr), tauspost_(nullptr), delayQueuePostLength_(nullptr), delayIndexPost_(nullptr), delayQueuePost_(nullptr), totalDelayPost_(nullptr) {
 }
 
 AllSTDPSynapses::AllSTDPSynapses(const int numVertices, const int maxEdges) :

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -7,86 +7,84 @@
  */
 
 #include "AllSTDPSynapses.h"
-#include "AllVertices.h"
 #include "AllSpikingNeurons.h"
+#include "AllVertices.h"
 #include "ParameterManager.h"
 
 AllSTDPSynapses::AllSTDPSynapses() : AllSpikingSynapses() {
-   totalDelayPost_ = nullptr;
-   delayQueuePost_ = nullptr;
-   delayIndexPost_ = nullptr;
-   delayQueuePostLength_ = nullptr;
-   tauspost_ = nullptr;
-   tauspre_ = nullptr;
-   taupos_ = nullptr;
-   tauneg_ = nullptr;
-   STDPgap_ = nullptr;
-   Wex_ = nullptr;
-   Aneg_ = nullptr;
-   Apos_ = nullptr;
-   mupos_ = nullptr;
-   muneg_ = nullptr;
-   defaultSTDPgap_=0;
-   tauspost_I_=0;
-   tauspre_I_=0;
-   tauspost_E_=0;
-   tauspre_E_=0;
-   taupos_I_=0;
-   tauneg_I_=0;
-   taupos_E_=0;
-   tauneg_E_=0;
-   Wex_I_=0;
-   Wex_E_=0;
-   Aneg_I_ = 0;
-   Aneg_E_ = 0;
-   Apos_I_ = 0;
-   Apos_E_ = 0;
+	totalDelayPost_ = nullptr;
+	delayQueuePost_ = nullptr;
+	delayIndexPost_ = nullptr;
+	delayQueuePostLength_ = nullptr;
+	tauspost_ = nullptr;
+	tauspre_ = nullptr;
+	taupos_ = nullptr;
+	tauneg_ = nullptr;
+	STDPgap_ = nullptr;
+	Wex_ = nullptr;
+	Aneg_ = nullptr;
+	Apos_ = nullptr;
+	mupos_ = nullptr;
+	muneg_ = nullptr;
+	defaultSTDPgap_ = 0;
+	tauspost_I_ = 0;
+	tauspre_I_ = 0;
+	tauspost_E_ = 0;
+	tauspre_E_ = 0;
+	taupos_I_ = 0;
+	tauneg_I_ = 0;
+	taupos_E_ = 0;
+	tauneg_E_ = 0;
+	Wex_I_ = 0;
+	Wex_E_ = 0;
+	Aneg_I_ = 0;
+	Aneg_E_ = 0;
+	Apos_I_ = 0;
+	Apos_E_ = 0;
 }
 
 AllSTDPSynapses::AllSTDPSynapses(const int numVertices, const int maxEdges) :
-      AllSpikingSynapses(numVertices, maxEdges) {
-   setupEdges(numVertices, maxEdges);
-}
+	AllSpikingSynapses(numVertices, maxEdges) { setupEdges(numVertices, maxEdges); }
 
 AllSTDPSynapses::~AllSTDPSynapses() {
-   BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
+	BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
 
-   if (maxTotalSynapses != 0) {
-      delete[] totalDelayPost_;
-      delete[] delayQueuePost_;
-      delete[] delayIndexPost_;
-      delete[] delayQueuePostLength_;
-      delete[] tauspost_;
-      delete[] tauspre_;
-      delete[] taupos_;
-      delete[] tauneg_;
-      delete[] STDPgap_;
-      delete[] Wex_;
-      delete[] Aneg_;
-      delete[] Apos_;
-      delete[] mupos_;
-      delete[] muneg_;
-   }
+	if (maxTotalSynapses != 0) {
+		delete[] totalDelayPost_;
+		delete[] delayQueuePost_;
+		delete[] delayIndexPost_;
+		delete[] delayQueuePostLength_;
+		delete[] tauspost_;
+		delete[] tauspre_;
+		delete[] taupos_;
+		delete[] tauneg_;
+		delete[] STDPgap_;
+		delete[] Wex_;
+		delete[] Aneg_;
+		delete[] Apos_;
+		delete[] mupos_;
+		delete[] muneg_;
+	}
 
-   totalDelayPost_ = nullptr;
-   delayQueuePost_ = nullptr;
-   delayIndexPost_ = nullptr;
-   delayQueuePostLength_ = nullptr;
-   tauspost_ = nullptr;
-   tauspre_ = nullptr;
-   taupos_ = nullptr;
-   tauneg_ = nullptr;
-   STDPgap_ = nullptr;
-   Wex_ = nullptr;
-   Aneg_ = nullptr;
-   Apos_ = nullptr;
-   mupos_ = nullptr;
-   muneg_ = nullptr;
+	totalDelayPost_ = nullptr;
+	delayQueuePost_ = nullptr;
+	delayIndexPost_ = nullptr;
+	delayQueuePostLength_ = nullptr;
+	tauspost_ = nullptr;
+	tauspre_ = nullptr;
+	taupos_ = nullptr;
+	tauneg_ = nullptr;
+	STDPgap_ = nullptr;
+	Wex_ = nullptr;
+	Aneg_ = nullptr;
+	Apos_ = nullptr;
+	mupos_ = nullptr;
+	muneg_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllSTDPSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+	setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -94,145 +92,146 @@ void AllSTDPSynapses::setupEdges() {
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
 void AllSTDPSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllSpikingSynapses::setupEdges(numVertices, maxEdges);
+	AllSpikingSynapses::setupEdges(numVertices, maxEdges);
 
-   BGSIZE maxTotalSynapses = maxEdges * numVertices;
+	BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
-   if (maxTotalSynapses != 0) {
-      totalDelayPost_ = new int[maxTotalSynapses];
-      delayQueuePost_ = new uint32_t[maxTotalSynapses];
-      delayIndexPost_ = new int[maxTotalSynapses];
-      delayQueuePostLength_ = new int[maxTotalSynapses];
-      tauspost_ = new BGFLOAT[maxTotalSynapses];
-      tauspre_ = new BGFLOAT[maxTotalSynapses];
-      taupos_ = new BGFLOAT[maxTotalSynapses];
-      tauneg_ = new BGFLOAT[maxTotalSynapses];
-      STDPgap_ = new BGFLOAT[maxTotalSynapses];
-      Wex_ = new BGFLOAT[maxTotalSynapses];
-      Aneg_ = new BGFLOAT[maxTotalSynapses];
-      Apos_ = new BGFLOAT[maxTotalSynapses];
-      mupos_ = new BGFLOAT[maxTotalSynapses];
-      muneg_ = new BGFLOAT[maxTotalSynapses];
-   }
+	if (maxTotalSynapses != 0) {
+		totalDelayPost_ = new int[maxTotalSynapses];
+		delayQueuePost_ = new uint32_t[maxTotalSynapses];
+		delayIndexPost_ = new int[maxTotalSynapses];
+		delayQueuePostLength_ = new int[maxTotalSynapses];
+		tauspost_ = new BGFLOAT[maxTotalSynapses];
+		tauspre_ = new BGFLOAT[maxTotalSynapses];
+		taupos_ = new BGFLOAT[maxTotalSynapses];
+		tauneg_ = new BGFLOAT[maxTotalSynapses];
+		STDPgap_ = new BGFLOAT[maxTotalSynapses];
+		Wex_ = new BGFLOAT[maxTotalSynapses];
+		Aneg_ = new BGFLOAT[maxTotalSynapses];
+		Apos_ = new BGFLOAT[maxTotalSynapses];
+		mupos_ = new BGFLOAT[maxTotalSynapses];
+		muneg_ = new BGFLOAT[maxTotalSynapses];
+	}
 }
 
 ///  Initializes the queues for the Synapse.
 ///
 ///  @param  iEdg   index of the synapse to set.
 void AllSTDPSynapses::initSpikeQueue(const BGSIZE iEdg) {
-   AllSpikingSynapses::initSpikeQueue(iEdg);
+	AllSpikingSynapses::initSpikeQueue(iEdg);
 
-   int &total_delay = totalDelayPost_[iEdg];
-   uint32_t &delayQueue = delayQueuePost_[iEdg];
-   int &delayIdx = delayIndexPost_[iEdg];
-   int &ldelayQueue = delayQueuePostLength_[iEdg];
+	int& total_delay = totalDelayPost_[iEdg];
+	uint32_t& delayQueue = delayQueuePost_[iEdg];
+	int& delayIdx = delayIndexPost_[iEdg];
+	int& ldelayQueue = delayQueuePostLength_[iEdg];
 
-   uint32_t size = total_delay / (sizeof(uint8_t) * 8) + 1;
-   assert(size <= BYTES_OF_DELAYQUEUE);
-   delayQueue = 0;
-   delayIdx = 0;
-   ldelayQueue = LENGTH_OF_DELAYQUEUE;
+	uint32_t size = total_delay / (sizeof(uint8_t) * 8) + 1;
+	assert(size <= BYTES_OF_DELAYQUEUE);
+	delayQueue = 0;
+	delayIdx = 0;
+	ldelayQueue = LENGTH_OF_DELAYQUEUE;
 }
 
 ///  Loads out all parameters from the config file.
 ///  Registered to OperationManager as Operation::loadParameters
 void AllSTDPSynapses::loadParameters() {
-   AllSpikingSynapses::loadParameters();
-   ParameterManager::getInstance().getBGFloatByXpath("//STDPgap/text()", defaultSTDPgap_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauspost/i/text()", tauspost_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauspost/e/text()", tauspost_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauspre/i/text()", tauspre_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauspre/e/text()", tauspre_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//taupos/i/text()", taupos_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//taupos/e/text()", taupos_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauneg/i/text()", tauneg_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tauneg/e/text()", tauneg_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Wex/i/text()", Wex_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Wex/e/text()", Wex_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Aneg/i/text()", Aneg_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Aneg/e/text()", Aneg_E_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Apos/i/text()", Apos_I_);
-   ParameterManager::getInstance().getBGFloatByXpath("//Apos/e/text()", Apos_E_);
+	AllSpikingSynapses::loadParameters();
+	ParameterManager::getInstance().getBGFloatByXpath("//STDPgap/text()", defaultSTDPgap_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauspost/i/text()", tauspost_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauspost/e/text()", tauspost_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauspre/i/text()", tauspre_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauspre/e/text()", tauspre_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//taupos/i/text()", taupos_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//taupos/e/text()", taupos_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauneg/i/text()", tauneg_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tauneg/e/text()", tauneg_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Wex/i/text()", Wex_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Wex/e/text()", Wex_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Aneg/i/text()", Aneg_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Aneg/e/text()", Aneg_E_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Apos/i/text()", Apos_I_);
+	ParameterManager::getInstance().getBGFloatByXpath("//Apos/e/text()", Apos_E_);
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllSTDPSynapses::printParameters() const {
-   AllSpikingSynapses::printParameters();
-   
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSTDPSynapses Parameters---" << std::endl
-                   << "\tEdges type: AllSTDPSynapses" << std::endl << std::endl
-                   
-                   <<"\tSTDP gap" << defaultSTDPgap_ << std::endl
-                   << "\n\tTauspost value: [" << " I: " << tauspost_I_ << ", " << " E: " << tauspost_E_  << "]"<< std::endl
-                   << "\n\tTauspre value: [" << " I: " << tauspre_I_ << ", " << " E: " << tauspre_E_ << "]"<< std::endl
-                   << "\n\tTaupos value: [" << " I: " << taupos_I_ << ", " << " E: " << taupos_E_  << "]"<< std::endl
-                   << "\n\tTau negvalue: [" << " I: " << tauneg_I_ << ", " << " E: " << tauneg_E_  << "]"<< std::endl
-                   << "\n\tWex value: [" << " I: " << Wex_I_ << ", " << " E: " << Wex_E_  << "]"<< std::endl
-                   << "\n\tAneg value: [" << " I: " << Aneg_I_ << ", " << " E: " << Aneg_E_  << "]"<< std::endl
-                   << "\n\tApos value: [" << " I: " << Apos_I_ << ", " << " E: " << Apos_E_  << "]"<< std::endl
-                   );
+	AllSpikingSynapses::printParameters();
+
+	LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSTDPSynapses Parameters---" << std::endl
+	                << "\tEdges type: AllSTDPSynapses" << std::endl << std::endl
+
+	                <<"\tSTDP gap" << defaultSTDPgap_ << std::endl
+	                << "\n\tTauspost value: [" << " I: " << tauspost_I_ << ", " << " E: " << tauspost_E_ << "]"<< std::
+	                endl
+	                << "\n\tTauspre value: [" << " I: " << tauspre_I_ << ", " << " E: " << tauspre_E_ << "]"<< std::endl
+	                << "\n\tTaupos value: [" << " I: " << taupos_I_ << ", " << " E: " << taupos_E_ << "]"<< std::endl
+	                << "\n\tTau negvalue: [" << " I: " << tauneg_I_ << ", " << " E: " << tauneg_E_ << "]"<< std::endl
+	                << "\n\tWex value: [" << " I: " << Wex_I_ << ", " << " E: " << Wex_E_ << "]"<< std::endl
+	                << "\n\tAneg value: [" << " I: " << Aneg_I_ << ", " << " E: " << Aneg_E_ << "]"<< std::endl
+	                << "\n\tApos value: [" << " I: " << Apos_I_ << ", " << " E: " << Apos_E_ << "]"<< std::endl
+		);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllSTDPSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
-   AllSpikingSynapses::readEdge(input, iEdg);
+void AllSTDPSynapses::readEdge(std::istream& input, const BGSIZE iEdg) {
+	AllSpikingSynapses::readEdge(input, iEdg);
 
-   // input.ignore() so input skips over end-of-line characters.
-   input >> totalDelayPost_[iEdg];
-   input.ignore();
-   input >> delayQueuePost_[iEdg];
-   input.ignore();
-   input >> delayIndexPost_[iEdg];
-   input.ignore();
-   input >> delayQueuePostLength_[iEdg];
-   input.ignore();
-   input >> tauspost_[iEdg];
-   input.ignore();
-   input >> tauspre_[iEdg];
-   input.ignore();
-   input >> taupos_[iEdg];
-   input.ignore();
-   input >> tauneg_[iEdg];
-   input.ignore();
-   input >> STDPgap_[iEdg];
-   input.ignore();
-   input >> Wex_[iEdg];
-   input.ignore();
-   input >> Aneg_[iEdg];
-   input.ignore();
-   input >> Apos_[iEdg];
-   input.ignore();
-   input >> mupos_[iEdg];
-   input.ignore();
-   input >> muneg_[iEdg];
-   input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> totalDelayPost_[iEdg];
+	input.ignore();
+	input >> delayQueuePost_[iEdg];
+	input.ignore();
+	input >> delayIndexPost_[iEdg];
+	input.ignore();
+	input >> delayQueuePostLength_[iEdg];
+	input.ignore();
+	input >> tauspost_[iEdg];
+	input.ignore();
+	input >> tauspre_[iEdg];
+	input.ignore();
+	input >> taupos_[iEdg];
+	input.ignore();
+	input >> tauneg_[iEdg];
+	input.ignore();
+	input >> STDPgap_[iEdg];
+	input.ignore();
+	input >> Wex_[iEdg];
+	input.ignore();
+	input >> Aneg_[iEdg];
+	input.ignore();
+	input >> Apos_[iEdg];
+	input.ignore();
+	input >> mupos_[iEdg];
+	input.ignore();
+	input >> muneg_[iEdg];
+	input.ignore();
 }
 
 ///  Write the synapse data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-   AllSpikingSynapses::writeEdge(output, iEdg);
+void AllSTDPSynapses::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	AllSpikingSynapses::writeEdge(output, iEdg);
 
-   output << totalDelayPost_[iEdg] << std::ends;
-   output << delayQueuePost_[iEdg] << std::ends;
-   output << delayIndexPost_[iEdg] << std::ends;
-   output << delayQueuePostLength_[iEdg] << std::ends;
-   output << tauspost_[iEdg] << std::ends;
-   output << tauspre_[iEdg] << std::ends;
-   output << taupos_[iEdg] << std::ends;
-   output << tauneg_[iEdg] << std::ends;
-   output << STDPgap_[iEdg] << std::ends;
-   output << Wex_[iEdg] << std::ends;
-   output << Aneg_[iEdg] << std::ends;
-   output << Apos_[iEdg] << std::ends;
-   output << mupos_[iEdg] << std::ends;
-   output << muneg_[iEdg] << std::ends;
+	output << totalDelayPost_[iEdg] << std::ends;
+	output << delayQueuePost_[iEdg] << std::ends;
+	output << delayIndexPost_[iEdg] << std::ends;
+	output << delayQueuePostLength_[iEdg] << std::ends;
+	output << tauspost_[iEdg] << std::ends;
+	output << tauspre_[iEdg] << std::ends;
+	output << taupos_[iEdg] << std::ends;
+	output << tauneg_[iEdg] << std::ends;
+	output << STDPgap_[iEdg] << std::ends;
+	output << Wex_[iEdg] << std::ends;
+	output << Aneg_[iEdg] << std::ends;
+	output << Apos_[iEdg] << std::ends;
+	output << mupos_[iEdg] << std::ends;
+	output << muneg_[iEdg] << std::ends;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -240,7 +239,7 @@ void AllSTDPSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
 ///  @param  iEdg            Index of the synapse to set.
 ///  @param  deltaT          Inner simulation step duration
 void AllSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   AllSpikingSynapses::resetEdge(iEdg, deltaT);
+	AllSpikingSynapses::resetEdge(iEdg, deltaT);
 }
 
 ///  Create a Synapse and connect it to the model.
@@ -252,27 +251,29 @@ void AllSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
 ///  @param  sumPoint    Summation point address.
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
-void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
-                                    const BGFLOAT deltaT, edgeType type) {
+void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+                                 const BGFLOAT deltaT, edgeType type) {
 
-   totalDelayPost_[iEdg] = 0;// Apr 12th 2020 move this line so that when AllSpikingSynapses::createEdge() is called, inside this method the initSpikeQueue() method can be called successfully
-   AllSpikingSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
+	totalDelayPost_[iEdg] = 0;
+	// Apr 12th 2020 move this line so that when AllSpikingSynapses::createEdge() is called, inside this method the initSpikeQueue() method can be called successfully
+	AllSpikingSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
 
-   // May 1st 2020
-   // Use constants from Froemke and Dan (2002).
-   // Spike-timing-dependent synaptic modification induced by natural spike trains. Nature 416 (3/2002)
-   //Apos_[iEdg] = 0.005;
-   //Aneg_[iEdg] = -(1.05*0.005);
-   Apos_[iEdg] = Apos_E_;
-   Aneg_[iEdg] = Aneg_E_;
-   STDPgap_[iEdg] = defaultSTDPgap_;
-   tauspost_[iEdg] = tauspost_E_;
-   tauspre_[iEdg] = tauspre_E_;
-   taupos_[iEdg] = taupos_E_;
-   tauneg_[iEdg] = tauneg_E_;
-   Wex_[iEdg] = Wex_E_ ;// this is based on overlap of 2 neurons' radii (r=4) of outgrowth, scale it by SYNAPSE_STRENGTH_ADJUSTMENT.
-   mupos_[iEdg] = 0;
-   muneg_[iEdg] = 0;
+	// May 1st 2020
+	// Use constants from Froemke and Dan (2002).
+	// Spike-timing-dependent synaptic modification induced by natural spike trains. Nature 416 (3/2002)
+	//Apos_[iEdg] = 0.005;
+	//Aneg_[iEdg] = -(1.05*0.005);
+	Apos_[iEdg] = Apos_E_;
+	Aneg_[iEdg] = Aneg_E_;
+	STDPgap_[iEdg] = defaultSTDPgap_;
+	tauspost_[iEdg] = tauspost_E_;
+	tauspre_[iEdg] = tauspre_E_;
+	taupos_[iEdg] = taupos_E_;
+	tauneg_[iEdg] = tauneg_E_;
+	Wex_[iEdg] = Wex_E_;
+	// this is based on overlap of 2 neurons' radii (r=4) of outgrowth, scale it by SYNAPSE_STRENGTH_ADJUSTMENT.
+	mupos_[iEdg] = 0;
+	muneg_[iEdg] = 0;
 }
 
 #ifndef __CUDACC__
@@ -281,166 +282,164 @@ void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVerte
 ///
 ///  @param  iEdg      Index of the Synapse to connect to.
 ///  @param  neurons   The Neuron list to search from.
-void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons) {
-   // If the synapse is inhibitory or its weight is zero, update synapse state using AllSpikingSynapses::advanceEdge method
-   //LOG4CPLUS_DEBUG(edgeLogger_, "iEdg : " << iEdg );
-   
-   BGFLOAT &W = W_[iEdg];
-   /*
-   if (W <= 0.0) {
-      AllSpikingSynapses::advanceEdge(iEdg, neurons);
-      return;
-   }
-    */
+void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices* neurons) {
+	// If the synapse is inhibitory or its weight is zero, update synapse state using AllSpikingSynapses::advanceEdge method
+	//LOG4CPLUS_DEBUG(edgeLogger_, "iEdg : " << iEdg );
 
-   BGFLOAT &decay = decay_[iEdg];
-   BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &summationPoint = *(summationPoint_[iEdg]);
+	BGFLOAT& W = W_[iEdg];
+	/*
+	if (W <= 0.0) {
+	   AllSpikingSynapses::advanceEdge(iEdg, neurons);
+	   return;
+	}
+	 */
 
-   // is an input in the queue?
-   bool fPre = isSpikeQueue(iEdg);
-   bool fPost = isSpikeQueuePost(iEdg);
+	BGFLOAT& decay = decay_[iEdg];
+	BGFLOAT& psr = psr_[iEdg];
+	BGFLOAT& summationPoint = *(summationPoint_[iEdg]);
 
-   if (fPre || fPost) {
-      const BGFLOAT taupos = taupos_[iEdg];
-      const BGFLOAT tauneg = tauneg_[iEdg];
-      const int total_delay = totalDelay_[iEdg];
+	// is an input in the queue?
+	bool fPre = isSpikeQueue(iEdg);
+	bool fPost = isSpikeQueuePost(iEdg);
 
-      BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
-      AllSpikingNeurons *spNeurons = dynamic_cast<AllSpikingNeurons *>(neurons);
+	if (fPre || fPost) {
+		const BGFLOAT taupos = taupos_[iEdg];
+		const BGFLOAT tauneg = tauneg_[iEdg];
+		const int total_delay = totalDelay_[iEdg];
 
-      // pre and post neurons index
-      int idxPre = sourceVertexIndex_[iEdg];
-      int idxPost = destVertexIndex_[iEdg];
-      uint64_t spikeHistory, spikeHistory2;
-      BGFLOAT delta;
-      BGFLOAT epre, epost;
+		BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
+		auto spNeurons = dynamic_cast<AllSpikingNeurons*>(neurons);
 
-      if (fPre) {   // preSpikeHit
-         // spikeCount points to the next available position of spike_history,
-         // so the getSpikeHistory w/offset = -2 will return the spike time
-         // just one before the last spike.
-         spikeHistory = spNeurons->getSpikeHistory(idxPre, -2);
-         
-         epre = 1.0;
-         epost = 1.0;
-         // call the learning function stdpLearning() for each pair of
-         // pre-post spikes
-         int offIndex = -1;   // last spike
-         while (true) {
-            spikeHistory = spNeurons->getSpikeHistory(idxPost, offIndex);
-            if (spikeHistory == ULONG_MAX)
-               break;
-            // delta is the spike interval between pre-post spikes
-            // (include pre-synaptic transmission delay)
-            delta = -static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
-            /*
-             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPre" << std::endl
-             << "\tiEdg: " << iEdg << std::endl
-             << "\tidxPre: " << idxPre << std::endl
-             << "\tidxPost: " << idxPost << std::endl
-             << "\tspikeHistory: " << spikeHistory << std::endl
-             << "\tepre: " << epre << std::endl
-             << "\tepost: " << epost << std::endl
-             << "\tg_simulationStep: " << g_simulationStep << std::endl
-             << "\tdelta: " << delta << std::endl << std::endl);
-             */
-            
-            if (delta <= -3.0 * tauneg)
-               break;
-            
-            stdpLearning(iEdg, delta, epost, epre, idxPre, idxPost);
-            --offIndex;
-         }
+		// pre and post neurons index
+		int idxPre = sourceVertexIndex_[iEdg];
+		int idxPost = destVertexIndex_[iEdg];
+		uint64_t spikeHistory, spikeHistory2;
+		BGFLOAT delta;
+		BGFLOAT epre, epost;
 
-         changePSR(iEdg, deltaT);
-      }
+		if (fPre) {
+			// preSpikeHit
+			// spikeCount points to the next available position of spike_history,
+			// so the getSpikeHistory w/offset = -2 will return the spike time
+			// just one before the last spike.
+			spikeHistory = spNeurons->getSpikeHistory(idxPre, -2);
 
-      if (fPost) {   // postSpikeHit
-                     // spikeCount points to the next available position of spike_history,
-                     // so the getSpikeHistory w/offset = -2 will return the spike time
-                     // just one before the last spike.
-         spikeHistory = spNeurons->getSpikeHistory(idxPost, -2);
-         epost = 1.0;
-         epre=1;
-         
-         
-         // call the learning function stdpLearning() for each pair of
-         // post-pre spikes
-         int offIndex = -1;   // last spike
-         while (true) {
-            spikeHistory = spNeurons->getSpikeHistory(idxPre, offIndex);
-            if (spikeHistory == ULONG_MAX)
-               break;
-            
-            if (spikeHistory + total_delay > g_simulationStep) {
-               --offIndex;
-               continue;
-            }
-            // delta is the spike interval between post-pre spikes
-            delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory - total_delay) * deltaT;
-            /*
-             LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPost" << std::endl
-             << "\tiEdg: " << iEdg << std::endl
-             << "\tidxPre: " << idxPre << std::endl
-             << "\tidxPost: " << idxPost << std::endl
-             << "\tspikeHistory: " << spikeHistory << std::endl
-             << "\tg_simulationStep: " << g_simulationStep << std::endl
-             << "\tepre: " << epre << std::endl
-             << "\tepost: " << epost << std::endl
-             << "\tdelta: " << delta << std::endl << std::endl);
-             */
-            if (delta >= 3.0 * taupos)
-               break;
-            
-            stdpLearning(iEdg, delta, epost, epre, idxPre, idxPost);
-            --offIndex;
-         }
-      }
-   }
+			epre = 1.0;
+			epost = 1.0;
+			// call the learning function stdpLearning() for each pair of
+			// pre-post spikes
+			int offIndex = -1; // last spike
+			while (true) {
+				spikeHistory = spNeurons->getSpikeHistory(idxPost, offIndex);
+				if (spikeHistory == ULONG_MAX) break;
+				// delta is the spike interval between pre-post spikes
+				// (include pre-synaptic transmission delay)
+				delta = -static_cast<BGFLOAT>(g_simulationStep - spikeHistory) * deltaT;
+				/*
+				 LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPre" << std::endl
+				 << "\tiEdg: " << iEdg << std::endl
+				 << "\tidxPre: " << idxPre << std::endl
+				 << "\tidxPost: " << idxPost << std::endl
+				 << "\tspikeHistory: " << spikeHistory << std::endl
+				 << "\tepre: " << epre << std::endl
+				 << "\tepost: " << epost << std::endl
+				 << "\tg_simulationStep: " << g_simulationStep << std::endl
+				 << "\tdelta: " << delta << std::endl << std::endl);
+				 */
 
-   // decay the post spike response
-   psr *= decay;
-   // and apply it to the summation point
+				if (delta <= -3.0 * tauneg) break;
+
+				stdpLearning(iEdg, delta, epost, epre, idxPre, idxPost);
+				--offIndex;
+			}
+
+			changePSR(iEdg, deltaT);
+		}
+
+		if (fPost) {
+			// postSpikeHit
+			// spikeCount points to the next available position of spike_history,
+			// so the getSpikeHistory w/offset = -2 will return the spike time
+			// just one before the last spike.
+			spikeHistory = spNeurons->getSpikeHistory(idxPost, -2);
+			epost = 1.0;
+			epre = 1;
+
+
+			// call the learning function stdpLearning() for each pair of
+			// post-pre spikes
+			int offIndex = -1; // last spike
+			while (true) {
+				spikeHistory = spNeurons->getSpikeHistory(idxPre, offIndex);
+				if (spikeHistory == ULONG_MAX) break;
+
+				if (spikeHistory + total_delay > g_simulationStep) {
+					--offIndex;
+					continue;
+				}
+				// delta is the spike interval between post-pre spikes
+				delta = static_cast<BGFLOAT>(g_simulationStep - spikeHistory - total_delay) * deltaT;
+				/*
+				 LOG4CPLUS_DEBUG(fileLogger_,"\nAllSTDPSynapses::advanceSynapse: fPost" << std::endl
+				 << "\tiEdg: " << iEdg << std::endl
+				 << "\tidxPre: " << idxPre << std::endl
+				 << "\tidxPost: " << idxPost << std::endl
+				 << "\tspikeHistory: " << spikeHistory << std::endl
+				 << "\tg_simulationStep: " << g_simulationStep << std::endl
+				 << "\tepre: " << epre << std::endl
+				 << "\tepost: " << epost << std::endl
+				 << "\tdelta: " << delta << std::endl << std::endl);
+				 */
+				if (delta >= 3.0 * taupos) break;
+
+				stdpLearning(iEdg, delta, epost, epre, idxPre, idxPost);
+				--offIndex;
+			}
+		}
+	}
+
+	// decay the post spike response
+	psr *= decay;
+	// and apply it to the summation point
 #ifdef USE_OMP
 #pragma omp atomic
 #endif
-   summationPoint += psr;
+	summationPoint += psr;
 #ifdef USE_OMP
-   //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
-   //#pragma omp flush (summationPoint)
+	//PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
+	//#pragma omp flush (summationPoint)
 #endif
 
 }
 
 
-BGFLOAT AllSTDPSynapses::synapticWeightModification(const BGSIZE iEdg, BGFLOAT synapticWeight, double delta)
-{
-   BGFLOAT STDPgap = STDPgap_[iEdg];
-   BGFLOAT muneg = muneg_[iEdg];
-   BGFLOAT mupos = mupos_[iEdg];
-   BGFLOAT tauneg = tauneg_[iEdg];
-   BGFLOAT taupos = taupos_[iEdg];
-   BGFLOAT Aneg = Aneg_[iEdg];
-   BGFLOAT Apos = Apos_[iEdg];
-   BGFLOAT Wex = Wex_[iEdg];
-   BGFLOAT& W = W_[iEdg];
-   edgeType type = type_[iEdg];
-   BGFLOAT dw = 0;
-   BGFLOAT oldW = W;
-   
-   // BGFLOAT modDelta = fabs(delta);
-   
-   if (delta < -STDPgap) {
-      // depression
-      
-      dw = pow(fabs(W) / Wex, muneg) * Aneg * exp(delta / tauneg);  // normalize
-   } else if (delta > STDPgap) {
-      // potentiation
-      dw = pow(fabs(Wex - fabs(W)) / Wex, mupos) * Apos * exp(-delta / taupos); // normalize
-   }
-   
-   return dw;
+BGFLOAT AllSTDPSynapses::synapticWeightModification(const BGSIZE iEdg, BGFLOAT synapticWeight, double delta) {
+	BGFLOAT STDPgap = STDPgap_[iEdg];
+	BGFLOAT muneg = muneg_[iEdg];
+	BGFLOAT mupos = mupos_[iEdg];
+	BGFLOAT tauneg = tauneg_[iEdg];
+	BGFLOAT taupos = taupos_[iEdg];
+	BGFLOAT Aneg = Aneg_[iEdg];
+	BGFLOAT Apos = Apos_[iEdg];
+	BGFLOAT Wex = Wex_[iEdg];
+	BGFLOAT& W = W_[iEdg];
+	edgeType type = type_[iEdg];
+	BGFLOAT dw = 0;
+	BGFLOAT oldW = W;
+
+	// BGFLOAT modDelta = fabs(delta);
+
+	if (delta < -STDPgap) {
+		// depression
+
+		dw = pow(fabs(W) / Wex, muneg) * Aneg * exp(delta / tauneg); // normalize
+	}
+	else if (delta > STDPgap) {
+		// potentiation
+		dw = pow(fabs(Wex - fabs(W)) / Wex, mupos) * Apos * exp(-delta / taupos); // normalize
+	}
+
+	return dw;
 }
 
 
@@ -455,50 +454,45 @@ BGFLOAT AllSTDPSynapses::synapticWeightModification(const BGSIZE iEdg, BGFLOAT s
 ///  @param destVertex Index of destination neuron
 void AllSTDPSynapses::stdpLearning(const BGSIZE iEdg, double delta, double epost,
                                    double epre, int srcVertex, int destVertex) {
-   BGFLOAT STDPgap = STDPgap_[iEdg];
-   BGFLOAT muneg = muneg_[iEdg];
-   BGFLOAT mupos = mupos_[iEdg];
-   BGFLOAT tauneg = tauneg_[iEdg];
-   BGFLOAT taupos = taupos_[iEdg];
-   BGFLOAT Aneg = Aneg_[iEdg];
-   BGFLOAT Apos = Apos_[iEdg];
-   BGFLOAT Wex = Wex_[iEdg];
-   BGFLOAT& W = W_[iEdg];
-   edgeType type = type_[iEdg];
-   BGFLOAT oldW=W;
-   // BGFLOAT modDelta = fabs(delta);
+	BGFLOAT STDPgap = STDPgap_[iEdg];
+	BGFLOAT muneg = muneg_[iEdg];
+	BGFLOAT mupos = mupos_[iEdg];
+	BGFLOAT tauneg = tauneg_[iEdg];
+	BGFLOAT taupos = taupos_[iEdg];
+	BGFLOAT Aneg = Aneg_[iEdg];
+	BGFLOAT Apos = Apos_[iEdg];
+	BGFLOAT Wex = Wex_[iEdg];
+	BGFLOAT& W = W_[iEdg];
+	edgeType type = type_[iEdg];
+	BGFLOAT oldW = W;
+	// BGFLOAT modDelta = fabs(delta);
 
-   if (delta <= fabs(STDPgap)) {
-      return;
-   }
+	if (delta <= fabs(STDPgap)) return;
 
-   // dw is the fractional change in synaptic strength; add 1.0 to become the scaling ratio
-   //dw = 1.0 + dw * epre * epost;
-   BGFLOAT dw = 1.0 + synapticWeightModification(iEdg, W, delta);   
-   
-   // if scaling ratio is less than zero, set it to zero so this synapse, its
-   // strength is always zero
-   // TODO: Where is the code for this?
-   
-   // current weight multiplies dw (scaling ratio) to generate new weight
-   if(dw != 0.0)
-      W *= dw;
-   
-   // if new weight is bigger than Wex (maximum allowed weight), then set it to Wex
-   if (fabs(W) > Wex) {
-      W = edgSign(type) * Wex;
-   }
-   /*
-    LOG4CPLUS_DEBUG(edgeLogger_, std::endl <<
-    "iEdg value " << iEdg
-    << "; source:" << srcVertex
-    << "; dest:" << destVertex
-    << "; delta:" << delta
-    << "; oldW:" << oldW
-    << " ;W:" << W
-    << std::endl);
-    
-    */
+	// dw is the fractional change in synaptic strength; add 1.0 to become the scaling ratio
+	//dw = 1.0 + dw * epre * epost;
+	BGFLOAT dw = 1.0 + synapticWeightModification(iEdg, W, delta);
+
+	// if scaling ratio is less than zero, set it to zero so this synapse, its
+	// strength is always zero
+	// TODO: Where is the code for this?
+
+	// current weight multiplies dw (scaling ratio) to generate new weight
+	if (dw != 0.0) W *= dw;
+
+	// if new weight is bigger than Wex (maximum allowed weight), then set it to Wex
+	if (fabs(W) > Wex) W = edgSign(type) * Wex;
+	/*
+	 LOG4CPLUS_DEBUG(edgeLogger_, std::endl <<
+	 "iEdg value " << iEdg
+	 << "; source:" << srcVertex
+	 << "; dest:" << destVertex
+	 << "; delta:" << delta
+	 << "; oldW:" << oldW
+	 << " ;W:" << W
+	 << std::endl);
+	 
+	 */
 }
 
 ///  Checks if there is an input spike in the queue (for back propagation).
@@ -506,38 +500,34 @@ void AllSTDPSynapses::stdpLearning(const BGSIZE iEdg, double delta, double epost
 ///  @param  iEdg   Index of the Synapse to connect to.
 ///  @return true if there is an input spike event.
 bool AllSTDPSynapses::isSpikeQueuePost(const BGSIZE iEdg) {
-   uint32_t &delayQueue = delayQueuePost_[iEdg];
-   int &delayIdx = delayIndexPost_[iEdg];
-   int &ldelayQueue = delayQueuePostLength_[iEdg];
+	uint32_t& delayQueue = delayQueuePost_[iEdg];
+	int& delayIdx = delayIndexPost_[iEdg];
+	int& ldelayQueue = delayQueuePostLength_[iEdg];
 
-   bool r = delayQueue & (0x1 << delayIdx);
-   delayQueue &= ~(0x1 << delayIdx);
-   if (++delayIdx >= ldelayQueue) {
-      delayIdx = 0;
-   }
-   return r;
+	bool r = delayQueue & (0x1 << delayIdx);
+	delayQueue &= ~(0x1 << delayIdx);
+	if (++delayIdx >= ldelayQueue) delayIdx = 0;
+	return r;
 }
 
 ///  Prepares Synapse for a spike hit (for back propagation).
 ///
 ///  @param  iEdg   Index of the Synapse to connect to.
 void AllSTDPSynapses::postSpikeHit(const BGSIZE iEdg) {
-   uint32_t &delay_queue = delayQueuePost_[iEdg];
-   int &delayIdx = delayIndexPost_[iEdg];
-   int &ldelayQueue = delayQueuePostLength_[iEdg];
-   int &total_delay = totalDelayPost_[iEdg];
+	uint32_t& delay_queue = delayQueuePost_[iEdg];
+	int& delayIdx = delayIndexPost_[iEdg];
+	int& ldelayQueue = delayQueuePostLength_[iEdg];
+	int& total_delay = totalDelayPost_[iEdg];
 
-   // Add to spike queue
+	// Add to spike queue
 
-   // calculate index where to insert the spike into delayQueue
-   int idx = delayIdx + total_delay;
-   if (idx >= ldelayQueue) {
-      idx -= ldelayQueue;
-   }
+	// calculate index where to insert the spike into delayQueue
+	int idx = delayIdx + total_delay;
+	if (idx >= ldelayQueue) idx -= ldelayQueue;
 
-   // set a spike
-   assert(!(delay_queue & (0x1 << idx)));
-   delay_queue |= (0x1 << idx);
+	// set a spike
+	assert(!(delay_queue & (0x1 << idx)));
+	delay_queue |= (0x1 << idx);
 }
 
 #endif
@@ -546,26 +536,24 @@ void AllSTDPSynapses::postSpikeHit(const BGSIZE iEdg) {
 ///  is allowed in the synapse class.
 ///
 ///  @retrun true if the back propagation is allowed.
-bool AllSTDPSynapses::allowBackPropagation() {
-   return true;
-}
+bool AllSTDPSynapses::allowBackPropagation() { return true; }
 
 ///  Prints SynapsesProps data.
 void AllSTDPSynapses::printSynapsesProps() const {
-   AllSpikingSynapses::printSynapsesProps();
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      if (W_[i] != 0.0) {
-         std::cout << "total_delayPost[" << i << "] = " << totalDelayPost_[i];
-         std::cout << " tauspost_: " << tauspost_[i];
-         std::cout << " tauspre_: " << tauspre_[i];
-         std::cout << " taupos_: " << taupos_[i];
-         std::cout << " tauneg_: " << tauneg_[i];
-         std::cout << " STDPgap_: " << STDPgap_[i];
-         std::cout << " Wex_: " << Wex_[i];
-         std::cout << " Aneg_: " << Aneg_[i];
-         std::cout << " Apos_: " << Apos_[i];
-         std::cout << " mupos_: " << mupos_[i];
-         std::cout << " muneg_: " << muneg_[i] << std::endl;
-      }
-   }
+	AllSpikingSynapses::printSynapsesProps();
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		if (W_[i] != 0.0) {
+			std::cout << "total_delayPost[" << i << "] = " << totalDelayPost_[i];
+			std::cout << " tauspost_: " << tauspost_[i];
+			std::cout << " tauspre_: " << tauspre_[i];
+			std::cout << " taupos_: " << taupos_[i];
+			std::cout << " tauneg_: " << tauneg_[i];
+			std::cout << " STDPgap_: " << STDPgap_[i];
+			std::cout << " Wex_: " << Wex_[i];
+			std::cout << " Aneg_: " << Aneg_[i];
+			std::cout << " Apos_: " << Apos_[i];
+			std::cout << " mupos_: " << mupos_[i];
+			std::cout << " muneg_: " << muneg_[i] << std::endl;
+		}
+	}
 }

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -74,7 +74,7 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 	public:
 		AllSTDPSynapses();
 
-		AllSTDPSynapses(const int numVertices, const int maxEdges);
+		AllSTDPSynapses(int numVertices, int maxEdges);
 
 		~AllSTDPSynapses() override;
 
@@ -87,7 +87,7 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 		///
 		///  @param  iEdg     Index of the synapse to set.
 		///  @param  deltaT   Inner simulation step duration
-		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void resetEdge(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 		///  Check if the back propagation (notify a spike event to the pre neuron)
 		///  is allowed in the synapse class.
@@ -111,7 +111,7 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Synapse to create.
-		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, BGFLOAT deltaT,
 		                edgeType type) override;
 
 		///  Prints SynapsesProps data.
@@ -122,24 +122,24 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of synapses per neuron.
-		void setupEdges(const int numVertices, const int maxEdges) override;
+		void setupEdges(int numVertices, int maxEdges) override;
 
 		///  Sets the data for Synapse to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the synapse to set.
-		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+		void readEdge(std::istream& input, BGSIZE iEdg) override;
 
 		///  Write the synapse data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the synapse to print out.
-		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+		void writeEdge(std::ostream& output, BGSIZE iEdg) const override;
 
 		///  Initializes the queues for the Synapse.
 		///
 		///  @param  iEdg   index of the synapse to set.
-		void initSpikeQueue(const BGSIZE iEdg) override;
+		void initSpikeQueue(BGSIZE iEdg) override;
 
 #ifdef __CUDACC__
    public:
@@ -241,21 +241,21 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 		///
 		///  @param  iEdg      Index of the Synapse to connect to.
 		///  @param  neurons   The Neuron list to search from.
-		void advanceEdge(const BGSIZE iEdg, AllVertices* neurons) override;
+		void advanceEdge(BGSIZE iEdg, AllVertices* neurons) override;
 
 		///  Prepares Synapse for a spike hit (for back propagation).
 		///
 		///  @param  iEdg   Index of the Synapse to connect to.
-		void postSpikeHit(const BGSIZE iEdg) override;
+		void postSpikeHit(BGSIZE iEdg) override;
 
 	protected:
 		///  Checks if there is an input spike in the queue (for back propagation).
 		///
 		///  @param  iEdg   Index of the Synapse to connect to.
 		///  @return true if there is an input spike event.
-		bool isSpikeQueuePost(const BGSIZE iEdg);
+		bool isSpikeQueuePost(BGSIZE iEdg);
 
-		virtual BGFLOAT synapticWeightModification(const BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
+		virtual BGFLOAT synapticWeightModification(BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
 
 	private:
 		///  Adjust synapse weight according to the Spike-timing-dependent synaptic modification
@@ -267,7 +267,7 @@ class AllSTDPSynapses : public AllSpikingSynapses {
 		///  @param  epre        Params for the rule given in Froemke and Dan (2002).
 		///  @param srcVertex Index of source neuron
 		///  @param destVertex Index of destination neuron
-		void stdpLearning(const BGSIZE iEdg, double delta, double epost, double epre,
+		void stdpLearning(BGSIZE iEdg, double delta, double epost, double epre,
 		                  int srcVertex, int destVertex);
 
 #endif

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -128,20 +128,20 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg) override;
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
 
    ///  Write the synapse data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const override;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
 
    ///  Initializes the queues for the Synapse.
    ///
    ///  @param  iEdg   index of the synapse to set.
    virtual void initSpikeQueue(const BGSIZE iEdg) override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all synapses' states,
        ///  and copy them from host to GPU memory.
@@ -234,7 +234,7 @@ protected:
        ///  @param  numVertices            Number of vertices.
        ///  @param  maxEdgesPerVertex  Maximum number of synapses per neuron.
        void copyDeviceToHost( AllSTDPSynapsesDeviceProperties& allEdgesDevice );
-#else // !defined(USE_GPU)
+#else
 public:
    ///  Advance one specific Synapse.
    ///  Update the state of synapse for a time step
@@ -340,7 +340,7 @@ public:
    BGFLOAT Apos_E_;
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllSTDPSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperties
 {
         ///  The synaptic transmission delay (delay of dendritic backpropagating spike), 
@@ -396,4 +396,4 @@ struct AllSTDPSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperti
         ///  True if use the rule given in Froemke and Dan (2002).
         bool *useFroemkeDanSTDP_;
 };
-#endif // defined(USE_GPU)
+#endif 

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -71,75 +71,75 @@
 struct AllSTDPSynapsesDeviceProperties;
 
 class AllSTDPSynapses : public AllSpikingSynapses {
-public:
-   AllSTDPSynapses();
+	public:
+		AllSTDPSynapses();
 
-   AllSTDPSynapses(const int numVertices, const int maxEdges);
+		AllSTDPSynapses(const int numVertices, const int maxEdges);
 
-   virtual ~AllSTDPSynapses();
+		~AllSTDPSynapses() override;
 
-   static AllEdges *Create() { return new AllSTDPSynapses(); }
+		static AllEdges* Create() { return new AllSTDPSynapses(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Reset time varying state vars and recompute decay.
-   ///
-   ///  @param  iEdg     Index of the synapse to set.
-   ///  @param  deltaT   Inner simulation step duration
-   virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		///  Reset time varying state vars and recompute decay.
+		///
+		///  @param  iEdg     Index of the synapse to set.
+		///  @param  deltaT   Inner simulation step duration
+		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-   ///  Check if the back propagation (notify a spike event to the pre neuron)
-   ///  is allowed in the synapse class.
-   ///
-   ///  @return true if the back propagation is allowed.
-   virtual bool allowBackPropagation() override;
+		///  Check if the back propagation (notify a spike event to the pre neuron)
+		///  is allowed in the synapse class.
+		///
+		///  @return true if the back propagation is allowed.
+		bool allowBackPropagation() override;
 
-   /// Load member variables from configuration file. Registered to OperationManager as
-   /// Operation::op::loadParameters
-   virtual void loadParameters() override;
-   
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		/// Load member variables from configuration file. Registered to OperationManager as
+		/// Operation::op::loadParameters
+		void loadParameters() override;
 
-   ///  Create a Synapse and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  srcVertex   Coordinates of the source Neuron.
-   ///  @param  destVertex  Coordinates of the destination Neuron.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Prints SynapsesProps data.
-   virtual void printSynapsesProps() const override;
+		///  Create a Synapse and connect it to the model.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  srcVertex   Coordinates of the source Neuron.
+		///  @param  destVertex  Coordinates of the destination Neuron.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Synapse to create.
+		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		                edgeType type) override;
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges) override;
+		///  Prints SynapsesProps data.
+		void printSynapsesProps() const override;
 
-   ///  Sets the data for Synapse to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of synapses per neuron.
+		void setupEdges(const int numVertices, const int maxEdges) override;
 
-   ///  Write the synapse data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
+		///  Sets the data for Synapse to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the synapse to set.
+		void readEdge(std::istream& input, const BGSIZE iEdg) override;
 
-   ///  Initializes the queues for the Synapse.
-   ///
-   ///  @param  iEdg   index of the synapse to set.
-   virtual void initSpikeQueue(const BGSIZE iEdg) override;
+		///  Write the synapse data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the synapse to print out.
+		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+
+		///  Initializes the queues for the Synapse.
+		///
+		///  @param  iEdg   index of the synapse to set.
+		void initSpikeQueue(const BGSIZE iEdg) override;
 
 #ifdef __CUDACC__
    public:
@@ -235,109 +235,109 @@ protected:
        ///  @param  maxEdgesPerVertex  Maximum number of synapses per neuron.
        void copyDeviceToHost( AllSTDPSynapsesDeviceProperties& allEdgesDevice );
 #else
-public:
-   ///  Advance one specific Synapse.
-   ///  Update the state of synapse for a time step
-   ///
-   ///  @param  iEdg      Index of the Synapse to connect to.
-   ///  @param  neurons   The Neuron list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *neurons) override;
+	public:
+		///  Advance one specific Synapse.
+		///  Update the state of synapse for a time step
+		///
+		///  @param  iEdg      Index of the Synapse to connect to.
+		///  @param  neurons   The Neuron list to search from.
+		void advanceEdge(const BGSIZE iEdg, AllVertices* neurons) override;
 
-   ///  Prepares Synapse for a spike hit (for back propagation).
-   ///
-   ///  @param  iEdg   Index of the Synapse to connect to.
-   virtual void postSpikeHit(const BGSIZE iEdg) override;
+		///  Prepares Synapse for a spike hit (for back propagation).
+		///
+		///  @param  iEdg   Index of the Synapse to connect to.
+		void postSpikeHit(const BGSIZE iEdg) override;
 
-protected:
-   ///  Checks if there is an input spike in the queue (for back propagation).
-   ///
-   ///  @param  iEdg   Index of the Synapse to connect to.
-   ///  @return true if there is an input spike event.
-   bool isSpikeQueuePost(const BGSIZE iEdg);
+	protected:
+		///  Checks if there is an input spike in the queue (for back propagation).
+		///
+		///  @param  iEdg   Index of the Synapse to connect to.
+		///  @return true if there is an input spike event.
+		bool isSpikeQueuePost(const BGSIZE iEdg);
 
-   virtual BGFLOAT synapticWeightModification(const BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
+		virtual BGFLOAT synapticWeightModification(const BGSIZE iEdg, BGFLOAT edgeWeight, double delta);
 
-private:
-   ///  Adjust synapse weight according to the Spike-timing-dependent synaptic modification
-   ///  induced by natural spike trains
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  delta       Pre/post synaptic spike interval.
-   ///  @param  epost       Params for the rule given in Froemke and Dan (2002).
-   ///  @param  epre        Params for the rule given in Froemke and Dan (2002).
-   ///  @param srcVertex Index of source neuron
-   ///  @param destVertex Index of destination neuron
-   void stdpLearning(const BGSIZE iEdg, double delta, double epost, double epre,
-                     int srcVertex, int destVertex);
+	private:
+		///  Adjust synapse weight according to the Spike-timing-dependent synaptic modification
+		///  induced by natural spike trains
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  delta       Pre/post synaptic spike interval.
+		///  @param  epost       Params for the rule given in Froemke and Dan (2002).
+		///  @param  epre        Params for the rule given in Froemke and Dan (2002).
+		///  @param srcVertex Index of source neuron
+		///  @param destVertex Index of destination neuron
+		void stdpLearning(const BGSIZE iEdg, double delta, double epost, double epre,
+		                  int srcVertex, int destVertex);
 
 #endif
-public:
-   ///  The synaptic transmission delay (delay of dendritic backpropagating spike),
-   ///  descretized into time steps.
-   int *totalDelayPost_;
+	public:
+		///  The synaptic transmission delay (delay of dendritic backpropagating spike),
+		///  descretized into time steps.
+		int* totalDelayPost_;
 
-   ///  Pointer to the delayed queue
-   uint32_t *delayQueuePost_;
+		///  Pointer to the delayed queue
+		uint32_t* delayQueuePost_;
 
-   ///  The index indicating the current time slot in the delayed queue.
-   int *delayIndexPost_;
+		///  The index indicating the current time slot in the delayed queue.
+		int* delayIndexPost_;
 
-   ///  Length of the delayed queue.
-   int *delayQueuePostLength_;
+		///  Length of the delayed queue.
+		int* delayQueuePostLength_;
 
-   ///  Used for extended rule by Froemke and Dan. See Froemke and Dan (2002).
-   ///  Spike-timing-dependent synaptic modification induced by natural spike trains.
-   ///  Nature 416 (3/2002).
-   BGFLOAT *tauspost_;
+		///  Used for extended rule by Froemke and Dan. See Froemke and Dan (2002).
+		///  Spike-timing-dependent synaptic modification induced by natural spike trains.
+		///  Nature 416 (3/2002).
+		BGFLOAT* tauspost_;
 
-   ///  sed for extended rule by Froemke and Dan.
-   BGFLOAT *tauspre_;
+		///  sed for extended rule by Froemke and Dan.
+		BGFLOAT* tauspre_;
 
-   ///  Timeconstant of exponential decay of positive learning window for STDP.
-   BGFLOAT *taupos_;
+		///  Timeconstant of exponential decay of positive learning window for STDP.
+		BGFLOAT* taupos_;
 
-   ///  Timeconstant of exponential decay of negative learning window for STDP.
-   BGFLOAT *tauneg_;
+		///  Timeconstant of exponential decay of negative learning window for STDP.
+		BGFLOAT* tauneg_;
 
-   ///  No learning is performed if \f$|Delta| = |t_{post}-t_{pre}| < STDPgap_\f$
-   BGFLOAT *STDPgap_;
+		///  No learning is performed if \f$|Delta| = |t_{post}-t_{pre}| < STDPgap_\f$
+		BGFLOAT* STDPgap_;
 
-   ///  The maximal/minimal weight of the synapse [readwrite; units=;]
-   BGFLOAT *Wex_;
+		///  The maximal/minimal weight of the synapse [readwrite; units=;]
+		BGFLOAT* Wex_;
 
-   ///  Defines the peak of the negative exponential learning window.
-   BGFLOAT *Aneg_;
+		///  Defines the peak of the negative exponential learning window.
+		BGFLOAT* Aneg_;
 
-   ///  Defines the peak of the positive exponential learning window.
-   BGFLOAT *Apos_;
+		///  Defines the peak of the positive exponential learning window.
+		BGFLOAT* Apos_;
 
-   ///  Extended multiplicative positive update:
-   ///  \f$dw = (Wex_-W)^{mupos_} * Apos_ * exp(-Delta/taupos_)\f$.
-   ///  Set to 0 for basic update. See Guetig, Aharonov, Rotter and Sompolinsky (2003).
-   ///  Learning input correlations through non-linear asymmetric Hebbian plasticity.
-   ///  Journal of Neuroscience 23. pp.3697-3714.
-   BGFLOAT *mupos_;
+		///  Extended multiplicative positive update:
+		///  \f$dw = (Wex_-W)^{mupos_} * Apos_ * exp(-Delta/taupos_)\f$.
+		///  Set to 0 for basic update. See Guetig, Aharonov, Rotter and Sompolinsky (2003).
+		///  Learning input correlations through non-linear asymmetric Hebbian plasticity.
+		///  Journal of Neuroscience 23. pp.3697-3714.
+		BGFLOAT* mupos_;
 
-   ///  Extended multiplicative negative update:
-   ///  \f$dw = W^{mupos_} * Aneg_ * exp(Delta/tauneg_)\f$. Set to 0 for basic update.
-   BGFLOAT *muneg_;
+		///  Extended multiplicative negative update:
+		///  \f$dw = W^{mupos_} * Aneg_ * exp(Delta/tauneg_)\f$. Set to 0 for basic update.
+		BGFLOAT* muneg_;
 
 
-   BGFLOAT defaultSTDPgap_;
-   BGFLOAT tauspost_I_;
-   BGFLOAT tauspre_I_;
-   BGFLOAT tauspost_E_;
-   BGFLOAT tauspre_E_;
-   BGFLOAT taupos_I_;
-   BGFLOAT tauneg_I_;
-   BGFLOAT taupos_E_;
-   BGFLOAT tauneg_E_;
-   BGFLOAT Wex_I_;
-   BGFLOAT Wex_E_;
-   BGFLOAT Aneg_I_;
-   BGFLOAT Aneg_E_;
-   BGFLOAT Apos_I_;
-   BGFLOAT Apos_E_;
+		BGFLOAT defaultSTDPgap_;
+		BGFLOAT tauspost_I_;
+		BGFLOAT tauspre_I_;
+		BGFLOAT tauspost_E_;
+		BGFLOAT tauspre_E_;
+		BGFLOAT taupos_I_;
+		BGFLOAT tauneg_I_;
+		BGFLOAT taupos_E_;
+		BGFLOAT tauneg_E_;
+		BGFLOAT Wex_I_;
+		BGFLOAT Wex_E_;
+		BGFLOAT Aneg_I_;
+		BGFLOAT Aneg_E_;
+		BGFLOAT Apos_I_;
+		BGFLOAT Apos_E_;
 };
 
 #ifdef __CUDACC__
@@ -396,4 +396,4 @@ struct AllSTDPSynapsesDeviceProperties : public AllSpikingSynapsesDeviceProperti
         ///  True if use the rule given in Froemke and Dan (2002).
         bool *useFroemkeDanSTDP_;
 };
-#endif 
+#endif

--- a/Simulator/Edges/Neuro/AllSTDPSynapses_d.cu
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses_d.cu
@@ -241,7 +241,7 @@ void AllSTDPSynapses::advanceEdges( void* allEdgesDevice, void* allVerticesDevic
     advanceSTDPSynapsesDevice <<< blocksPerGrid, threadsPerBlock >>> ( totalEdgeCount_, (EdgeIndexMap*) edgeIndexMapDevice, g_simulationStep, Simulator::getInstance().getDeltaT(), 
                                 (AllSTDPSynapsesDeviceProperties*)allEdgesDevice, (AllSpikingNeuronsDeviceProperties*)allVerticesDevice, maxSpikes );
 }
-    
+
 ///  Set synapse class ID defined by enumClassSynapses for the caller's Synapse class.
 ///  The class ID will be set to classSynapses_d in device memory,
 ///  and the classSynapses_d will be referred to call a device function for the

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -189,16 +189,16 @@ void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVe
 
 	BGFLOAT tau;
 	switch (type) {
-		case II: tau = 6e-3;
+		case edgeType::II: tau = 6e-3;
 			delay = 0.8e-3;
 			break;
-		case IE: tau = 6e-3;
+		case edgeType::IE: tau = 6e-3;
 			delay = 0.8e-3;
 			break;
-		case EI: tau = 3e-3;
+		case edgeType::EI: tau = 3e-3;
 			delay = 0.8e-3;
 			break;
-		case EE: tau = 3e-3;
+		case edgeType::EE: tau = 3e-3;
 			delay = 1.5e-3;
 			break;
 		default:

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -11,21 +11,7 @@
 #include "AllSpikingSynapses.h"
 #include "ParameterManager.h"
 
-AllSpikingSynapses::AllSpikingSynapses() : AllNeuroEdges() {
-	decay_ = nullptr;
-	totalDelay_ = nullptr;
-	delayQueue_ = nullptr;
-	delayIndex_ = nullptr;
-	delayQueueLength_ = nullptr;
-	tau_ = nullptr;
-	tau_II_ = 0;
-	tau_IE_ = 0;
-	tau_EI_ = 0;
-	tau_EE_ = 0;
-	delay_II_ = 0;
-	delay_IE_ = 0;
-	delay_EI_ = 0;
-	delay_EE_ = 0;
+AllSpikingSynapses::AllSpikingSynapses() : AllNeuroEdges(), delay_EE_(0), delay_EI_(0), delay_IE_(0), delay_II_(0), tau_EE_(0), tau_EI_(0), tau_IE_(0), tau_II_(0), tau_(nullptr), delayQueueLength_(nullptr), delayIndex_(nullptr), delayQueue_(nullptr), totalDelay_(nullptr), decay_(nullptr) {
 }
 
 AllSpikingSynapses::AllSpikingSynapses(const int numVertices, const int maxEdges) { setupEdges(numVertices, maxEdges); }

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -11,8 +11,6 @@
 #include "AllSpikingSynapses.h"
 #include "ParameterManager.h"
 
-using namespace std;
-
 AllSpikingSynapses::AllSpikingSynapses() : AllNeuroEdges() {
    decay_ = nullptr;
    totalDelay_ = nullptr;
@@ -121,22 +119,22 @@ void AllSpikingSynapses::loadParameters() {
 void AllSpikingSynapses::printParameters() const {
    AllNeuroEdges::printParameters();
    
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSpikingSynapses Parameters---" << endl
-                   << "\tEdges type: AllSpikingSynapses" << endl << endl);
+   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSpikingSynapses Parameters---" << std::endl
+                   << "\tEdges type: AllSpikingSynapses" << std::endl << std::endl);
    LOG4CPLUS_DEBUG(edgeLogger_, "\n\tTau values: ["
                    << " II: " << tau_II_ << ", " << " IE: " << tau_IE_ << "," << "EI : " << tau_EI_<< "," << " EE: " << tau_EE_ << "]"
-                   << endl);
+                   << std::endl);
    
    LOG4CPLUS_DEBUG(edgeLogger_,"\n\tDelay values: ["
                    << " II: "<< delay_II_ << ", " << " IE: "<< delay_IE_ << "," << "EI :" << delay_EI_<< "," << " EE: "<< delay_EE_ << "]"
-                   << endl);
+                   << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllSpikingSynapses::readEdge(istream &input, const BGSIZE iEdg) {
+void AllSpikingSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
    AllNeuroEdges::readEdge(input, iEdg);
 
    // input.ignore() so input skips over end-of-line characters.
@@ -158,15 +156,15 @@ void AllSpikingSynapses::readEdge(istream &input, const BGSIZE iEdg) {
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllSpikingSynapses::writeEdge(ostream &output, const BGSIZE iEdg) const {
+void AllSpikingSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
    AllNeuroEdges::writeEdge(output, iEdg);
 
-   output << decay_[iEdg] << ends;
-   output << totalDelay_[iEdg] << ends;
-   output << delayQueue_[iEdg] << ends;
-   output << delayIndex_[iEdg] << ends;
-   output << delayQueueLength_[iEdg] << ends;
-   output << tau_[iEdg] << ends;
+   output << decay_[iEdg] << std::ends;
+   output << totalDelay_[iEdg] << std::ends;
+   output << delayQueue_[iEdg] << std::ends;
+   output << delayIndex_[iEdg] << std::ends;
+   output << delayQueueLength_[iEdg] << std::ends;
+   output << tau_[iEdg] << std::ends;
 }
 
 ///  Create a Synapse and connect it to the model.
@@ -221,7 +219,7 @@ void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVe
    resetEdge(iEdg, deltaT);
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Checks if there is an input spike in the queue.
 ///
@@ -259,7 +257,7 @@ void AllSpikingSynapses::preSpikeHit(const BGSIZE iEdg) {
    }
    if((delayQueue & (0x1 << idx)) != 0)
    {
-      LOG4CPLUS_ERROR(edgeLogger_,"Delay Queue Error " << setbase(2) << delayQueue << setbase(10) << " index " << idx << " edge ID " << iEdg);
+      LOG4CPLUS_ERROR(edgeLogger_,"Delay Queue Error " << std::setbase(2) << delayQueue << std::setbase(10) << " index " << idx << " edge ID " << iEdg);
       assert(false);
    }
    
@@ -312,7 +310,7 @@ void AllSpikingSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
    psr += (W / decay);    // calculate psr
 }
 
-#endif //!defined(USE_GPU)
+#endif
 
 ///  Updates the decay if the synapse selected.
 ///
@@ -342,9 +340,9 @@ void AllSpikingSynapses::printSynapsesProps() const {
    AllNeuroEdges::printSynapsesProps();
    for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
       if (W_[i] != 0.0) {
-         cout << "decay[" << i << "] = " << decay_[i];
-         cout << " tau: " << tau_[i];
-         cout << " total_delay: " << totalDelay_[i] << endl;
+         std::cout << "decay[" << i << "] = " << decay_[i];
+         std::cout << " tau: " << tau_[i];
+         std::cout << " total_delay: " << totalDelay_[i] << std::endl;
       }
    }
 }

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -12,49 +12,47 @@
 #include "ParameterManager.h"
 
 AllSpikingSynapses::AllSpikingSynapses() : AllNeuroEdges() {
-   decay_ = nullptr;
-   totalDelay_ = nullptr;
-   delayQueue_ = nullptr;
-   delayIndex_ = nullptr;
-   delayQueueLength_ = nullptr;
-   tau_ = nullptr;
-   tau_II_=0;
-   tau_IE_=0;
-   tau_EI_=0;
-   tau_EE_=0;
-   delay_II_=0;
-   delay_IE_=0;
-   delay_EI_=0;
-   delay_EE_=0;
+	decay_ = nullptr;
+	totalDelay_ = nullptr;
+	delayQueue_ = nullptr;
+	delayIndex_ = nullptr;
+	delayQueueLength_ = nullptr;
+	tau_ = nullptr;
+	tau_II_ = 0;
+	tau_IE_ = 0;
+	tau_EI_ = 0;
+	tau_EE_ = 0;
+	delay_II_ = 0;
+	delay_IE_ = 0;
+	delay_EI_ = 0;
+	delay_EE_ = 0;
 }
 
-AllSpikingSynapses::AllSpikingSynapses(const int numVertices, const int maxEdges) {
-   setupEdges(numVertices, maxEdges);
-}
+AllSpikingSynapses::AllSpikingSynapses(const int numVertices, const int maxEdges) { setupEdges(numVertices, maxEdges); }
 
 AllSpikingSynapses::~AllSpikingSynapses() {
-   BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
-  
-  if (maxTotalSynapses != 0) {
-      delete[] decay_;
-      delete[] totalDelay_;
-      delete[] delayQueue_;
-      delete[] delayIndex_;
-      delete[] delayQueueLength_;
-      delete[] tau_;
-  }
+	BGSIZE maxTotalSynapses = maxEdgesPerVertex_ * countVertices_;
 
-   decay_ = nullptr;
-   totalDelay_ = nullptr;
-   delayQueue_ = nullptr;
-   delayIndex_ = nullptr;
-   delayQueueLength_ = nullptr;
-   tau_ = nullptr;
+	if (maxTotalSynapses != 0) {
+		delete[] decay_;
+		delete[] totalDelay_;
+		delete[] delayQueue_;
+		delete[] delayIndex_;
+		delete[] delayQueueLength_;
+		delete[] tau_;
+	}
+
+	decay_ = nullptr;
+	totalDelay_ = nullptr;
+	delayQueue_ = nullptr;
+	delayIndex_ = nullptr;
+	delayQueueLength_ = nullptr;
+	tau_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
 void AllSpikingSynapses::setupEdges() {
-   setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
+	setupEdges(Simulator::getInstance().getTotalVertices(), Simulator::getInstance().getMaxEdgesPerVertex());
 }
 
 ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -62,34 +60,34 @@ void AllSpikingSynapses::setupEdges() {
 ///  @param  numVertices   Total number of vertices in the network.
 ///  @param  maxEdges  Maximum number of synapses per neuron.
 void AllSpikingSynapses::setupEdges(const int numVertices, const int maxEdges) {
-   AllNeuroEdges::setupEdges(numVertices, maxEdges);
+	AllNeuroEdges::setupEdges(numVertices, maxEdges);
 
-   BGSIZE maxTotalSynapses = maxEdges * numVertices;
+	BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
-   if (maxTotalSynapses != 0) {
-      decay_ = new BGFLOAT[maxTotalSynapses];
-      totalDelay_ = new int[maxTotalSynapses];
-      delayQueue_ = new uint32_t[maxTotalSynapses];
-      delayIndex_ = new int[maxTotalSynapses];
-      delayQueueLength_ = new int[maxTotalSynapses];
-      tau_ = new BGFLOAT[maxTotalSynapses];
-   }
+	if (maxTotalSynapses != 0) {
+		decay_ = new BGFLOAT[maxTotalSynapses];
+		totalDelay_ = new int[maxTotalSynapses];
+		delayQueue_ = new uint32_t[maxTotalSynapses];
+		delayIndex_ = new int[maxTotalSynapses];
+		delayQueueLength_ = new int[maxTotalSynapses];
+		tau_ = new BGFLOAT[maxTotalSynapses];
+	}
 }
 
 ///  Initializes the queues for the Synapse.
 ///
 ///  @param  iEdg   index of the synapse to set.
 void AllSpikingSynapses::initSpikeQueue(const BGSIZE iEdg) {
-   int &totalDelay = totalDelay_[iEdg];
-   uint32_t &delayQueue = delayQueue_[iEdg];
-   int &delayIdx = delayIndex_[iEdg];
-   int &ldelayQueue = delayQueueLength_[iEdg];
+	int& totalDelay = totalDelay_[iEdg];
+	uint32_t& delayQueue = delayQueue_[iEdg];
+	int& delayIdx = delayIndex_[iEdg];
+	int& ldelayQueue = delayQueueLength_[iEdg];
 
-   uint32_t size = totalDelay / (sizeof(uint8_t) * 8) + 1;
-   assert(size <= BYTES_OF_DELAYQUEUE);
-   delayQueue = 0;
-   delayIdx = 0;
-   ldelayQueue = LENGTH_OF_DELAYQUEUE;
+	uint32_t size = totalDelay / (sizeof(uint8_t) * 8) + 1;
+	assert(size <= BYTES_OF_DELAYQUEUE);
+	delayQueue = 0;
+	delayIdx = 0;
+	ldelayQueue = LENGTH_OF_DELAYQUEUE;
 }
 
 ///  Reset time varying state vars and recompute decay.
@@ -97,74 +95,76 @@ void AllSpikingSynapses::initSpikeQueue(const BGSIZE iEdg) {
 ///  @param  iEdg     Index of the synapse to set.
 ///  @param  deltaT   Inner simulation step duration
 void AllSpikingSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   AllNeuroEdges::resetEdge(iEdg, deltaT);
+	AllNeuroEdges::resetEdge(iEdg, deltaT);
 
-   assert(updateDecay(iEdg, deltaT));
+	assert(updateDecay(iEdg, deltaT));
 }
 
 
 void AllSpikingSynapses::loadParameters() {
-   ParameterManager::getInstance().getBGFloatByXpath("//tau/ii/text()", tau_II_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tau/ie/text()", tau_IE_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tau/ei/text()", tau_EI_);
-   ParameterManager::getInstance().getBGFloatByXpath("//tau/ee/text()", tau_EE_);
-   ParameterManager::getInstance().getBGFloatByXpath("//delay/ii/text()", delay_II_);
-   ParameterManager::getInstance().getBGFloatByXpath("//delay/ie/text()", delay_IE_);
-   ParameterManager::getInstance().getBGFloatByXpath("//delay/ei/text()", delay_EI_);
-   ParameterManager::getInstance().getBGFloatByXpath("//delay/ee/text()", delay_EE_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tau/ii/text()", tau_II_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tau/ie/text()", tau_IE_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tau/ei/text()", tau_EI_);
+	ParameterManager::getInstance().getBGFloatByXpath("//tau/ee/text()", tau_EE_);
+	ParameterManager::getInstance().getBGFloatByXpath("//delay/ii/text()", delay_II_);
+	ParameterManager::getInstance().getBGFloatByXpath("//delay/ie/text()", delay_IE_);
+	ParameterManager::getInstance().getBGFloatByXpath("//delay/ei/text()", delay_EI_);
+	ParameterManager::getInstance().getBGFloatByXpath("//delay/ee/text()", delay_EE_);
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllSpikingSynapses::printParameters() const {
-   AllNeuroEdges::printParameters();
-   
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSpikingSynapses Parameters---" << std::endl
-                   << "\tEdges type: AllSpikingSynapses" << std::endl << std::endl);
-   LOG4CPLUS_DEBUG(edgeLogger_, "\n\tTau values: ["
-                   << " II: " << tau_II_ << ", " << " IE: " << tau_IE_ << "," << "EI : " << tau_EI_<< "," << " EE: " << tau_EE_ << "]"
-                   << std::endl);
-   
-   LOG4CPLUS_DEBUG(edgeLogger_,"\n\tDelay values: ["
-                   << " II: "<< delay_II_ << ", " << " IE: "<< delay_IE_ << "," << "EI :" << delay_EI_<< "," << " EE: "<< delay_EE_ << "]"
-                   << std::endl);
+	AllNeuroEdges::printParameters();
+
+	LOG4CPLUS_DEBUG(edgeLogger_, "\n\t---AllSpikingSynapses Parameters---" << std::endl
+	                << "\tEdges type: AllSpikingSynapses" << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(edgeLogger_, "\n\tTau values: ["
+	                << " II: " << tau_II_ << ", " << " IE: " << tau_IE_ << "," << "EI : " << tau_EI_<< "," << " EE: " <<
+	                tau_EE_ << "]"
+	                << std::endl);
+
+	LOG4CPLUS_DEBUG(edgeLogger_, "\n\tDelay values: ["
+	                << " II: "<< delay_II_ << ", " << " IE: "<< delay_IE_ << "," << "EI :" << delay_EI_<< "," << " EE: "
+	                << delay_EE_ << "]"
+	                << std::endl);
 }
 
 ///  Sets the data for Synapse to input's data.
 ///
 ///  @param  input  istream to read from.
 ///  @param  iEdg   Index of the synapse to set.
-void AllSpikingSynapses::readEdge(std::istream &input, const BGSIZE iEdg) {
-   AllNeuroEdges::readEdge(input, iEdg);
+void AllSpikingSynapses::readEdge(std::istream& input, const BGSIZE iEdg) {
+	AllNeuroEdges::readEdge(input, iEdg);
 
-   // input.ignore() so input skips over end-of-line characters.
-   input >> decay_[iEdg];
-   input.ignore();
-   input >> totalDelay_[iEdg];
-   input.ignore();
-   input >> delayQueue_[iEdg];
-   input.ignore();
-   input >> delayIndex_[iEdg];
-   input.ignore();
-   input >> delayQueueLength_[iEdg];
-   input.ignore();
-   input >> tau_[iEdg];
-   input.ignore();
+	// input.ignore() so input skips over end-of-line characters.
+	input >> decay_[iEdg];
+	input.ignore();
+	input >> totalDelay_[iEdg];
+	input.ignore();
+	input >> delayQueue_[iEdg];
+	input.ignore();
+	input >> delayIndex_[iEdg];
+	input.ignore();
+	input >> delayQueueLength_[iEdg];
+	input.ignore();
+	input >> tau_[iEdg];
+	input.ignore();
 }
 
 ///  Write the synapse data to the stream.
 ///
 ///  @param  output  stream to print out to.
 ///  @param  iEdg    Index of the synapse to print out.
-void AllSpikingSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) const {
-   AllNeuroEdges::writeEdge(output, iEdg);
+void AllSpikingSynapses::writeEdge(std::ostream& output, const BGSIZE iEdg) const {
+	AllNeuroEdges::writeEdge(output, iEdg);
 
-   output << decay_[iEdg] << std::ends;
-   output << totalDelay_[iEdg] << std::ends;
-   output << delayQueue_[iEdg] << std::ends;
-   output << delayIndex_[iEdg] << std::ends;
-   output << delayQueueLength_[iEdg] << std::ends;
-   output << tau_[iEdg] << std::ends;
+	output << decay_[iEdg] << std::ends;
+	output << totalDelay_[iEdg] << std::ends;
+	output << delayQueue_[iEdg] << std::ends;
+	output << delayIndex_[iEdg] << std::ends;
+	output << delayQueueLength_[iEdg] << std::ends;
+	output << tau_[iEdg] << std::ends;
 }
 
 ///  Create a Synapse and connect it to the model.
@@ -175,48 +175,44 @@ void AllSpikingSynapses::writeEdge(std::ostream &output, const BGSIZE iEdg) cons
 ///  @param  sumPoint    Summation point address.
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
-void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
-                                       const BGFLOAT deltaT, edgeType type) {
-   BGFLOAT delay;
+void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint,
+                                    const BGFLOAT deltaT, edgeType type) {
+	BGFLOAT delay;
 
-   inUse_[iEdg] = true;
-   summationPoint_[iEdg] = sumPoint;
-   destVertexIndex_[iEdg] = destVertex;
-   sourceVertexIndex_[iEdg] = srcVertex;
-   W_[iEdg] = edgSign(type) * 10.0e-9;
-   type_[iEdg] = type;
-   tau_[iEdg] = DEFAULT_tau;
+	inUse_[iEdg] = true;
+	summationPoint_[iEdg] = sumPoint;
+	destVertexIndex_[iEdg] = destVertex;
+	sourceVertexIndex_[iEdg] = srcVertex;
+	W_[iEdg] = edgSign(type) * 10.0e-9;
+	type_[iEdg] = type;
+	tau_[iEdg] = DEFAULT_tau;
 
-   BGFLOAT tau;
-   switch (type) {
-      case II:
-         tau = 6e-3;
-         delay = 0.8e-3;
-         break;
-      case IE:
-         tau = 6e-3;
-         delay = 0.8e-3;
-         break;
-      case EI:
-         tau = 3e-3;
-         delay = 0.8e-3;
-         break;
-      case EE:
-         tau = 3e-3;
-         delay = 1.5e-3;
-         break;
-      default:
-         assert(false);
-         break;
-   }
+	BGFLOAT tau;
+	switch (type) {
+		case II: tau = 6e-3;
+			delay = 0.8e-3;
+			break;
+		case IE: tau = 6e-3;
+			delay = 0.8e-3;
+			break;
+		case EI: tau = 3e-3;
+			delay = 0.8e-3;
+			break;
+		case EE: tau = 3e-3;
+			delay = 1.5e-3;
+			break;
+		default:
+			assert(false);
+			break;
+	}
 
-   tau_[iEdg] = tau;
-   totalDelay_[iEdg] = static_cast<int>( delay / deltaT ) + 1;
+	tau_[iEdg] = tau;
+	totalDelay_[iEdg] = static_cast<int>(delay / deltaT) + 1;
 
-   // initializes the queues for the Synapses
-   initSpikeQueue(iEdg);
-   // reset time varying state vars and recompute decay
-   resetEdge(iEdg, deltaT);
+	// initializes the queues for the Synapses
+	initSpikeQueue(iEdg);
+	// reset time varying state vars and recompute decay
+	resetEdge(iEdg, deltaT);
 }
 
 #ifndef __CUDACC__
@@ -226,75 +222,69 @@ void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVe
 ///  @param  iEdg   Index of the Synapse to connect to.
 ///  @return true if there is an input spike event.
 bool AllSpikingSynapses::isSpikeQueue(const BGSIZE iEdg) {
-   uint32_t &delayQueue = delayQueue_[iEdg];
-   int &delayIdx = delayIndex_[iEdg];
-   int &ldelayQueue = delayQueueLength_[iEdg];
+	uint32_t& delayQueue = delayQueue_[iEdg];
+	int& delayIdx = delayIndex_[iEdg];
+	int& ldelayQueue = delayQueueLength_[iEdg];
 
-   bool r = delayQueue & (0x1 << delayIdx);
-   delayQueue &= ~(0x1 << delayIdx);
-   if (++delayIdx >= ldelayQueue) {
-      delayIdx = 0;
-   }
-   return r;
+	bool r = delayQueue & (0x1 << delayIdx);
+	delayQueue &= ~(0x1 << delayIdx);
+	if (++delayIdx >= ldelayQueue) delayIdx = 0;
+	return r;
 }
 
 ///  Prepares Synapse for a spike hit.
 ///
 ///  @param  iEdg   Index of the Synapse to update.
 void AllSpikingSynapses::preSpikeHit(const BGSIZE iEdg) {
-   uint32_t &delayQueue = delayQueue_[iEdg];
-   int &delayIdx = delayIndex_[iEdg];
-   int &ldelayQueue = delayQueueLength_[iEdg];
-   int &totalDelay = totalDelay_[iEdg];
+	uint32_t& delayQueue = delayQueue_[iEdg];
+	int& delayIdx = delayIndex_[iEdg];
+	int& ldelayQueue = delayQueueLength_[iEdg];
+	int& totalDelay = totalDelay_[iEdg];
 
-   // Add to spike queue
+	// Add to spike queue
 
-   // calculate index where to insert the spike into delayQueue
-   //LOG4CPLUS_TRACE(edgeLogger_,"delayidx "<<delayIdx<<" totalDelay "<<totalDelay<<" ldelayQueue "<<ldelayQueue);
-   int idx = delayIdx + totalDelay;
-   if (idx >= ldelayQueue) {
-      idx -= ldelayQueue;
-   }
-   if((delayQueue & (0x1 << idx)) != 0)
-   {
-      LOG4CPLUS_ERROR(edgeLogger_,"Delay Queue Error " << std::setbase(2) << delayQueue << std::setbase(10) << " index " << idx << " edge ID " << iEdg);
-      assert(false);
-   }
-   
-   // set a spike
-   delayQueue |= (0x1 << idx);
+	// calculate index where to insert the spike into delayQueue
+	//LOG4CPLUS_TRACE(edgeLogger_,"delayidx "<<delayIdx<<" totalDelay "<<totalDelay<<" ldelayQueue "<<ldelayQueue);
+	int idx = delayIdx + totalDelay;
+	if (idx >= ldelayQueue) idx -= ldelayQueue;
+	if ((delayQueue & (0x1 << idx)) != 0) {
+		LOG4CPLUS_ERROR(edgeLogger_,
+		                "Delay Queue Error " << std::setbase(2) << delayQueue << std::setbase(10) << " index " << idx <<
+		                " edge ID " << iEdg);
+		assert(false);
+	}
+
+	// set a spike
+	delayQueue |= (0x1 << idx);
 }
 
 ///  Prepares Synapse for a spike hit (for back propagation).
 ///
 ///  @param  iEdg   Index of the Synapse to update.
-void AllSpikingSynapses::postSpikeHit(const BGSIZE iEdg) {
-}
+void AllSpikingSynapses::postSpikeHit(const BGSIZE iEdg) {}
 
 ///  Advance one specific Synapse.
 ///
 ///  @param  iEdg      Index of the Synapse to connect to.
 ///  @param  neurons   The Neuron list to search from.
-void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons) {
-   BGFLOAT &decay = decay_[iEdg];
-   BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &summationPoint = *(summationPoint_[iEdg]);
+void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices* neurons) {
+	BGFLOAT& decay = decay_[iEdg];
+	BGFLOAT& psr = psr_[iEdg];
+	BGFLOAT& summationPoint = *(summationPoint_[iEdg]);
 
-   // is an input in the queue?
-   if (isSpikeQueue(iEdg)) {
-      changePSR(iEdg, Simulator::getInstance().getDeltaT());
-   }
+	// is an input in the queue?
+	if (isSpikeQueue(iEdg)) changePSR(iEdg, Simulator::getInstance().getDeltaT());
 
-   // decay the post spike response
-   psr *= decay;
-   // and apply it to the summation point
+	// decay the post spike response
+	psr *= decay;
+	// and apply it to the summation point
 #ifdef USE_OMP
 #pragma omp atomic #endif
 #endif
-   summationPoint += psr;
+	summationPoint += psr;
 #ifdef USE_OMP
-   //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
-   //#pragma omp flush (summationPoint)
+	//PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
+	//#pragma omp flush (summationPoint)
 #endif
 }
 
@@ -303,11 +293,11 @@ void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons) {
 ///  @param  iEdg        Index of the synapse to set.
 ///  @param  deltaT      Inner simulation step duration.
 void AllSpikingSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &W = W_[iEdg];
-   BGFLOAT &decay = decay_[iEdg];
+	BGFLOAT& psr = psr_[iEdg];
+	BGFLOAT& W = W_[iEdg];
+	BGFLOAT& decay = decay_[iEdg];
 
-   psr += (W / decay);    // calculate psr
+	psr += (W / decay); // calculate psr
 }
 
 #endif
@@ -317,32 +307,30 @@ void AllSpikingSynapses::changePSR(const BGSIZE iEdg, const BGFLOAT deltaT) {
 ///  @param  iEdg    Index of the synapse to set.
 ///  @param  deltaT  Inner simulation step duration
 bool AllSpikingSynapses::updateDecay(const BGSIZE iEdg, const BGFLOAT deltaT) {
-   BGFLOAT &tau = tau_[iEdg];
-   BGFLOAT &decay = decay_[iEdg];
+	BGFLOAT& tau = tau_[iEdg];
+	BGFLOAT& decay = decay_[iEdg];
 
-   if (tau > 0) {
-      decay = exp(-deltaT / tau);
-      return true;
-   }
-   return false;
+	if (tau > 0) {
+		decay = exp(-deltaT / tau);
+		return true;
+	}
+	return false;
 }
 
 ///  Check if the back propagation (notify a spike event to the pre neuron)
 ///  is allowed in the synapse class.
 ///
 ///  @return true if the back propagation is allowed.
-bool AllSpikingSynapses::allowBackPropagation() {
-   return false;
-}
+bool AllSpikingSynapses::allowBackPropagation() { return false; }
 
 ///  Prints SynapsesProps data to console.
 void AllSpikingSynapses::printSynapsesProps() const {
-   AllNeuroEdges::printSynapsesProps();
-   for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
-      if (W_[i] != 0.0) {
-         std::cout << "decay[" << i << "] = " << decay_[i];
-         std::cout << " tau: " << tau_[i];
-         std::cout << " total_delay: " << totalDelay_[i] << std::endl;
-      }
-   }
+	AllNeuroEdges::printSynapsesProps();
+	for (int i = 0; i < maxEdgesPerVertex_ * countVertices_; i++) {
+		if (W_[i] != 0.0) {
+			std::cout << "decay[" << i << "] = " << decay_[i];
+			std::cout << " tau: " << tau_[i];
+			std::cout << " total_delay: " << totalDelay_[i] << std::endl;
+		}
+	}
 }

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -28,88 +28,86 @@
 
 struct AllSpikingSynapsesDeviceProperties;
 
-using fpPreSynapsesSpikeHit_t =  void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
+using fpPreSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties*);
 
-using fpPostSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
+using fpPostSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties*);
 
 class AllSpikingSynapses : public AllNeuroEdges {
-public:
-   AllSpikingSynapses();
+	public:
+		AllSpikingSynapses();
 
-   AllSpikingSynapses(const int numVertices, const int maxEdges);
+		AllSpikingSynapses(const int numVertices, const int maxEdges);
 
-   virtual ~AllSpikingSynapses();
+		~AllSpikingSynapses() override;
 
-   static AllEdges *Create() {
-      return new AllSpikingSynapses();
-   }
+		static AllEdges* Create() { return new AllSpikingSynapses(); }
 
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   virtual void setupEdges() override;
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		void setupEdges() override;
 
-   ///  Reset time varying state vars and recompute decay.
-   ///
-   ///  @param  iEdg     Index of the synapse to set.
-   ///  @param  deltaT   Inner simulation step duration
-   virtual void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		///  Reset time varying state vars and recompute decay.
+		///
+		///  @param  iEdg     Index of the synapse to set.
+		///  @param  deltaT   Inner simulation step duration
+		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
-   virtual void loadParameters() override;
-   
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		/// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
+		void loadParameters() override;
 
-   ///  Create a Synapse and connect it to the model.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  srcVertex   Coordinates of the source Neuron.
-   ///  @param  destVertex  Coordinates of the destination Neuron.
-   ///  @param  sumPoint    Summation point address.
-   ///  @param  deltaT      Inner simulation step duration.
-   ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
-                              edgeType type) override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Check if the back propagation (notify a spike event to the pre neuron)
-   ///  is allowed in the synapse class.
-   ///
-   ///  @return true if the back propagation is allowed.
-   virtual bool allowBackPropagation();
+		///  Create a Synapse and connect it to the model.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  srcVertex   Coordinates of the source Neuron.
+		///  @param  destVertex  Coordinates of the destination Neuron.
+		///  @param  sumPoint    Summation point address.
+		///  @param  deltaT      Inner simulation step duration.
+		///  @param  type        Type of the Synapse to create.
+		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		                edgeType type) override;
 
-   ///  Prints SynapsesProps data to console.
-   virtual void printSynapsesProps() const;
+		///  Check if the back propagation (notify a spike event to the pre neuron)
+		///  is allowed in the synapse class.
+		///
+		///  @return true if the back propagation is allowed.
+		virtual bool allowBackPropagation();
 
-protected:
-   ///  Setup the internal structure of the class (allocate memories and initialize them).
-   ///
-   ///  @param  numVertices   Total number of vertices in the network.
-   ///  @param  maxEdges  Maximum number of synapses per neuron.
-   virtual void setupEdges(const int numVertices, const int maxEdges);
+		///  Prints SynapsesProps data to console.
+		void printSynapsesProps() const override;
 
-   ///  Initializes the queues for the Synapse.
-   ///
-   ///  @param  iEdg   index of the synapse to set.
-   virtual void initSpikeQueue(const BGSIZE iEdg);
+	protected:
+		///  Setup the internal structure of the class (allocate memories and initialize them).
+		///
+		///  @param  numVertices   Total number of vertices in the network.
+		///  @param  maxEdges  Maximum number of synapses per neuron.
+		void setupEdges(const int numVertices, const int maxEdges) override;
 
-   ///  Updates the decay if the synapse selected.
-   ///
-   ///  @param  iEdg    Index of the synapse to set.
-   ///  @param  deltaT  Inner simulation step duration
-   ///  @return true is success.
-   bool updateDecay(const BGSIZE iEdg, const BGFLOAT deltaT);
+		///  Initializes the queues for the Synapse.
+		///
+		///  @param  iEdg   index of the synapse to set.
+		virtual void initSpikeQueue(const BGSIZE iEdg);
 
-   ///  Sets the data for Synapse to input's data.
-   ///
-   ///  @param  input  istream to read from.
-   ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
+		///  Updates the decay if the synapse selected.
+		///
+		///  @param  iEdg    Index of the synapse to set.
+		///  @param  deltaT  Inner simulation step duration
+		///  @return true is success.
+		bool updateDecay(const BGSIZE iEdg, const BGFLOAT deltaT);
 
-   ///  Write the synapse data to the stream.
-   ///
-   ///  @param  output  stream to print out to.
-   ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
+		///  Sets the data for Synapse to input's data.
+		///
+		///  @param  input  istream to read from.
+		///  @param  iEdg   Index of the synapse to set.
+		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+
+		///  Write the synapse data to the stream.
+		///
+		///  @param  output  stream to print out to.
+		///  @param  iEdg    Index of the synapse to print out.
+		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -218,74 +216,73 @@ protected:
        ///  @param  maxEdgesPerVertex  Maximum number of synapses per neuron.
        void copyDeviceToHost( AllSpikingSynapsesDeviceProperties& allEdgesDevice);
 #else
-public:
-   ///  Advance one specific Synapse.
-   ///
-   ///  @param  iEdg      Index of the Synapse to connect to.
-   ///  @param  neurons   The Neuron list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *neurons) override;
+	public:
+		///  Advance one specific Synapse.
+		///
+		///  @param  iEdg      Index of the Synapse to connect to.
+		///  @param  neurons   The Neuron list to search from.
+		void advanceEdge(const BGSIZE iEdg, AllVertices* neurons) override;
 
-   ///  Prepares Synapse for a spike hit.
-   ///
-   ///  @param  iEdg   Index of the Synapse to update.
-   virtual void preSpikeHit(const BGSIZE iEdg);
+		///  Prepares Synapse for a spike hit.
+		///
+		///  @param  iEdg   Index of the Synapse to update.
+		virtual void preSpikeHit(const BGSIZE iEdg);
 
-   ///  Prepares Synapse for a spike hit (for back propagation).
-   ///
-   ///  @param  iEdg   Index of the Synapse to update.
-   virtual void postSpikeHit(const BGSIZE iEdg);
+		///  Prepares Synapse for a spike hit (for back propagation).
+		///
+		///  @param  iEdg   Index of the Synapse to update.
+		virtual void postSpikeHit(const BGSIZE iEdg);
 
-protected:
-   ///  Checks if there is an input spike in the queue.
-   ///
-   ///  @param  iEdg   Index of the Synapse to connect to.
-   ///  @return true if there is an input spike event.
-   bool isSpikeQueue(const BGSIZE iEdg);
+	protected:
+		///  Checks if there is an input spike in the queue.
+		///
+		///  @param  iEdg   Index of the Synapse to connect to.
+		///  @return true if there is an input spike event.
+		bool isSpikeQueue(const BGSIZE iEdg);
 
-   ///  Calculate the post synapse response after a spike.
-   ///
-   ///  @param  iEdg        Index of the synapse to set.
-   ///  @param  deltaT      Inner simulation step duration.
-   virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT);
+		///  Calculate the post synapse response after a spike.
+		///
+		///  @param  iEdg        Index of the synapse to set.
+		///  @param  deltaT      Inner simulation step duration.
+		virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT);
 
 #endif
 
-public:
+	public:
+		///  The decay for the psr.
+		BGFLOAT* decay_;
 
-   ///  The decay for the psr.
-   BGFLOAT *decay_;
+		///  The synaptic time constant \f$\tau\f$ [units=sec; range=(0,100)].
+		BGFLOAT* tau_;
 
-   ///  The synaptic time constant \f$\tau\f$ [units=sec; range=(0,100)].
-   BGFLOAT *tau_;
+		BGFLOAT tau_II_;
+		BGFLOAT tau_IE_;
+		BGFLOAT tau_EI_;
+		BGFLOAT tau_EE_;
+		BGFLOAT delay_II_;
+		BGFLOAT delay_IE_;
+		BGFLOAT delay_EI_;
+		BGFLOAT delay_EE_;
 
-   BGFLOAT tau_II_;
-   BGFLOAT tau_IE_;
-   BGFLOAT tau_EI_;
-   BGFLOAT tau_EE_;
-   BGFLOAT delay_II_;
-   BGFLOAT delay_IE_;
-   BGFLOAT delay_EI_;
-   BGFLOAT delay_EE_;
-   
 #define BYTES_OF_DELAYQUEUE         ( sizeof(uint32_t) / sizeof(uint8_t) )
 #define LENGTH_OF_DELAYQUEUE        ( BYTES_OF_DELAYQUEUE * 8 )
 
-   ///  The synaptic transmission delay, descretized into time steps.
-   int *totalDelay_;
+		///  The synaptic transmission delay, descretized into time steps.
+		int* totalDelay_;
 
-   ///  Pointer to the delayed queue.
-   uint32_t *delayQueue_;
+		///  Pointer to the delayed queue.
+		uint32_t* delayQueue_;
 
-   ///  The index indicating the current time slot in the delayed queue
-   ///  Note: This variable is used in GpuSim_struct.cu but I am not sure
-   ///  if it is actually from a synapse. Will need a little help here. -Aaron
-   ///  Note: This variable can be GLOBAL VARIABLE, but need to modify the code.
-   int *delayIndex_;
+		///  The index indicating the current time slot in the delayed queue
+		///  Note: This variable is used in GpuSim_struct.cu but I am not sure
+		///  if it is actually from a synapse. Will need a little help here. -Aaron
+		///  Note: This variable can be GLOBAL VARIABLE, but need to modify the code.
+		int* delayIndex_;
 
-   ///  Length of the delayed queue.
-   int *delayQueueLength_;
+		///  Length of the delayed queue.
+		int* delayQueueLength_;
 
-protected:
+	protected:
 };
 
 #ifdef __CUDACC__
@@ -313,4 +310,3 @@ struct AllSpikingSynapsesDeviceProperties : public AllEdgesDeviceProperties
         int *delayQueueLength_;
 };
 #endif
-

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -28,9 +28,9 @@
 
 struct AllSpikingSynapsesDeviceProperties;
 
-typedef void (*fpPreSynapsesSpikeHit_t)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
+using fpPreSynapsesSpikeHit_t =  void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
 
-typedef void (*fpPostSynapsesSpikeHit_t)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
+using fpPostSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties *);
 
 class AllSpikingSynapses : public AllNeuroEdges {
 public:
@@ -103,15 +103,15 @@ protected:
    ///
    ///  @param  input  istream to read from.
    ///  @param  iEdg   Index of the synapse to set.
-   virtual void readEdge(istream &input, const BGSIZE iEdg) override;
+   virtual void readEdge(std::istream &input, const BGSIZE iEdg) override;
 
    ///  Write the synapse data to the stream.
    ///
    ///  @param  output  stream to print out to.
    ///  @param  iEdg    Index of the synapse to print out.
-   virtual void writeEdge(ostream &output, const BGSIZE iEdg) const override;
+   virtual void writeEdge(std::ostream &output, const BGSIZE iEdg) const override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all synapses' states,
        ///  and copy them from host to GPU memory.
@@ -217,7 +217,7 @@ protected:
        ///  @param  numVertices            Number of vertices.
        ///  @param  maxEdgesPerVertex  Maximum number of synapses per neuron.
        void copyDeviceToHost( AllSpikingSynapsesDeviceProperties& allEdgesDevice);
-#else  // !defined(USE_GPU)
+#else
 public:
    ///  Advance one specific Synapse.
    ///
@@ -288,7 +288,7 @@ public:
 protected:
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllSpikingSynapsesDeviceProperties : public AllEdgesDeviceProperties
 {
         ///  The decay for the psr.
@@ -312,5 +312,5 @@ struct AllSpikingSynapsesDeviceProperties : public AllEdgesDeviceProperties
         ///  Length of the delayed queue.
         int *delayQueueLength_;
 };
-#endif // defined(USE_GPU)
+#endif
 

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -28,15 +28,15 @@
 
 struct AllSpikingSynapsesDeviceProperties;
 
-using fpPreSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties*);
+using fpPreSynapsesSpikeHit_t = void (*)(BGSIZE, AllSpikingSynapsesDeviceProperties*);
 
-using fpPostSynapsesSpikeHit_t = void (*)(const BGSIZE, AllSpikingSynapsesDeviceProperties*);
+using fpPostSynapsesSpikeHit_t = void (*)(BGSIZE, AllSpikingSynapsesDeviceProperties*);
 
 class AllSpikingSynapses : public AllNeuroEdges {
 	public:
 		AllSpikingSynapses();
 
-		AllSpikingSynapses(const int numVertices, const int maxEdges);
+		AllSpikingSynapses(int numVertices, int maxEdges);
 
 		~AllSpikingSynapses() override;
 
@@ -49,7 +49,7 @@ class AllSpikingSynapses : public AllNeuroEdges {
 		///
 		///  @param  iEdg     Index of the synapse to set.
 		///  @param  deltaT   Inner simulation step duration
-		void resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT) override;
+		void resetEdge(BGSIZE iEdg, BGFLOAT deltaT) override;
 
 		/// Load member variables from configuration file. Registered to OperationManager as Operation::op::loadParameters
 		void loadParameters() override;
@@ -66,7 +66,7 @@ class AllSpikingSynapses : public AllNeuroEdges {
 		///  @param  sumPoint    Summation point address.
 		///  @param  deltaT      Inner simulation step duration.
 		///  @param  type        Type of the Synapse to create.
-		void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, const BGFLOAT deltaT,
+		void createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT* sumPoint, BGFLOAT deltaT,
 		                edgeType type) override;
 
 		///  Check if the back propagation (notify a spike event to the pre neuron)
@@ -83,31 +83,31 @@ class AllSpikingSynapses : public AllNeuroEdges {
 		///
 		///  @param  numVertices   Total number of vertices in the network.
 		///  @param  maxEdges  Maximum number of synapses per neuron.
-		void setupEdges(const int numVertices, const int maxEdges) override;
+		void setupEdges(int numVertices, int maxEdges) override;
 
 		///  Initializes the queues for the Synapse.
 		///
 		///  @param  iEdg   index of the synapse to set.
-		virtual void initSpikeQueue(const BGSIZE iEdg);
+		virtual void initSpikeQueue(BGSIZE iEdg);
 
 		///  Updates the decay if the synapse selected.
 		///
 		///  @param  iEdg    Index of the synapse to set.
 		///  @param  deltaT  Inner simulation step duration
 		///  @return true is success.
-		bool updateDecay(const BGSIZE iEdg, const BGFLOAT deltaT);
+		bool updateDecay(BGSIZE iEdg, BGFLOAT deltaT);
 
 		///  Sets the data for Synapse to input's data.
 		///
 		///  @param  input  istream to read from.
 		///  @param  iEdg   Index of the synapse to set.
-		void readEdge(std::istream& input, const BGSIZE iEdg) override;
+		void readEdge(std::istream& input, BGSIZE iEdg) override;
 
 		///  Write the synapse data to the stream.
 		///
 		///  @param  output  stream to print out to.
 		///  @param  iEdg    Index of the synapse to print out.
-		void writeEdge(std::ostream& output, const BGSIZE iEdg) const override;
+		void writeEdge(std::ostream& output, BGSIZE iEdg) const override;
 
 #ifdef __CUDACC__
    public:
@@ -221,30 +221,30 @@ class AllSpikingSynapses : public AllNeuroEdges {
 		///
 		///  @param  iEdg      Index of the Synapse to connect to.
 		///  @param  neurons   The Neuron list to search from.
-		void advanceEdge(const BGSIZE iEdg, AllVertices* neurons) override;
+		void advanceEdge(BGSIZE iEdg, AllVertices* neurons) override;
 
 		///  Prepares Synapse for a spike hit.
 		///
 		///  @param  iEdg   Index of the Synapse to update.
-		virtual void preSpikeHit(const BGSIZE iEdg);
+		virtual void preSpikeHit(BGSIZE iEdg);
 
 		///  Prepares Synapse for a spike hit (for back propagation).
 		///
 		///  @param  iEdg   Index of the Synapse to update.
-		virtual void postSpikeHit(const BGSIZE iEdg);
+		virtual void postSpikeHit(BGSIZE iEdg);
 
 	protected:
 		///  Checks if there is an input spike in the queue.
 		///
 		///  @param  iEdg   Index of the Synapse to connect to.
 		///  @return true if there is an input spike event.
-		bool isSpikeQueue(const BGSIZE iEdg);
+		bool isSpikeQueue(BGSIZE iEdg);
 
 		///  Calculate the post synapse response after a spike.
 		///
 		///  @param  iEdg        Index of the synapse to set.
 		///  @param  deltaT      Inner simulation step duration.
-		virtual void changePSR(const BGSIZE iEdg, const BGFLOAT deltaT);
+		virtual void changePSR(BGSIZE iEdg, BGFLOAT deltaT);
 
 #endif
 

--- a/Simulator/Edges/Neuro/AllSpikingSynapses_d.cu
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses_d.cu
@@ -260,7 +260,7 @@ void AllSpikingSynapses::copyDeviceEdgeSumIdxToHost(void* allEdgesDevice )
                 maxTotalSynapses * sizeof( int ), cudaMemcpyDeviceToHost ) );
         HANDLE_ERROR( cudaMemcpy ( inUse_, allEdgesDeviceProps.inUse_,
                 maxTotalSynapses * sizeof( bool ), cudaMemcpyDeviceToHost ) );
-       
+
         // Set countVertices_ to 0 to avoid illegal memory deallocation 
         // at AllSpikingSynapses deconstructor.
         //allEdges.countVertices_ = 0;

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs.h
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs.h
@@ -14,8 +14,6 @@
 #include "AllSTDPSynapses.h"
 #include "BGTypes.h"
 
-using namespace std;
-
 #if defined(__CUDACC__)
 
 extern __device__ enumClassSynapses classSynapses_d;

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cu
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cu
@@ -15,7 +15,7 @@
 
 
 // a device variable to store synapse class ID.
-__device__ enumClassSynapses classSynapses_d = undefClassSynapses; 
+__device__ enumClassSynapses classSynapses_d = undefClassSynapses;
 
 /******************************************
  * @name Device Functions for utility
@@ -93,7 +93,7 @@ __device__ void changeDSSynapsePSRDevice(AllDSSynapsesDeviceProperties* allEdges
     psr += ( ( W / decay ) * u * r );// calculate psr
     lastSpike = simulationStep; // record the time of the spike
 }
-    
+
 ///  Checks if there is an input spike in the queue.
 ///
 ///  @param[in] allEdgesDevice     GPU address of AllSpikingSynapsesDeviceProperties structures 
@@ -116,7 +116,7 @@ __device__ bool isSpikingSynapsesSpikeQueueDevice(AllSpikingSynapsesDeviceProper
 
     return isFired;
 }
-   
+
 ///  Adjust synapse weight according to the Spike-timing-dependent synaptic modification
 ///  induced by natural spike trains
 ///

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -16,14 +16,9 @@
 
 /// Constructor
 Layout::Layout() :
-	numEndogenouslyActiveNeurons_(0),
+	xloc_(nullptr), starterMap_(nullptr), vertexTypeMap_(nullptr), dist_(nullptr), dist2_(nullptr), yloc_(nullptr), numEndogenouslyActiveNeurons_(0),
 	gridLayout_(true) {
-	xloc_ = nullptr;
-	yloc_ = nullptr;
-	dist2_ = nullptr;
-	dist_ = nullptr;
-	vertexTypeMap_ = nullptr;
-	starterMap_ = nullptr;
+
 
 	// Create Vertices/Neurons class using type definition in configuration file
 	std::string type;
@@ -31,11 +26,11 @@ Layout::Layout() :
 	vertices_ = VerticesFactory::getInstance()->createVertices(type);
 
 	// Register loadParameters function as a loadParameters operation in the Operation Manager
-	std::function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);
+	const std::function loadParametersFunc = [this] { loadParameters(); };
 	OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
 	// Register printParameters function as a printParameters operation in the OperationManager
-	std::function<void()> printParametersFunc = std::bind(&Layout::printParameters, this);
+	const std::function printParametersFunc = [this] { printParameters(); };
 	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
 	// Get a copy of the file logger to use log4cplus macros

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -26,17 +26,17 @@ Layout::Layout() :
    starterMap_ = nullptr;
 
    // Create Vertices/Neurons class using type definition in configuration file
-   string type;
+   std::string type;
    ParameterManager::getInstance().getStringByXpath("//VerticesParams/@class", type);
    vertices_ = VerticesFactory::getInstance()->createVertices(type);
 
    // Register loadParameters function as a loadParameters operation in the Operation Manager
-   function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);
+   std::function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);
    OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
    // Register printParameters function as a printParameters operation in the OperationManager
-   function<void()> printParametersFunc = bind(&Layout::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+   std::function<void()> printParametersFunc = std::bind(&Layout::printParameters, this);
+   OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
    // Get a copy of the file logger to use log4cplus macros
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
@@ -59,7 +59,7 @@ Layout::~Layout() {
    starterMap_ = nullptr;
 }
 
-shared_ptr<AllVertices> Layout::getVertices() const {
+std::shared_ptr<AllVertices> Layout::getVertices() const {
    return vertices_;
 }
 
@@ -101,19 +101,19 @@ void Layout::setupLayout() {
 
 /// Prints out all parameters to logging file. Registered to OperationManager as Operation::printParameters
 void Layout::printParameters() const {
-   stringstream output;
-   output << "\nLAYOUT PARAMETERS" << endl;
+   std::stringstream output;
+   output << "\nLAYOUT PARAMETERS" << std::endl;
    output << "\tEndogenously active neuron positions: ";
    for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) {
        output << endogenouslyActiveNeuronList_[i] << " ";
    }
-   output << endl;
+   output << std::endl;
 
    output << "\tInhibitory neuron positions: ";
    for (BGSIZE i = 0; i < inhibitoryNeuronLayout_.size(); i++) {
       output << inhibitoryNeuronLayout_[i] << " ";
    }
-   output << endl;
+   output << std::endl;
 
    LOG4CPLUS_DEBUG(fileLogger_, output.str());
 }
@@ -121,7 +121,7 @@ void Layout::printParameters() const {
 /// Creates a vertex type map.
 /// @param  numVertices number of the vertices to have in the type map.
 void Layout::generateVertexTypeMap(int numVertices) {
-   DEBUG(cout << "\nInitializing vertex type map: VTYPE_UNDEF" << endl;);
+   DEBUG(std::cout << "\nInitializing vertex type map: VTYPE_UNDEF" << std::endl;);
 
    for (int i = 0; i < numVertices; i++) {
       vertexTypeMap_[i] = VTYPE_UNDEF;

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -117,7 +117,7 @@ void Layout::printParameters() const {
 void Layout::generateVertexTypeMap(int numVertices) {
 	DEBUG(std::cout << "\nInitializing vertex type map: VTYPE_UNDEF" << std::endl;);
 
-	for (int i = 0; i < numVertices; i++) vertexTypeMap_[i] = VTYPE_UNDEF;
+	for (int i = 0; i < numVertices; i++) vertexTypeMap_[i] = vertexType::VTYPE_UNDEF;
 }
 
 /// Populates the starter map.

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -7,155 +7,141 @@
  */
 
 #include "Layout.h"
-#include "Simulator.h"
-#include "ParseParamError.h"
-#include "Util.h"
-#include "ParameterManager.h"
 #include "OperationManager.h"
+#include "ParameterManager.h"
+#include "ParseParamError.h"
+#include "Simulator.h"
+#include "Util.h"
 #include "VerticesFactory.h"
 
 /// Constructor
 Layout::Layout() :
-      numEndogenouslyActiveNeurons_(0),
-      gridLayout_(true) {
-   xloc_ = nullptr;
-   yloc_ = nullptr;
-   dist2_ = nullptr;
-   dist_ = nullptr;
-   vertexTypeMap_ = nullptr;
-   starterMap_ = nullptr;
+	numEndogenouslyActiveNeurons_(0),
+	gridLayout_(true) {
+	xloc_ = nullptr;
+	yloc_ = nullptr;
+	dist2_ = nullptr;
+	dist_ = nullptr;
+	vertexTypeMap_ = nullptr;
+	starterMap_ = nullptr;
 
-   // Create Vertices/Neurons class using type definition in configuration file
-   std::string type;
-   ParameterManager::getInstance().getStringByXpath("//VerticesParams/@class", type);
-   vertices_ = VerticesFactory::getInstance()->createVertices(type);
+	// Create Vertices/Neurons class using type definition in configuration file
+	std::string type;
+	ParameterManager::getInstance().getStringByXpath("//VerticesParams/@class", type);
+	vertices_ = VerticesFactory::getInstance()->createVertices(type);
 
-   // Register loadParameters function as a loadParameters operation in the Operation Manager
-   std::function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
+	// Register loadParameters function as a loadParameters operation in the Operation Manager
+	std::function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
-   // Register printParameters function as a printParameters operation in the OperationManager
-   std::function<void()> printParametersFunc = std::bind(&Layout::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
+	// Register printParameters function as a printParameters operation in the OperationManager
+	std::function<void()> printParametersFunc = std::bind(&Layout::printParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
-   // Get a copy of the file logger to use log4cplus macros
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	// Get a copy of the file logger to use log4cplus macros
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
 /// Destructor
 Layout::~Layout() {
-   if (xloc_ != nullptr) delete xloc_;
-   if (yloc_ != nullptr) delete yloc_;
-   if (dist2_ != nullptr) delete dist2_;
-   if (dist_ != nullptr) delete dist_;
-   if (vertexTypeMap_ != nullptr) delete[] vertexTypeMap_;  //todo: is delete[] changing once array becomes vector?
-   if (starterMap_ != nullptr) delete[] starterMap_; //todo: is delete[] changing once array becomes vector?
+	if (xloc_ != nullptr) delete xloc_;
+	if (yloc_ != nullptr) delete yloc_;
+	if (dist2_ != nullptr) delete dist2_;
+	if (dist_ != nullptr) delete dist_;
+	if (vertexTypeMap_ != nullptr) delete[] vertexTypeMap_; //todo: is delete[] changing once array becomes vector?
+	if (starterMap_ != nullptr) delete[] starterMap_; //todo: is delete[] changing once array becomes vector?
 
-   xloc_ = nullptr;
-   yloc_ = nullptr;
-   dist2_ = nullptr;
-   dist_ = nullptr;
-   vertexTypeMap_ = nullptr;
-   starterMap_ = nullptr;
+	xloc_ = nullptr;
+	yloc_ = nullptr;
+	dist2_ = nullptr;
+	dist_ = nullptr;
+	vertexTypeMap_ = nullptr;
+	starterMap_ = nullptr;
 }
 
-std::shared_ptr<AllVertices> Layout::getVertices() const {
-   return vertices_;
-}
+std::shared_ptr<AllVertices> Layout::getVertices() const { return vertices_; }
 
 
 /// Setup the internal structure of the class.
 /// Allocate memories to store all layout state, no sequential dependency in this method
 void Layout::setupLayout() {
-   int numVertices = Simulator::getInstance().getTotalVertices();
+	int numVertices = Simulator::getInstance().getTotalVertices();
 
-   // Allocate memory
-   xloc_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
-   yloc_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
-   dist2_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
-   dist_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
+	// Allocate memory
+	xloc_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
+	yloc_ = new VectorMatrix(MATRIX_TYPE, MATRIX_INIT, 1, numVertices);
+	dist2_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
+	dist_ = new CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices, numVertices);
 
-   // Initialize neuron locations memory, grab global info
-   initVerticesLocs();
+	// Initialize neuron locations memory, grab global info
+	initVerticesLocs();
 
-   // computing distance between each pair of vertices given each vertex's xy location
-   for (int n = 0; n < numVertices - 1; n++) {
-      for (int n2 = n + 1; n2 < numVertices; n2++) {
-         // distance^2 between two points in point-slope form
-         (*dist2_)(n, n2) = ((*xloc_)[n] - (*xloc_)[n2]) * ((*xloc_)[n] - (*xloc_)[n2]) +
-                            ((*yloc_)[n] - (*yloc_)[n2]) * ((*yloc_)[n] - (*yloc_)[n2]);
+	// computing distance between each pair of vertices given each vertex's xy location
+	for (int n = 0; n < numVertices - 1; n++) {
+		for (int n2 = n + 1; n2 < numVertices; n2++) {
+			// distance^2 between two points in point-slope form
+			(*dist2_)(n, n2) = ((*xloc_)[n] - (*xloc_)[n2]) * ((*xloc_)[n] - (*xloc_)[n2]) +
+				((*yloc_)[n] - (*yloc_)[n2]) * ((*yloc_)[n] - (*yloc_)[n2]);
 
-         // both points are equidistant from each other
-         (*dist2_)(n2, n) = (*dist2_)(n, n2);
-      }
-   }
+			// both points are equidistant from each other
+			(*dist2_)(n2, n) = (*dist2_)(n, n2);
+		}
+	}
 
-   // take the square root to get actual distance (Pythagoras was right!)
-   (*dist_) = sqrt((*dist2_));
+	// take the square root to get actual distance (Pythagoras was right!)
+	(*dist_) = sqrt((*dist2_));
 
-   // more allocation of internal memory
-   vertexTypeMap_ = new vertexType[numVertices]; // todo: make array into vector
-   starterMap_ = new bool[numVertices]; // todo: make array into vector
+	// more allocation of internal memory
+	vertexTypeMap_ = new vertexType[numVertices]; // todo: make array into vector
+	starterMap_ = new bool[numVertices]; // todo: make array into vector
 }
 
 
 /// Prints out all parameters to logging file. Registered to OperationManager as Operation::printParameters
 void Layout::printParameters() const {
-   std::stringstream output;
-   output << "\nLAYOUT PARAMETERS" << std::endl;
-   output << "\tEndogenously active neuron positions: ";
-   for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) {
-       output << endogenouslyActiveNeuronList_[i] << " ";
-   }
-   output << std::endl;
+	std::stringstream output;
+	output << "\nLAYOUT PARAMETERS" << std::endl;
+	output << "\tEndogenously active neuron positions: ";
+	for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) output << endogenouslyActiveNeuronList_[i] << " ";
+	output << std::endl;
 
-   output << "\tInhibitory neuron positions: ";
-   for (BGSIZE i = 0; i < inhibitoryNeuronLayout_.size(); i++) {
-      output << inhibitoryNeuronLayout_[i] << " ";
-   }
-   output << std::endl;
+	output << "\tInhibitory neuron positions: ";
+	for (BGSIZE i = 0; i < inhibitoryNeuronLayout_.size(); i++) output << inhibitoryNeuronLayout_[i] << " ";
+	output << std::endl;
 
-   LOG4CPLUS_DEBUG(fileLogger_, output.str());
+	LOG4CPLUS_DEBUG(fileLogger_, output.str());
 }
 
 /// Creates a vertex type map.
 /// @param  numVertices number of the vertices to have in the type map.
 void Layout::generateVertexTypeMap(int numVertices) {
-   DEBUG(std::cout << "\nInitializing vertex type map: VTYPE_UNDEF" << std::endl;);
+	DEBUG(std::cout << "\nInitializing vertex type map: VTYPE_UNDEF" << std::endl;);
 
-   for (int i = 0; i < numVertices; i++) {
-      vertexTypeMap_[i] = VTYPE_UNDEF;
-   }
+	for (int i = 0; i < numVertices; i++) vertexTypeMap_[i] = VTYPE_UNDEF;
 }
 
 /// Populates the starter map.
 /// Selects num_endogenously_active_neurons excitory neurons and converts them into starter neurons.
 /// @param  numVertices number of vertices to have in the map.
-void Layout::initStarterMap(const int numVertices) {
-   for (int i = 0; i < numVertices; i++) {
-      starterMap_[i] = false;
-   }
-}
+void Layout::initStarterMap(const int numVertices) { for (int i = 0; i < numVertices; i++) starterMap_[i] = false; }
 
 /// Initialize the location maps (xloc and yloc).
 void Layout::initVerticesLocs() {
-   int numVertices = Simulator::getInstance().getTotalVertices();
+	int numVertices = Simulator::getInstance().getTotalVertices();
 
-   // Initialize vertex locations
-   if (gridLayout_) {
-      // grid layout
-      for (int i = 0; i < numVertices; i++) {
-         (*xloc_)[i] = i % Simulator::getInstance().getHeight();
-         (*yloc_)[i] = i / Simulator::getInstance().getHeight();
-      }
-   } else {
-      // random layout
-      for (int i = 0; i < numVertices; i++) {
-         (*xloc_)[i] = initRNG.inRange(0, Simulator::getInstance().getWidth());
-         (*yloc_)[i] = initRNG.inRange(0, Simulator::getInstance().getHeight());
-      }
-   }
+	// Initialize vertex locations
+	if (gridLayout_) {
+		// grid layout
+		for (int i = 0; i < numVertices; i++) {
+			(*xloc_)[i] = i % Simulator::getInstance().getHeight();
+			(*yloc_)[i] = i / Simulator::getInstance().getHeight();
+		}
+	}
+	else {
+		// random layout
+		for (int i = 0; i < numVertices; i++) {
+			(*xloc_)[i] = initRNG.inRange(0, Simulator::getInstance().getWidth());
+			(*yloc_)[i] = initRNG.inRange(0, Simulator::getInstance().getHeight());
+		}
+	}
 }
-
-
-

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -24,8 +24,6 @@
 #include "Utils/Global.h"
 #include "AllVertices.h"
 
-using namespace std;
-
 class AllVertices;
 
 class Layout {
@@ -34,7 +32,7 @@ public:
 
    virtual ~Layout();
 
-   shared_ptr<AllVertices> getVertices() const;
+   std::shared_ptr<AllVertices> getVertices() const;
 
    /// Setup the internal structure of the class.
    /// Allocate memories to store all layout state.
@@ -70,7 +68,7 @@ public:
 
    CompleteMatrix *dist_;    ///< The true inter-neuron distance.
 
-   vector<int> probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
+   std::vector<int> probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
 
    vertexType *vertexTypeMap_;    ///< The vertex type map (INH, EXC).
 
@@ -82,17 +80,17 @@ public:
 
 
 protected:
-   shared_ptr<AllVertices> vertices_;
+   std::shared_ptr<AllVertices> vertices_;
 
-   vector<int> endogenouslyActiveNeuronList_;    ///< Endogenously active neurons list.
+   std::vector<int> endogenouslyActiveNeuronList_;    ///< Endogenously active neurons list.
 
-   vector<int> inhibitoryNeuronLayout_;    ///< Inhibitory neurons list.
+   std::vector<int> inhibitoryNeuronLayout_;    ///< Inhibitory neurons list.
 
-   vector<int> callerVertexList_;    ///< Caller vertex list.
+   std::vector<int> callerVertexList_;    ///< Caller vertex list.
 
-   vector<int> psapVertexList_;    ///< PSAP vertex list.
+   std::vector<int> psapVertexList_;    ///< PSAP vertex list.
    
-   vector<int> responderVertexList_;    ///< Responder vertex list.
+   std::vector<int> responderVertexList_;    ///< Responder vertex list.
 
    log4cplus::Logger fileLogger_;
 

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -52,13 +52,13 @@ class Layout {
 		/// Selects num_endogenously_active_neurons excitory neurons
 		/// and converts them into starter neurons.
 		/// @param  numVertices number of vertices to have in the map.
-		virtual void initStarterMap(const int numVertices);
+		virtual void initStarterMap(int numVertices);
 
 		/// Returns the type of synapse at the given coordinates
 		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
 		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
 		/// @return type of the synapse.
-		virtual edgeType edgType(const int srcVertex, const int destVertex) = 0;
+		virtual edgeType edgType(int srcVertex, int destVertex) = 0;
 
 		VectorMatrix* xloc_; ///< Store neuron i's x location.
 

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -21,84 +21,84 @@
 
 #include <log4cplus/loggingmacros.h>
 
-#include "Utils/Global.h"
 #include "AllVertices.h"
+#include "Utils/Global.h"
 
 class AllVertices;
 
 class Layout {
-public:
-   Layout();
+	public:
+		Layout();
 
-   virtual ~Layout();
+		virtual ~Layout();
 
-   std::shared_ptr<AllVertices> getVertices() const;
+		std::shared_ptr<AllVertices> getVertices() const;
 
-   /// Setup the internal structure of the class.
-   /// Allocate memories to store all layout state.
-   virtual void setupLayout();
+		/// Setup the internal structure of the class.
+		/// Allocate memories to store all layout state.
+		virtual void setupLayout();
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters() = 0;
+		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
+		virtual void loadParameters() = 0;
 
-   /// Prints out all parameters to logging file. Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const;
+		/// Prints out all parameters to logging file. Registered to OperationManager as Operation::printParameters
+		virtual void printParameters() const;
 
-   /// Creates a neurons type map.
-   /// @param  numVertices number of the neurons to have in the type map.
-   virtual void generateVertexTypeMap(int numVertices);
+		/// Creates a neurons type map.
+		/// @param  numVertices number of the neurons to have in the type map.
+		virtual void generateVertexTypeMap(int numVertices);
 
-   /// Populates the starter map.
-   /// Selects num_endogenously_active_neurons excitory neurons
-   /// and converts them into starter neurons.
-   /// @param  numVertices number of vertices to have in the map.
-   virtual void initStarterMap(const int numVertices);
+		/// Populates the starter map.
+		/// Selects num_endogenously_active_neurons excitory neurons
+		/// and converts them into starter neurons.
+		/// @param  numVertices number of vertices to have in the map.
+		virtual void initStarterMap(const int numVertices);
 
-   /// Returns the type of synapse at the given coordinates
-   /// @param    srcVertex  integer that points to a Neuron in the type map as a source.
-   /// @param    destVertex integer that points to a Neuron in the type map as a destination.
-   /// @return type of the synapse.
-   virtual edgeType edgType(const int srcVertex, const int destVertex) = 0;
+		/// Returns the type of synapse at the given coordinates
+		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
+		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
+		/// @return type of the synapse.
+		virtual edgeType edgType(const int srcVertex, const int destVertex) = 0;
 
-   VectorMatrix *xloc_;  ///< Store neuron i's x location.
+		VectorMatrix* xloc_; ///< Store neuron i's x location.
 
-   VectorMatrix *yloc_;   ///< Store neuron i's y location.
+		VectorMatrix* yloc_; ///< Store neuron i's y location.
 
-   CompleteMatrix *dist2_;  ///< Inter-neuron distance squared.
+		CompleteMatrix* dist2_; ///< Inter-neuron distance squared.
 
-   CompleteMatrix *dist_;    ///< The true inter-neuron distance.
+		CompleteMatrix* dist_; ///< The true inter-neuron distance.
 
-   std::vector<int> probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
+		std::vector<int> probedNeuronList_;
+		///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
 
-   vertexType *vertexTypeMap_;    ///< The vertex type map (INH, EXC).
+		vertexType* vertexTypeMap_; ///< The vertex type map (INH, EXC).
 
-   bool *starterMap_; ///< The starter existence map (T/F).
+		bool* starterMap_; ///< The starter existence map (T/F).
 
-   BGSIZE numEndogenouslyActiveNeurons_;    ///< Number of endogenously active neurons.
+		BGSIZE numEndogenouslyActiveNeurons_; ///< Number of endogenously active neurons.
 
-   BGSIZE numCallerVertices_;    ///< Number of caller vertices.
+		BGSIZE numCallerVertices_; ///< Number of caller vertices.
 
 
-protected:
-   std::shared_ptr<AllVertices> vertices_;
+	protected:
+		std::shared_ptr<AllVertices> vertices_;
 
-   std::vector<int> endogenouslyActiveNeuronList_;    ///< Endogenously active neurons list.
+		std::vector<int> endogenouslyActiveNeuronList_; ///< Endogenously active neurons list.
 
-   std::vector<int> inhibitoryNeuronLayout_;    ///< Inhibitory neurons list.
+		std::vector<int> inhibitoryNeuronLayout_; ///< Inhibitory neurons list.
 
-   std::vector<int> callerVertexList_;    ///< Caller vertex list.
+		std::vector<int> callerVertexList_; ///< Caller vertex list.
 
-   std::vector<int> psapVertexList_;    ///< PSAP vertex list.
-   
-   std::vector<int> responderVertexList_;    ///< Responder vertex list.
+		std::vector<int> psapVertexList_; ///< PSAP vertex list.
 
-   log4cplus::Logger fileLogger_;
+		std::vector<int> responderVertexList_; ///< Responder vertex list.
 
-private:
-   /// initialize the location maps (xloc and yloc).
-   void initVerticesLocs();
+		log4cplus::Logger fileLogger_;
 
-   bool gridLayout_;    ///< True if grid layout.
+	private:
+		/// initialize the location maps (xloc and yloc).
+		void initVerticesLocs();
+
+		bool gridLayout_; ///< True if grid layout.
 
 };
-

--- a/Simulator/Layouts/LayoutFactory.cpp
+++ b/Simulator/Layouts/LayoutFactory.cpp
@@ -41,7 +41,11 @@ std::shared_ptr<Layout> LayoutFactory::createLayout(const std::string& className
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
 Layout* LayoutFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
-		second();
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) {
+			return i->
+				second();
+		}
+	}
 	return nullptr;
 }

--- a/Simulator/Layouts/LayoutFactory.cpp
+++ b/Simulator/Layouts/LayoutFactory.cpp
@@ -7,8 +7,8 @@
  */
 
 #include "LayoutFactory.h"
-#include "FixedLayout.h"
 #include "DynamicLayout.h"
+#include "FixedLayout.h"
 #include "Layout911.h"
 
 /// Constructor is private to keep a singleton instance of this class.
@@ -41,8 +41,7 @@ std::shared_ptr<Layout> LayoutFactory::createLayout(const std::string& className
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
 Layout* LayoutFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Layouts/LayoutFactory.cpp
+++ b/Simulator/Layouts/LayoutFactory.cpp
@@ -13,39 +13,36 @@
 
 /// Constructor is private to keep a singleton instance of this class.
 LayoutFactory::LayoutFactory() {
-   // register layout classes
-   registerClass("FixedLayout", &FixedLayout::Create);
-   registerClass("DynamicLayout", &DynamicLayout::Create);
-   registerClass("Layout911", &Layout911::Create);
+	// register layout classes
+	registerClass("FixedLayout", &FixedLayout::Create);
+	registerClass("DynamicLayout", &DynamicLayout::Create);
+	registerClass("Layout911", &Layout911::Create);
 }
 
-LayoutFactory::~LayoutFactory() {
-   createFunctions.clear();
-}
+LayoutFactory::~LayoutFactory() { createFunctions.clear(); }
 
 ///  Register layout class and its creation function to the factory.
 ///
 ///  @param  className  vertices class name.
 ///  @param  Pointer to the class creation function.
-void LayoutFactory::registerClass(const string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void LayoutFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired layout class.
-shared_ptr<Layout> LayoutFactory::createLayout(const string &className) {
-   layoutInstance = shared_ptr<Layout>(invokeCreateFunction(className));
-   return layoutInstance;
+std::shared_ptr<Layout> LayoutFactory::createLayout(const std::string& className) {
+	layoutInstance = std::shared_ptr<Layout>(invokeCreateFunction(className));
+	return layoutInstance;
 }
 
 /// Create an instance of the layout class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-Layout *LayoutFactory::invokeCreateFunction(const string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+Layout* LayoutFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Layouts/LayoutFactory.h
+++ b/Simulator/Layouts/LayoutFactory.h
@@ -15,8 +15,6 @@
 #include "Global.h"
 #include "Layout.h"
 
-using namespace std;
-
 class LayoutFactory {
 
 public:
@@ -28,7 +26,7 @@ public:
    }
 
    // Invokes constructor for desired concrete class
-   shared_ptr<Layout> createLayout(const string &className);
+   std::shared_ptr<Layout> createLayout(const std::string &className);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    LayoutFactory(LayoutFactory const &) = delete;
@@ -39,20 +37,20 @@ private:
    LayoutFactory();
 
    /// Smart pointer to layout instance
-   shared_ptr<Layout> layoutInstance;
+   std::shared_ptr<Layout> layoutInstance;
 
    /// Defines function type for usage in internal map
-   typedef Layout *(*CreateFunction)(void);
+   using CreateFunction =  Layout *(*)(void);
 
    /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> LayoutFunctionMap;
+   using LayoutFunctionMap =  std::map<std::string, CreateFunction>;
 
    /// Makes class-to-function map an internal factory member.
    LayoutFunctionMap createFunctions;
 
    /// Retrieves and invokes correct ::Create() function.
-   Layout *invokeCreateFunction(const string &className);
+   Layout *invokeCreateFunction(const std::string &className);
 
    /// Register neuron class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+   void registerClass(const std::string &className, CreateFunction function);
 };

--- a/Simulator/Layouts/LayoutFactory.h
+++ b/Simulator/Layouts/LayoutFactory.h
@@ -17,40 +17,40 @@
 
 class LayoutFactory {
 
-public:
-   ~LayoutFactory();
+	public:
+		~LayoutFactory();
 
-   static LayoutFactory *getInstance() {
-      static LayoutFactory instance;
-      return &instance;
-   }
+		static LayoutFactory* getInstance() {
+			static LayoutFactory instance;
+			return &instance;
+		}
 
-   // Invokes constructor for desired concrete class
-   std::shared_ptr<Layout> createLayout(const std::string &className);
+		// Invokes constructor for desired concrete class
+		std::shared_ptr<Layout> createLayout(const std::string& className);
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   LayoutFactory(LayoutFactory const &) = delete;
-   void operator=(LayoutFactory const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		LayoutFactory(const LayoutFactory&) = delete;
+		void operator=(const LayoutFactory&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   LayoutFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		LayoutFactory();
 
-   /// Smart pointer to layout instance
-   std::shared_ptr<Layout> layoutInstance;
+		/// Smart pointer to layout instance
+		std::shared_ptr<Layout> layoutInstance;
 
-   /// Defines function type for usage in internal map
-   using CreateFunction =  Layout *(*)(void);
+		/// Defines function type for usage in internal map
+		using CreateFunction = Layout *(*)(void);
 
-   /// Defines map between class name and corresponding ::Create() function.
-   using LayoutFunctionMap =  std::map<std::string, CreateFunction>;
+		/// Defines map between class name and corresponding ::Create() function.
+		using LayoutFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   LayoutFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		LayoutFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   Layout *invokeCreateFunction(const std::string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		Layout* invokeCreateFunction(const std::string& className);
 
-   /// Register neuron class and it's create function to the factory.
-   void registerClass(const std::string &className, CreateFunction function);
+		/// Register neuron class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Simulator/Layouts/NG911/Layout911.cpp
+++ b/Simulator/Layouts/NG911/Layout911.cpp
@@ -9,106 +9,95 @@
 #include "Layout911.h"
 #include "ParameterManager.h"
 
-Layout911::Layout911() {
+Layout911::Layout911() {}
 
-}
-
-Layout911::~Layout911() {
-
-}
+Layout911::~Layout911() {}
 
 void Layout911::loadParameters() {
-    // Get the file paths for the vertex lists from the configuration file
-   std::string callerFilePath;
-   std::string psapFilePath;
-   std::string responderFilePath;
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/callersListFileName/text()",
-                                                         callerFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() caller "
-                          "vertex list file path wasn't found and will not be initialized");
-   }
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/PSAPsListFileName/text()",
-                                                         psapFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() psap "
-                          "vertex list file path wasn't found and will not be initialized");
-   }
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/respondersListFileName/text()",
-                                                         responderFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() responder"
-                          "vertex list file path wasn't found and will not be initialized");
-   }
+	// Get the file paths for the vertex lists from the configuration file
+	std::string callerFilePath;
+	std::string psapFilePath;
+	std::string responderFilePath;
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/callersListFileName/text()",
+	                                                      callerFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() caller "
+			"vertex list file path wasn't found and will not be initialized");
+	}
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/PSAPsListFileName/text()",
+	                                                      psapFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() psap "
+			"vertex list file path wasn't found and will not be initialized");
+	}
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/respondersListFileName/text()",
+	                                                      responderFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() responder"
+			"vertex list file path wasn't found and will not be initialized");
+	}
 
-   // Initialize Vertex Lists based on the data read from the xml files
-   if (!ParameterManager::getInstance().getIntVectorByXpath(callerFilePath, "C", callerVertexList_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "caller vertex list list file wasn't loaded correctly"
-                          "\n\tfile path: " + callerFilePath);
-   }
-   numCallerVertices_ = callerVertexList_.size();
-   if (!ParameterManager::getInstance().getIntVectorByXpath(psapFilePath, "P", psapVertexList_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "psap vertex list file wasn't loaded correctly."
-                          "\n\tfile path: " + psapFilePath);
-   }
-   if (!ParameterManager::getInstance().getIntVectorByXpath(responderFilePath, "R", responderVertexList_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "responder vertex list file wasn't loaded correctly."
-                          "\n\tfile path: " + responderFilePath);
-   }
+	// Initialize Vertex Lists based on the data read from the xml files
+	if (!ParameterManager::getInstance().getIntVectorByXpath(callerFilePath, "C", callerVertexList_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"caller vertex list list file wasn't loaded correctly"
+			"\n\tfile path: " + callerFilePath);
+	}
+	numCallerVertices_ = callerVertexList_.size();
+	if (!ParameterManager::getInstance().getIntVectorByXpath(psapFilePath, "P", psapVertexList_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"psap vertex list file wasn't loaded correctly."
+			"\n\tfile path: " + psapFilePath);
+	}
+	if (!ParameterManager::getInstance().getIntVectorByXpath(responderFilePath, "R", responderVertexList_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"responder vertex list file wasn't loaded correctly."
+			"\n\tfile path: " + responderFilePath);
+	}
 }
 
-void Layout911::printParameters() const {
-
-}
+void Layout911::printParameters() const {}
 
 /// Creates a vertex type map.
 /// @param  numVertices number of the vertices to have in the type map.
 void Layout911::generateVertexTypeMap(int numVertices) {
-   DEBUG(std::cout << "\nInitializing vertex type map" << std::endl;);
+	DEBUG(std::cout << "\nInitializing vertex type map" << std::endl;);
 
-   // Populate vertexTypeMap_ with base layer of CALR
-   std::fill_n(vertexTypeMap_, numVertices, CALR);
+	// Populate vertexTypeMap_ with base layer of CALR
+	std::fill_n(vertexTypeMap_, numVertices, CALR);
 
-   // for (int i = 0; i < numVertices; i++) {
-   //    vertexTypeMap_[i] = CALR;
-   // }
+	// for (int i = 0; i < numVertices; i++) {
+	//    vertexTypeMap_[i] = CALR;
+	// }
 
-   int numPSAPs = psapVertexList_.size();
-   int numResps = responderVertexList_.size();
-   int numCalrs = numVertices - numPSAPs - numResps;
+	int numPSAPs = psapVertexList_.size();
+	int numResps = responderVertexList_.size();
+	int numCalrs = numVertices - numPSAPs - numResps;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
-   << "\tTotal vertices: " << numVertices << std::endl
-   << "\tCaller vertices: " << numCalrs << std::endl
-   << "\tPSAP vertices: " << numPSAPs << std::endl
-   << "\tResponder vertices: " << numResps << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+	                << "\tTotal vertices: " << numVertices << std::endl
+	                << "\tCaller vertices: " << numCalrs << std::endl
+	                << "\tPSAP vertices: " << numPSAPs << std::endl
+	                << "\tResponder vertices: " << numResps << std::endl);
 
-   // Insert PSAPs
-   for (int i = 0; i < numPSAPs; i++) {
-      assert(psapVertexList_.at(i) < numVertices);
-      vertexTypeMap_[psapVertexList_.at(i)] = PSAP;
-   }
+	// Insert PSAPs
+	for (int i = 0; i < numPSAPs; i++) {
+		assert(psapVertexList_.at(i) < numVertices);
+		vertexTypeMap_[psapVertexList_.at(i)] = PSAP;
+	}
 
-   // Insert Responders
-   for (int i = 0; i < responderVertexList_.size(); i++) {
-      assert(responderVertexList_.at(i) < numVertices);
-      vertexTypeMap_[responderVertexList_.at(i)] = RESP;
-   }
+	// Insert Responders
+	for (int i = 0; i < responderVertexList_.size(); i++) {
+		assert(responderVertexList_.at(i) < numVertices);
+		vertexTypeMap_[responderVertexList_.at(i)] = RESP;
+	}
 
-   LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
+	LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
 }
 
-void Layout911::initStarterMap(const int numVertices) {
-   Layout::initStarterMap(numVertices);
-}
+void Layout911::initStarterMap(const int numVertices) { Layout::initStarterMap(numVertices); }
 
 // Get the zone of the vertex
 // Only built for 10x10 grid
 // See: https://docs.google.com/spreadsheets/d/1DqP8sjkfJ_pkxtETzuEdoVZbWOGu633EMQAeShe5k68/edit?usp=sharing
-int Layout911::zone(int index) {
-   
-    return (index%10 >= 5) + 2*(index < 50);
-}
+int Layout911::zone(int index) { return (index % 10 >= 5) + 2 * (index < 50); }
 
 ///  Returns the type of synapse at the given coordinates
 ///
@@ -116,14 +105,10 @@ int Layout911::zone(int index) {
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType Layout911::edgType(const int srcVertex, const int destVertex) {
-   if (vertexTypeMap_[srcVertex] == CALR && vertexTypeMap_[destVertex] == PSAP)
-      return CP;
-   else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == RESP)
-      return PR;
-   else if (vertexTypeMap_[srcVertex] == RESP && vertexTypeMap_[destVertex] == CALR)
-      return RC;
-   else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == PSAP)
-      return PP;
+	if (vertexTypeMap_[srcVertex] == CALR && vertexTypeMap_[destVertex] == PSAP) return CP;
+	else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == RESP) return PR;
+	else if (vertexTypeMap_[srcVertex] == RESP && vertexTypeMap_[destVertex] == CALR) return RC;
+	else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == PSAP) return PP;
 
-   return ETYPE_UNDEF;
+	return ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/NG911/Layout911.cpp
+++ b/Simulator/Layouts/NG911/Layout911.cpp
@@ -61,7 +61,7 @@ void Layout911::generateVertexTypeMap(int numVertices) {
 	DEBUG(std::cout << "\nInitializing vertex type map" << std::endl;);
 
 	// Populate vertexTypeMap_ with base layer of CALR
-	std::fill_n(vertexTypeMap_, numVertices, CALR);
+	std::fill_n(vertexTypeMap_, numVertices, vertexType::CALR);
 
 	// for (int i = 0; i < numVertices; i++) {
 	//    vertexTypeMap_[i] = CALR;
@@ -80,13 +80,13 @@ void Layout911::generateVertexTypeMap(int numVertices) {
 	// Insert PSAPs
 	for (int i = 0; i < numPSAPs; i++) {
 		assert(psapVertexList_.at(i) < numVertices);
-		vertexTypeMap_[psapVertexList_.at(i)] = PSAP;
+		vertexTypeMap_[psapVertexList_.at(i)] = vertexType::PSAP;
 	}
 
 	// Insert Responders
 	for (int i = 0; i < responderVertexList_.size(); i++) {
 		assert(responderVertexList_.at(i) < numVertices);
-		vertexTypeMap_[responderVertexList_.at(i)] = RESP;
+		vertexTypeMap_[responderVertexList_.at(i)] = vertexType::RESP;
 	}
 
 	LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
@@ -105,10 +105,14 @@ int Layout911::zone(int index) { return (index % 10 >= 5) + 2 * (index < 50); }
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType Layout911::edgType(const int srcVertex, const int destVertex) {
-	if (vertexTypeMap_[srcVertex] == CALR && vertexTypeMap_[destVertex] == PSAP) return CP;
-	else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == RESP) return PR;
-	else if (vertexTypeMap_[srcVertex] == RESP && vertexTypeMap_[destVertex] == CALR) return RC;
-	else if (vertexTypeMap_[srcVertex] == PSAP && vertexTypeMap_[destVertex] == PSAP) return PP;
+	if (vertexTypeMap_[srcVertex] == vertexType::CALR && vertexTypeMap_[destVertex] == vertexType::PSAP) return
+		edgeType::CP;
+	if (vertexTypeMap_[srcVertex] == vertexType::PSAP && vertexTypeMap_[destVertex] == vertexType::RESP) return
+		edgeType::PR;
+	if (vertexTypeMap_[srcVertex] == vertexType::RESP && vertexTypeMap_[destVertex] == vertexType::CALR) return
+		edgeType::RC;
+	if (vertexTypeMap_[srcVertex] == vertexType::PSAP && vertexTypeMap_[destVertex] == vertexType::PSAP) return
+		edgeType::PP;
 
-	return ETYPE_UNDEF;
+	return edgeType::ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/NG911/Layout911.cpp
+++ b/Simulator/Layouts/NG911/Layout911.cpp
@@ -19,39 +19,39 @@ Layout911::~Layout911() {
 
 void Layout911::loadParameters() {
     // Get the file paths for the vertex lists from the configuration file
-   string callerFilePath;
-   string psapFilePath;
-   string responderFilePath;
+   std::string callerFilePath;
+   std::string psapFilePath;
+   std::string responderFilePath;
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/callersListFileName/text()",
                                                          callerFilePath)) {
-      throw runtime_error("In Layout::loadParameters() caller "
+      throw std::runtime_error("In Layout::loadParameters() caller "
                           "vertex list file path wasn't found and will not be initialized");
    }
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/PSAPsListFileName/text()",
                                                          psapFilePath)) {
-      throw runtime_error("In Layout::loadParameters() psap "
+      throw std::runtime_error("In Layout::loadParameters() psap "
                           "vertex list file path wasn't found and will not be initialized");
    }
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/respondersListFileName/text()",
                                                          responderFilePath)) {
-      throw runtime_error("In Layout::loadParameters() responder"
+      throw std::runtime_error("In Layout::loadParameters() responder"
                           "vertex list file path wasn't found and will not be initialized");
    }
 
    // Initialize Vertex Lists based on the data read from the xml files
    if (!ParameterManager::getInstance().getIntVectorByXpath(callerFilePath, "C", callerVertexList_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "caller vertex list list file wasn't loaded correctly"
                           "\n\tfile path: " + callerFilePath);
    }
    numCallerVertices_ = callerVertexList_.size();
    if (!ParameterManager::getInstance().getIntVectorByXpath(psapFilePath, "P", psapVertexList_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "psap vertex list file wasn't loaded correctly."
                           "\n\tfile path: " + psapFilePath);
    }
    if (!ParameterManager::getInstance().getIntVectorByXpath(responderFilePath, "R", responderVertexList_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "responder vertex list file wasn't loaded correctly."
                           "\n\tfile path: " + responderFilePath);
    }
@@ -64,10 +64,10 @@ void Layout911::printParameters() const {
 /// Creates a vertex type map.
 /// @param  numVertices number of the vertices to have in the type map.
 void Layout911::generateVertexTypeMap(int numVertices) {
-   DEBUG(cout << "\nInitializing vertex type map" << endl;);
+   DEBUG(std::cout << "\nInitializing vertex type map" << std::endl;);
 
    // Populate vertexTypeMap_ with base layer of CALR
-   fill_n(vertexTypeMap_, numVertices, CALR);
+   std::fill_n(vertexTypeMap_, numVertices, CALR);
 
    // for (int i = 0; i < numVertices; i++) {
    //    vertexTypeMap_[i] = CALR;
@@ -77,11 +77,11 @@ void Layout911::generateVertexTypeMap(int numVertices) {
    int numResps = responderVertexList_.size();
    int numCalrs = numVertices - numPSAPs - numResps;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << endl
-   << "\tTotal vertices: " << numVertices << endl
-   << "\tCaller vertices: " << numCalrs << endl
-   << "\tPSAP vertices: " << numPSAPs << endl
-   << "\tResponder vertices: " << numResps << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+   << "\tTotal vertices: " << numVertices << std::endl
+   << "\tCaller vertices: " << numCalrs << std::endl
+   << "\tPSAP vertices: " << numPSAPs << std::endl
+   << "\tResponder vertices: " << numResps << std::endl);
 
    // Insert PSAPs
    for (int i = 0; i < numPSAPs; i++) {

--- a/Simulator/Layouts/NG911/Layout911.h
+++ b/Simulator/Layouts/NG911/Layout911.h
@@ -16,8 +16,6 @@
 
 #include "Layout.h"
 
-using namespace std;
-
 class Layout911 : public Layout {
 public:
    Layout911();

--- a/Simulator/Layouts/NG911/Layout911.h
+++ b/Simulator/Layouts/NG911/Layout911.h
@@ -42,7 +42,7 @@ class Layout911 : public Layout {
 		///  Populates the starter map.
 		///
 		///  @param  numVertices number of vertices to have in the map.
-		void initStarterMap(const int numVertices) override;
+		void initStarterMap(int numVertices) override;
 
 		/// Get the zone of the vertex
 		/// Only built for 10x10 grid
@@ -54,7 +54,7 @@ class Layout911 : public Layout {
 		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
 		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
 		/// @return type of the synapse.
-		edgeType edgType(const int srcVertex, const int destVertex) override;
+		edgeType edgType(int srcVertex, int destVertex) override;
 
 
 };

--- a/Simulator/Layouts/NG911/Layout911.h
+++ b/Simulator/Layouts/NG911/Layout911.h
@@ -17,47 +17,44 @@
 #include "Layout.h"
 
 class Layout911 : public Layout {
-public:
-   Layout911();
+	public:
+		Layout911();
 
-   virtual ~Layout911();
+		~Layout911() override;
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static Layout *Create() { return new Layout911(); }
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static Layout* Create() { return new Layout911(); }
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters() override;
+		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
+		void loadParameters() override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Creates a vertex type map.
-   ///
-   ///  @param  numVertices number of the vertices to have in the type map.
-   virtual void generateVertexTypeMap(int numVertices) override;
+		///  Creates a vertex type map.
+		///
+		///  @param  numVertices number of the vertices to have in the type map.
+		void generateVertexTypeMap(int numVertices) override;
 
-   ///  Populates the starter map.
-   ///
-   ///  @param  numVertices number of vertices to have in the map.
-   virtual void initStarterMap(const int numVertices) override;
+		///  Populates the starter map.
+		///
+		///  @param  numVertices number of vertices to have in the map.
+		void initStarterMap(const int numVertices) override;
 
-   /// Get the zone of the vertex
-   /// Only built for 10x10 grid
-   /// See: https://docs.google.com/spreadsheets/d/1DqP8sjkfJ_pkxtETzuEdoVZbWOGu633EMQAeShe5k68/edit?usp=sharing
-   /// @param  index    the index of the vertex
-   int zone(int index);
+		/// Get the zone of the vertex
+		/// Only built for 10x10 grid
+		/// See: https://docs.google.com/spreadsheets/d/1DqP8sjkfJ_pkxtETzuEdoVZbWOGu633EMQAeShe5k68/edit?usp=sharing
+		/// @param  index    the index of the vertex
+		int zone(int index);
 
-   /// Returns the type of synapse at the given coordinates
-   /// @param    srcVertex  integer that points to a Neuron in the type map as a source.
-   /// @param    destVertex integer that points to a Neuron in the type map as a destination.
-   /// @return type of the synapse.
-   virtual edgeType edgType(const int srcVertex, const int destVertex) override;
-
-
+		/// Returns the type of synapse at the given coordinates
+		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
+		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
+		/// @return type of the synapse.
+		edgeType edgType(const int srcVertex, const int destVertex) override;
 
 
 };
-

--- a/Simulator/Layouts/Neuro/DynamicLayout.cpp
+++ b/Simulator/Layouts/Neuro/DynamicLayout.cpp
@@ -32,13 +32,13 @@ void DynamicLayout::generateVertexTypeMap(int numVertices) {
 	LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map..." << std::endl);
 
 	// Populate vertexTypeMap_ with EXC
-	std::fill_n(vertexTypeMap_, numVertices, EXC);
+	std::fill_n(vertexTypeMap_, numVertices, vertexType::EXC);
 
 	// for (int i = 0; i < numVertices; i++) {
 	//    vertexTypeMap_[i] = EXC;
 	// }
 
-	int numExcitatory = (int)(fractionExcitatory_ * numVertices + 0.5);
+	int numExcitatory = static_cast<int>(fractionExcitatory_ * numVertices + 0.5);
 	int numInhibitory = numVertices - numExcitatory;
 
 	LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
@@ -57,7 +57,7 @@ void DynamicLayout::generateVertexTypeMap(int numVertices) {
 		if (j < numInhibitory) rgInhibitoryLayout[j] = i;
 	}
 
-	for (int i = 0; i < numInhibitory; i++) vertexTypeMap_[rgInhibitoryLayout[i]] = INH;
+	for (int i = 0; i < numInhibitory; i++) vertexTypeMap_[rgInhibitoryLayout[i]] = vertexType::INH;
 	delete[] rgInhibitoryLayout;
 
 	LOG4CPLUS_INFO(fileLogger_, "Done initializing vertex type map");
@@ -71,7 +71,7 @@ void DynamicLayout::generateVertexTypeMap(int numVertices) {
 void DynamicLayout::initStarterMap(const int numVertices) {
 	Layout::initStarterMap(numVertices);
 
-	numEndogenouslyActiveNeurons_ = (BGSIZE)(fractionEndogenouslyActive_ * numVertices + 0.5);
+	numEndogenouslyActiveNeurons_ = static_cast<uint32_t>(fractionEndogenouslyActive_ * numVertices + 0.5);
 	BGSIZE startersAllocated = 0;
 
 	LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << std::endl
@@ -86,7 +86,7 @@ void DynamicLayout::initStarterMap(const int numVertices) {
 
 		// If the neuron at that index is excitatory and not already in the
 		// starter map, add an entry.
-		if (vertexTypeMap_[i] == EXC && !starterMap_[i]) {
+		if (vertexTypeMap_[i] == vertexType::EXC && !starterMap_[i]) {
 			starterMap_[i] = true;
 			startersAllocated++;
 			LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << std::endl;);
@@ -132,10 +132,14 @@ void DynamicLayout::loadParameters() {
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType DynamicLayout::edgType(const int srcVertex, const int destVertex) {
-	if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH) return II;
-	else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC) return IE;
-	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH) return EI;
-	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC) return EE;
+	if (vertexTypeMap_[srcVertex] == vertexType::INH && vertexTypeMap_[destVertex] == vertexType::INH) return
+		edgeType::II;
+	if (vertexTypeMap_[srcVertex] == vertexType::INH && vertexTypeMap_[destVertex] == vertexType::EXC) return
+		edgeType::IE;
+	if (vertexTypeMap_[srcVertex] == vertexType::EXC && vertexTypeMap_[destVertex] == vertexType::INH) return
+		edgeType::EI;
+	if (vertexTypeMap_[srcVertex] == vertexType::EXC && vertexTypeMap_[destVertex] == vertexType::EXC) return
+		edgeType::EE;
 
-	return ETYPE_UNDEF;
+	return edgeType::ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/Neuro/DynamicLayout.cpp
+++ b/Simulator/Layouts/Neuro/DynamicLayout.cpp
@@ -22,19 +22,19 @@ DynamicLayout::~DynamicLayout() {
 ///  Registered to OperationManager as Operation::printParameters
 void DynamicLayout::printParameters() const {
    Layout::printParameters();
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: Dynamic Layout" << endl
-                                 << "\tfraction endogenously active:" << fractionEndogenouslyActive_ << endl
-                                 << "\tfraction excitatory:" << fractionExcitatory_ << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: Dynamic Layout" << std::endl
+                                 << "\tfraction endogenously active:" << fractionEndogenouslyActive_ << std::endl
+                                 << "\tfraction excitatory:" << fractionExcitatory_ << std::endl << std::endl);
 }
 
 ///  Creates a randomly ordered distribution with the specified numbers of neuron types.
 ///
 ///  @param  numVertices number of the vertices to have in the type map.
 void DynamicLayout::generateVertexTypeMap(int numVertices) {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map..." << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map..." << std::endl);
 
    // Populate vertexTypeMap_ with EXC
-   fill_n(vertexTypeMap_, numVertices, EXC);
+   std::fill_n(vertexTypeMap_, numVertices, EXC);
 
    // for (int i = 0; i < numVertices; i++) {
    //    vertexTypeMap_[i] = EXC;
@@ -43,10 +43,10 @@ void DynamicLayout::generateVertexTypeMap(int numVertices) {
    int numExcitatory = (int) (fractionExcitatory_ * numVertices + 0.5);
    int numInhibitory = numVertices - numExcitatory;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << endl
-                                 << "\tTotal vertices: " << numVertices << endl
-                                 << "\tInhibitory Neurons: " << numInhibitory << endl
-                                 << "\tExcitatory Neurons: " << numExcitatory << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+                                 << "\tTotal vertices: " << numVertices << std::endl
+                                 << "\tInhibitory Neurons: " << numInhibitory << std::endl
+                                 << "\tExcitatory Neurons: " << numExcitatory << std::endl);
 
    LOG4CPLUS_INFO(fileLogger_, "Randomly selecting inhibitory neurons...");
 
@@ -82,10 +82,10 @@ void DynamicLayout::initStarterMap(const int numVertices) {
    numEndogenouslyActiveNeurons_ = (BGSIZE) (fractionEndogenouslyActive_ * numVertices + 0.5);
    BGSIZE startersAllocated = 0;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << endl
-                                 << "\tTotal Neurons: " << numVertices << endl
+   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << std::endl
+                                 << "\tTotal Neurons: " << numVertices << std::endl
                                  << "\tStarter Neurons: " << numEndogenouslyActiveNeurons_
-                                 << endl);
+                                 << std::endl);
 
    // randomly set neurons as starters until we've created enough
    while (startersAllocated < numEndogenouslyActiveNeurons_) {
@@ -97,7 +97,7 @@ void DynamicLayout::initStarterMap(const int numVertices) {
       if (vertexTypeMap_[i] == EXC && !starterMap_[i]) {
          starterMap_[i] = true;
          startersAllocated++;
-         LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << endl;);
+         LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << std::endl;);
       }
    }
 
@@ -107,28 +107,28 @@ void DynamicLayout::initStarterMap(const int numVertices) {
 /// Load member variables from configuration file. Registered to OperationManager as Operations::op::loadParameters
 void DynamicLayout::loadParameters() {
    // Get the file paths for the Neuron lists from the configuration file
-   string activeNListFilePath;
-   string inhibitoryNListFilePath;
+   std::string activeNListFilePath;
+   std::string inhibitoryNListFilePath;
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
                                                          activeNListFilePath)) {
-      throw runtime_error("In Layout::loadParameters() Endogenously "
+      throw std::runtime_error("In Layout::loadParameters() Endogenously "
                           "active neuron list file path wasn't found and will not be initialized");
    }
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
                                                          inhibitoryNListFilePath)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Inhibitory neuron list file path wasn't found and will not be initialized");
    }
 
    // Initialize Neuron Lists based on the data read from the xml files
    if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Endogenously active neuron list file wasn't loaded correctly"
                           "\n\tfile path: " + activeNListFilePath);
    }
    numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
    if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Inhibitory neuron list file wasn't loaded correctly."
                           "\n\tfile path: " + inhibitoryNListFilePath);
    }

--- a/Simulator/Layouts/Neuro/DynamicLayout.cpp
+++ b/Simulator/Layouts/Neuro/DynamicLayout.cpp
@@ -7,68 +7,60 @@
  */
 
 #include "DynamicLayout.h"
+#include "ParameterManager.h"
 #include "ParseParamError.h"
 #include "Util.h"
-#include "ParameterManager.h"
 
 // TODO: Neither the constructor nor the destructor are needed here, right?
-DynamicLayout::DynamicLayout() : Layout() {
-}
+DynamicLayout::DynamicLayout() : Layout() {}
 
-DynamicLayout::~DynamicLayout() {
-}
+DynamicLayout::~DynamicLayout() {}
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void DynamicLayout::printParameters() const {
-   Layout::printParameters();
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: Dynamic Layout" << std::endl
-                                 << "\tfraction endogenously active:" << fractionEndogenouslyActive_ << std::endl
-                                 << "\tfraction excitatory:" << fractionExcitatory_ << std::endl << std::endl);
+	Layout::printParameters();
+	LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: Dynamic Layout" << std::endl
+	                << "\tfraction endogenously active:" << fractionEndogenouslyActive_ << std::endl
+	                << "\tfraction excitatory:" << fractionExcitatory_ << std::endl << std::endl);
 }
 
 ///  Creates a randomly ordered distribution with the specified numbers of neuron types.
 ///
 ///  @param  numVertices number of the vertices to have in the type map.
 void DynamicLayout::generateVertexTypeMap(int numVertices) {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map..." << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map..." << std::endl);
 
-   // Populate vertexTypeMap_ with EXC
-   std::fill_n(vertexTypeMap_, numVertices, EXC);
+	// Populate vertexTypeMap_ with EXC
+	std::fill_n(vertexTypeMap_, numVertices, EXC);
 
-   // for (int i = 0; i < numVertices; i++) {
-   //    vertexTypeMap_[i] = EXC;
-   // }
+	// for (int i = 0; i < numVertices; i++) {
+	//    vertexTypeMap_[i] = EXC;
+	// }
 
-   int numExcitatory = (int) (fractionExcitatory_ * numVertices + 0.5);
-   int numInhibitory = numVertices - numExcitatory;
+	int numExcitatory = (int)(fractionExcitatory_ * numVertices + 0.5);
+	int numInhibitory = numVertices - numExcitatory;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
-                                 << "\tTotal vertices: " << numVertices << std::endl
-                                 << "\tInhibitory Neurons: " << numInhibitory << std::endl
-                                 << "\tExcitatory Neurons: " << numExcitatory << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+	                << "\tTotal vertices: " << numVertices << std::endl
+	                << "\tInhibitory Neurons: " << numInhibitory << std::endl
+	                << "\tExcitatory Neurons: " << numExcitatory << std::endl);
 
-   LOG4CPLUS_INFO(fileLogger_, "Randomly selecting inhibitory neurons...");
+	LOG4CPLUS_INFO(fileLogger_, "Randomly selecting inhibitory neurons...");
 
-   int *rgInhibitoryLayout = new int[numInhibitory];
+	auto rgInhibitoryLayout = new int[numInhibitory];
 
-   for (int i = 0; i < numInhibitory; i++) {
-      rgInhibitoryLayout[i] = i;
-   }
+	for (int i = 0; i < numInhibitory; i++) rgInhibitoryLayout[i] = i;
 
-   for (int i = numInhibitory; i < numVertices; i++) {
-      int j = static_cast<int>(initRNG() * numVertices);
-      if (j < numInhibitory) {
-         rgInhibitoryLayout[j] = i;
-      }
-   }
+	for (int i = numInhibitory; i < numVertices; i++) {
+		int j = static_cast<int>(initRNG() * numVertices);
+		if (j < numInhibitory) rgInhibitoryLayout[j] = i;
+	}
 
-   for (int i = 0; i < numInhibitory; i++) {
-      vertexTypeMap_[rgInhibitoryLayout[i]] = INH;
-   }
-   delete[] rgInhibitoryLayout;
+	for (int i = 0; i < numInhibitory; i++) vertexTypeMap_[rgInhibitoryLayout[i]] = INH;
+	delete[] rgInhibitoryLayout;
 
-   LOG4CPLUS_INFO(fileLogger_, "Done initializing vertex type map");
+	LOG4CPLUS_INFO(fileLogger_, "Done initializing vertex type map");
 }
 
 ///  Populates the starter map.
@@ -77,61 +69,61 @@ void DynamicLayout::generateVertexTypeMap(int numVertices) {
 ///
 ///  @param  numVertices number of vertices to have in the map.
 void DynamicLayout::initStarterMap(const int numVertices) {
-   Layout::initStarterMap(numVertices);
+	Layout::initStarterMap(numVertices);
 
-   numEndogenouslyActiveNeurons_ = (BGSIZE) (fractionEndogenouslyActive_ * numVertices + 0.5);
-   BGSIZE startersAllocated = 0;
+	numEndogenouslyActiveNeurons_ = (BGSIZE)(fractionEndogenouslyActive_ * numVertices + 0.5);
+	BGSIZE startersAllocated = 0;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << std::endl
-                                 << "\tTotal Neurons: " << numVertices << std::endl
-                                 << "\tStarter Neurons: " << numEndogenouslyActiveNeurons_
-                                 << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nNEURON STARTER MAP" << std::endl
+	                << "\tTotal Neurons: " << numVertices << std::endl
+	                << "\tStarter Neurons: " << numEndogenouslyActiveNeurons_
+	                << std::endl);
 
-   // randomly set neurons as starters until we've created enough
-   while (startersAllocated < numEndogenouslyActiveNeurons_) {
-      // Get a random neuron ID
-      int i = static_cast<int>(initRNG.inRange(0, numVertices));
+	// randomly set neurons as starters until we've created enough
+	while (startersAllocated < numEndogenouslyActiveNeurons_) {
+		// Get a random neuron ID
+		int i = static_cast<int>(initRNG.inRange(0, numVertices));
 
-      // If the neuron at that index is excitatory and not already in the
-      // starter map, add an entry.
-      if (vertexTypeMap_[i] == EXC && !starterMap_[i]) {
-         starterMap_[i] = true;
-         startersAllocated++;
-         LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << std::endl;);
-      }
-   }
+		// If the neuron at that index is excitatory and not already in the
+		// starter map, add an entry.
+		if (vertexTypeMap_[i] == EXC && !starterMap_[i]) {
+			starterMap_[i] = true;
+			startersAllocated++;
+			LOG4CPLUS_DEBUG(fileLogger_, "Allocated EA neuron at random index [" << i << "]" << std::endl;);
+		}
+	}
 
-   LOG4CPLUS_INFO(fileLogger_, "Done randomly initializing starter map");
+	LOG4CPLUS_INFO(fileLogger_, "Done randomly initializing starter map");
 }
 
 /// Load member variables from configuration file. Registered to OperationManager as Operations::op::loadParameters
 void DynamicLayout::loadParameters() {
-   // Get the file paths for the Neuron lists from the configuration file
-   std::string activeNListFilePath;
-   std::string inhibitoryNListFilePath;
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
-                                                         activeNListFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() Endogenously "
-                          "active neuron list file path wasn't found and will not be initialized");
-   }
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
-                                                         inhibitoryNListFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Inhibitory neuron list file path wasn't found and will not be initialized");
-   }
+	// Get the file paths for the Neuron lists from the configuration file
+	std::string activeNListFilePath;
+	std::string inhibitoryNListFilePath;
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
+	                                                      activeNListFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() Endogenously "
+			"active neuron list file path wasn't found and will not be initialized");
+	}
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
+	                                                      inhibitoryNListFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Inhibitory neuron list file path wasn't found and will not be initialized");
+	}
 
-   // Initialize Neuron Lists based on the data read from the xml files
-   if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Endogenously active neuron list file wasn't loaded correctly"
-                          "\n\tfile path: " + activeNListFilePath);
-   }
-   numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
-   if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Inhibitory neuron list file wasn't loaded correctly."
-                          "\n\tfile path: " + inhibitoryNListFilePath);
-   }
+	// Initialize Neuron Lists based on the data read from the xml files
+	if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Endogenously active neuron list file wasn't loaded correctly"
+			"\n\tfile path: " + activeNListFilePath);
+	}
+	numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
+	if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Inhibitory neuron list file wasn't loaded correctly."
+			"\n\tfile path: " + inhibitoryNListFilePath);
+	}
 }
 
 ///  Returns the type of synapse at the given coordinates
@@ -140,14 +132,10 @@ void DynamicLayout::loadParameters() {
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType DynamicLayout::edgType(const int srcVertex, const int destVertex) {
-   if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH)
-      return II;
-   else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC)
-      return IE;
-   else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH)
-      return EI;
-   else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC)
-      return EE;
+	if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH) return II;
+	else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC) return IE;
+	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH) return EI;
+	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC) return EE;
 
-   return ETYPE_UNDEF;
+	return ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/Neuro/DynamicLayout.h
+++ b/Simulator/Layouts/Neuro/DynamicLayout.h
@@ -17,8 +17,6 @@
 
 #include "Layout.h"
 
-using namespace std;
-
 class DynamicLayout : public Layout {
 public:
    DynamicLayout();

--- a/Simulator/Layouts/Neuro/DynamicLayout.h
+++ b/Simulator/Layouts/Neuro/DynamicLayout.h
@@ -39,7 +39,7 @@ class DynamicLayout : public Layout {
 		///  and converts them into starter neurons.
 		///
 		///  @param  numVertices number of vertices to have in the map.
-		void initStarterMap(const int numVertices) override;
+		void initStarterMap(int numVertices) override;
 
 		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
 		void loadParameters() override;
@@ -48,7 +48,7 @@ class DynamicLayout : public Layout {
 		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
 		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
 		/// @return type of the synapse.
-		edgeType edgType(const int srcVertex, const int destVertex) override;
+		edgeType edgType(int srcVertex, int destVertex) override;
 
 	private:
 		/// Fraction of endogenously active neurons.

--- a/Simulator/Layouts/Neuro/DynamicLayout.h
+++ b/Simulator/Layouts/Neuro/DynamicLayout.h
@@ -18,43 +18,42 @@
 #include "Layout.h"
 
 class DynamicLayout : public Layout {
-public:
-   DynamicLayout();
+	public:
+		DynamicLayout();
 
-   virtual ~DynamicLayout();
+		~DynamicLayout() override;
 
-   static Layout *Create() { return new DynamicLayout(); }
+		static Layout* Create() { return new DynamicLayout(); }
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Creates a randomly ordered distribution with the specified numbers of neuron types.
-   ///
-   ///  @param  numVertices number of the neurons to have in the type map.
-   virtual void generateVertexTypeMap(int numVertices) override;
+		///  Creates a randomly ordered distribution with the specified numbers of neuron types.
+		///
+		///  @param  numVertices number of the neurons to have in the type map.
+		void generateVertexTypeMap(int numVertices) override;
 
-   ///  Populates the starter map.
-   ///  Selects num_endogenously_active_neurons excitory neurons
-   ///  and converts them into starter neurons.
-   ///
-   ///  @param  numVertices number of vertices to have in the map.
-   virtual void initStarterMap(const int numVertices) override;
+		///  Populates the starter map.
+		///  Selects num_endogenously_active_neurons excitory neurons
+		///  and converts them into starter neurons.
+		///
+		///  @param  numVertices number of vertices to have in the map.
+		void initStarterMap(const int numVertices) override;
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters(); 
+		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
+		void loadParameters() override;
 
-   /// Returns the type of synapse at the given coordinates
-   /// @param    srcVertex  integer that points to a Neuron in the type map as a source.
-   /// @param    destVertex integer that points to a Neuron in the type map as a destination.
-   /// @return type of the synapse.
-   virtual edgeType edgType(const int srcVertex, const int destVertex);
+		/// Returns the type of synapse at the given coordinates
+		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
+		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
+		/// @return type of the synapse.
+		edgeType edgType(const int srcVertex, const int destVertex) override;
 
-private:
-   /// Fraction of endogenously active neurons.
-   BGFLOAT fractionEndogenouslyActive_;
+	private:
+		/// Fraction of endogenously active neurons.
+		BGFLOAT fractionEndogenouslyActive_;
 
-   /// Fraction of exitatory neurons.
-   BGFLOAT fractionExcitatory_;
+		/// Fraction of exitatory neurons.
+		BGFLOAT fractionExcitatory_;
 };
-

--- a/Simulator/Layouts/Neuro/FixedLayout.cpp
+++ b/Simulator/Layouts/Neuro/FixedLayout.cpp
@@ -7,94 +7,92 @@
  */
 
 #include "FixedLayout.h"
+#include "ParameterManager.h"
 #include "ParseParamError.h"
 #include "Util.h"
-#include "ParameterManager.h"
 
 // TODO: I don't think that either of the constructor or destructor is needed here
-FixedLayout::FixedLayout() : Layout() {
-}
+FixedLayout::FixedLayout() : Layout() {}
 
-FixedLayout::~FixedLayout() {
-}
+FixedLayout::~FixedLayout() {}
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void FixedLayout::printParameters() const {
-   Layout::printParameters();
+	Layout::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: FixedLayout" << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: FixedLayout" << std::endl << std::endl);
 }
 
 ///  Creates a randomly ordered distribution with the specified numbers of vertex types.
 ///
 ///  @param  numVertices number of the vertices to have in the type map.
 void FixedLayout::generateVertexTypeMap(int numVertices) {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map" << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map" << std::endl);
 
-   // Populate vertexTypeMap_ with EXC
-   std::fill_n(vertexTypeMap_, numVertices, EXC);
+	// Populate vertexTypeMap_ with EXC
+	std::fill_n(vertexTypeMap_, numVertices, EXC);
 
-   // for (int i = 0; i < numVertices; i++) {
-   //    vertexTypeMap_[i] = EXC;
-   // }
+	// for (int i = 0; i < numVertices; i++) {
+	//    vertexTypeMap_[i] = EXC;
+	// }
 
-   int numInhibitoryNeurons = inhibitoryNeuronLayout_.size();
-   int numExcititoryNeurons = numVertices - numInhibitoryNeurons;
+	int numInhibitoryNeurons = inhibitoryNeuronLayout_.size();
+	int numExcititoryNeurons = numVertices - numInhibitoryNeurons;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
-   << "\tTotal vertices: " << numVertices << std::endl
-   << "\tInhibitory Neurons: " << numInhibitoryNeurons << std::endl
-   << "\tExcitatory Neurons: " << numExcititoryNeurons << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+	                << "\tTotal vertices: " << numVertices << std::endl
+	                << "\tInhibitory Neurons: " << numInhibitoryNeurons << std::endl
+	                << "\tExcitatory Neurons: " << numExcititoryNeurons << std::endl);
 
-   for (int i = 0; i < numInhibitoryNeurons; i++) {
-      assert(inhibitoryNeuronLayout_.at(i) < numVertices);
-      vertexTypeMap_[inhibitoryNeuronLayout_.at(i)] = INH;
-   }
+	for (int i = 0; i < numInhibitoryNeurons; i++) {
+		assert(inhibitoryNeuronLayout_.at(i) < numVertices);
+		vertexTypeMap_[inhibitoryNeuronLayout_.at(i)] = INH;
+	}
 
-   LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
+	LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
 }
 
 ///  Populates the starter map.
 ///  Selects \e numStarter excitory neurons and converts them into starter neurons.
 ///  @param  numVertices number of vertices to have in the map.
 void FixedLayout::initStarterMap(const int numVertices) {
-   Layout::initStarterMap(numVertices);
+	Layout::initStarterMap(numVertices);
 
-   for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) {
-      assert(endogenouslyActiveNeuronList_.at(i) < numVertices);
-      starterMap_[endogenouslyActiveNeuronList_.at(i)] = true;
-   }
+	for (BGSIZE i = 0; i < numEndogenouslyActiveNeurons_; i++) {
+		assert(endogenouslyActiveNeuronList_.at(i) < numVertices);
+		starterMap_[endogenouslyActiveNeuronList_.at(i)] = true;
+	}
 }
 
 /// Load member variables from configuration file. Registered to OperationManager as Operations::op::loadParameters
 void FixedLayout::loadParameters() {
-   // Get the file paths for the Neuron lists from the configuration file
-   std::string activeNListFilePath;
-   std::string inhibitoryNListFilePath;
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
-                                                         activeNListFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() Endogenously "
-                          "active neuron list file path wasn't found and will not be initialized");
-   }
-   if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
-                                                         inhibitoryNListFilePath)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Inhibitory neuron list file path wasn't found and will not be initialized");
-   }
+	// Get the file paths for the Neuron lists from the configuration file
+	std::string activeNListFilePath;
+	std::string inhibitoryNListFilePath;
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
+	                                                      activeNListFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() Endogenously "
+			"active neuron list file path wasn't found and will not be initialized");
+	}
+	if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
+	                                                      inhibitoryNListFilePath)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Inhibitory neuron list file path wasn't found and will not be initialized");
+	}
 
-   // Initialize Neuron Lists based on the data read from the xml files
-   if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Endogenously active neuron list file wasn't loaded correctly"
-                          "\n\tfile path: " + activeNListFilePath);
-   }
-   numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
-   if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
-      throw std::runtime_error("In Layout::loadParameters() "
-                          "Inhibitory neuron list file wasn't loaded correctly."
-                          "\n\tfile path: " + inhibitoryNListFilePath);
-   }
+	// Initialize Neuron Lists based on the data read from the xml files
+	if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Endogenously active neuron list file wasn't loaded correctly"
+			"\n\tfile path: " + activeNListFilePath);
+	}
+	numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
+	if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
+		throw std::runtime_error("In Layout::loadParameters() "
+			"Inhibitory neuron list file wasn't loaded correctly."
+			"\n\tfile path: " + inhibitoryNListFilePath);
+	}
 }
 
 ///  Returns the type of synapse at the given coordinates
@@ -103,14 +101,10 @@ void FixedLayout::loadParameters() {
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType FixedLayout::edgType(const int srcVertex, const int destVertex) {
-   if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH)
-      return II;
-   else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC)
-      return IE;
-   else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH)
-      return EI;
-   else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC)
-      return EE;
+	if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH) return II;
+	else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC) return IE;
+	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH) return EI;
+	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC) return EE;
 
-   return ETYPE_UNDEF;
+	return ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/Neuro/FixedLayout.cpp
+++ b/Simulator/Layouts/Neuro/FixedLayout.cpp
@@ -23,17 +23,17 @@ FixedLayout::~FixedLayout() {
 void FixedLayout::printParameters() const {
    Layout::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: FixedLayout" << endl << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tLayout type: FixedLayout" << std::endl << std::endl);
 }
 
 ///  Creates a randomly ordered distribution with the specified numbers of vertex types.
 ///
 ///  @param  numVertices number of the vertices to have in the type map.
 void FixedLayout::generateVertexTypeMap(int numVertices) {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map" << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map" << std::endl);
 
    // Populate vertexTypeMap_ with EXC
-   fill_n(vertexTypeMap_, numVertices, EXC);
+   std::fill_n(vertexTypeMap_, numVertices, EXC);
 
    // for (int i = 0; i < numVertices; i++) {
    //    vertexTypeMap_[i] = EXC;
@@ -42,10 +42,10 @@ void FixedLayout::generateVertexTypeMap(int numVertices) {
    int numInhibitoryNeurons = inhibitoryNeuronLayout_.size();
    int numExcititoryNeurons = numVertices - numInhibitoryNeurons;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << endl
-   << "\tTotal vertices: " << numVertices << endl
-   << "\tInhibitory Neurons: " << numInhibitoryNeurons << endl
-   << "\tExcitatory Neurons: " << numExcititoryNeurons << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTEX TYPE MAP" << std::endl
+   << "\tTotal vertices: " << numVertices << std::endl
+   << "\tInhibitory Neurons: " << numInhibitoryNeurons << std::endl
+   << "\tExcitatory Neurons: " << numExcititoryNeurons << std::endl);
 
    for (int i = 0; i < numInhibitoryNeurons; i++) {
       assert(inhibitoryNeuronLayout_.at(i) < numVertices);
@@ -70,28 +70,28 @@ void FixedLayout::initStarterMap(const int numVertices) {
 /// Load member variables from configuration file. Registered to OperationManager as Operations::op::loadParameters
 void FixedLayout::loadParameters() {
    // Get the file paths for the Neuron lists from the configuration file
-   string activeNListFilePath;
-   string inhibitoryNListFilePath;
+   std::string activeNListFilePath;
+   std::string inhibitoryNListFilePath;
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/activeNListFileName/text()",
                                                          activeNListFilePath)) {
-      throw runtime_error("In Layout::loadParameters() Endogenously "
+      throw std::runtime_error("In Layout::loadParameters() Endogenously "
                           "active neuron list file path wasn't found and will not be initialized");
    }
    if (!ParameterManager::getInstance().getStringByXpath("//LayoutFiles/inhNListFileName/text()",
                                                          inhibitoryNListFilePath)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Inhibitory neuron list file path wasn't found and will not be initialized");
    }
 
    // Initialize Neuron Lists based on the data read from the xml files
    if (!ParameterManager::getInstance().getIntVectorByXpath(activeNListFilePath, "A", endogenouslyActiveNeuronList_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Endogenously active neuron list file wasn't loaded correctly"
                           "\n\tfile path: " + activeNListFilePath);
    }
    numEndogenouslyActiveNeurons_ = endogenouslyActiveNeuronList_.size();
    if (!ParameterManager::getInstance().getIntVectorByXpath(inhibitoryNListFilePath, "I", inhibitoryNeuronLayout_)) {
-      throw runtime_error("In Layout::loadParameters() "
+      throw std::runtime_error("In Layout::loadParameters() "
                           "Inhibitory neuron list file wasn't loaded correctly."
                           "\n\tfile path: " + inhibitoryNListFilePath);
    }

--- a/Simulator/Layouts/Neuro/FixedLayout.cpp
+++ b/Simulator/Layouts/Neuro/FixedLayout.cpp
@@ -31,7 +31,7 @@ void FixedLayout::generateVertexTypeMap(int numVertices) {
 	LOG4CPLUS_DEBUG(fileLogger_, "\nInitializing vertex type map" << std::endl);
 
 	// Populate vertexTypeMap_ with EXC
-	std::fill_n(vertexTypeMap_, numVertices, EXC);
+	std::fill_n(vertexTypeMap_, numVertices, vertexType::EXC);
 
 	// for (int i = 0; i < numVertices; i++) {
 	//    vertexTypeMap_[i] = EXC;
@@ -47,7 +47,7 @@ void FixedLayout::generateVertexTypeMap(int numVertices) {
 
 	for (int i = 0; i < numInhibitoryNeurons; i++) {
 		assert(inhibitoryNeuronLayout_.at(i) < numVertices);
-		vertexTypeMap_[inhibitoryNeuronLayout_.at(i)] = INH;
+		vertexTypeMap_[inhibitoryNeuronLayout_.at(i)] = vertexType::INH;
 	}
 
 	LOG4CPLUS_INFO(fileLogger_, "Finished initializing vertex type map");
@@ -101,10 +101,14 @@ void FixedLayout::loadParameters() {
 ///  @param    destVertex integer that points to a Neuron in the type map as a destination.
 ///  @return type of the synapse.
 edgeType FixedLayout::edgType(const int srcVertex, const int destVertex) {
-	if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == INH) return II;
-	else if (vertexTypeMap_[srcVertex] == INH && vertexTypeMap_[destVertex] == EXC) return IE;
-	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == INH) return EI;
-	else if (vertexTypeMap_[srcVertex] == EXC && vertexTypeMap_[destVertex] == EXC) return EE;
+	if (vertexTypeMap_[srcVertex] == vertexType::INH && vertexTypeMap_[destVertex] != vertexType::INH) return
+		edgeType::II;
+	if (vertexTypeMap_[srcVertex] == vertexType::INH && vertexTypeMap_[destVertex] == vertexType::EXC) return
+		edgeType::IE;
+	if (vertexTypeMap_[srcVertex] == vertexType::EXC && vertexTypeMap_[destVertex] == vertexType::INH) return
+		edgeType::EI;
+	if (vertexTypeMap_[srcVertex] == vertexType::EXC && vertexTypeMap_[destVertex] == vertexType::EXC) return
+		edgeType::EE;
 
-	return ETYPE_UNDEF;
+	return edgeType::ETYPE_UNDEF;
 }

--- a/Simulator/Layouts/Neuro/FixedLayout.h
+++ b/Simulator/Layouts/Neuro/FixedLayout.h
@@ -18,36 +18,35 @@
 #include "Layout.h"
 
 class FixedLayout : public Layout {
-public:
-   FixedLayout();
+	public:
+		FixedLayout();
 
-   virtual ~FixedLayout();
+		~FixedLayout() override;
 
-   static Layout *Create() { return new FixedLayout(); }
+		static Layout* Create() { return new FixedLayout(); }
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Creates a vertex type map.
-   ///
-   ///  @param  numVertices number of the vertices to have in the type map.
-   virtual void generateVertexTypeMap(int numVertices) override;
+		///  Creates a vertex type map.
+		///
+		///  @param  numVertices number of the vertices to have in the type map.
+		void generateVertexTypeMap(int numVertices) override;
 
-   ///  Populates the starter map.
-   ///  Selects num_endogenously_active_neurons excitory neurons
-   ///  and converts them into starter vertices.
-   ///
-   ///  @param  numVertices number of vertices to have in the map.
-   virtual void initStarterMap(const int numVertices) override;
+		///  Populates the starter map.
+		///  Selects num_endogenously_active_neurons excitory neurons
+		///  and converts them into starter vertices.
+		///
+		///  @param  numVertices number of vertices to have in the map.
+		void initStarterMap(const int numVertices) override;
 
-   /// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters() override;
+		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
+		void loadParameters() override;
 
-   /// Returns the type of synapse at the given coordinates
-   /// @param    srcVertex  integer that points to a Neuron in the type map as a source.
-   /// @param    destVertex integer that points to a Neuron in the type map as a destination.
-   /// @return type of the synapse.
-   virtual edgeType edgType(const int srcVertex, const int destVertex) override;
+		/// Returns the type of synapse at the given coordinates
+		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
+		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
+		/// @return type of the synapse.
+		edgeType edgType(const int srcVertex, const int destVertex) override;
 };
-

--- a/Simulator/Layouts/Neuro/FixedLayout.h
+++ b/Simulator/Layouts/Neuro/FixedLayout.h
@@ -17,8 +17,6 @@
 
 #include "Layout.h"
 
-using namespace std;
-
 class FixedLayout : public Layout {
 public:
    FixedLayout();

--- a/Simulator/Layouts/Neuro/FixedLayout.h
+++ b/Simulator/Layouts/Neuro/FixedLayout.h
@@ -39,7 +39,7 @@ class FixedLayout : public Layout {
 		///  and converts them into starter vertices.
 		///
 		///  @param  numVertices number of vertices to have in the map.
-		void initStarterMap(const int numVertices) override;
+		void initStarterMap(int numVertices) override;
 
 		/// Load member variables from configuration file. Registered to OperationManager as Operation::loadParameters
 		void loadParameters() override;
@@ -48,5 +48,5 @@ class FixedLayout : public Layout {
 		/// @param    srcVertex  integer that points to a Neuron in the type map as a source.
 		/// @param    destVertex integer that points to a Neuron in the type map as a destination.
 		/// @return type of the synapse.
-		edgeType edgType(const int srcVertex, const int destVertex) override;
+		edgeType edgType(int srcVertex, int destVertex) override;
 };

--- a/Simulator/Recorders/IRecorder.h
+++ b/Simulator/Recorders/IRecorder.h
@@ -12,52 +12,52 @@
 
 #include <log4cplus/loggingmacros.h>
 
+#include "AllVertices.h"
 #include "Global.h"
 #include "Model.h"
 #include "Simulator.h"
-#include "AllVertices.h"
 
 class Model;
 class AllVertices;
 
 class IRecorder {
-public:
-   virtual ~IRecorder() {}
+	public:
+		virtual ~IRecorder() {}
 
-   /// Initialize data
-   ///
-   /// @param[in] stateOutputFileName       File name to save histories
-   virtual void init() = 0;
+		/// Initialize data
+		///
+		/// @param[in] stateOutputFileName       File name to save histories
+		virtual void init() = 0;
 
-   /// Init radii and rates history matrices with default values
-   virtual void initDefaultValues() = 0;
+		/// Init radii and rates history matrices with default values
+		virtual void initDefaultValues() = 0;
 
-   /// Init radii and rates history matrices with current radii and rates
-   virtual void initValues() = 0;
+		/// Init radii and rates history matrices with current radii and rates
+		virtual void initValues() = 0;
 
-   /// Get the current radii and rates values
-   virtual void getValues() = 0;
+		/// Get the current radii and rates values
+		virtual void getValues() = 0;
 
-   /// Terminate process
-   virtual void term() = 0;
+		/// Terminate process
+		virtual void term() = 0;
 
-   /// Compile history information in every epoch
-   ///
-   /// @param[in] neurons   The entire list of neurons.
-   virtual void compileHistories(AllVertices &vertices) = 0;
+		/// Compile history information in every epoch
+		///
+		/// @param[in] neurons   The entire list of neurons.
+		virtual void compileHistories(AllVertices& vertices) = 0;
 
-   /// Writes simulation results to an output destination.
-   ///
-   /// @param[in] neurons   The entire list of neurons.
-   virtual void saveSimData(const AllVertices &vertices) = 0;
+		/// Writes simulation results to an output destination.
+		///
+		/// @param[in] neurons   The entire list of neurons.
+		virtual void saveSimData(const AllVertices& vertices) = 0;
 
-   /// Prints loaded parameters to logging file.
-   virtual void printParameters() = 0;
+		/// Prints loaded parameters to logging file.
+		virtual void printParameters() = 0;
 
-protected:
-   /// File path to the file that the results will be printed to.
-   std::string resultFileName_;
+	protected:
+		/// File path to the file that the results will be printed to.
+		std::string resultFileName_;
 
-   /// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
-   log4cplus::Logger fileLogger_;
+		/// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
+		log4cplus::Logger fileLogger_;
 };

--- a/Simulator/Recorders/IRecorder.h
+++ b/Simulator/Recorders/IRecorder.h
@@ -56,7 +56,7 @@ public:
 
 protected:
    /// File path to the file that the results will be printed to.
-   string resultFileName_;
+   std::string resultFileName_;
 
    /// Loggers used to print to using log4cplus logging macros, prints to Results/Debug/logging.txt
    log4cplus::Logger fileLogger_;

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -40,11 +40,13 @@ void Xml911Recorder::saveSimData(const AllVertices& vertices) {
 	auto& conns911 = dynamic_cast<Connections911&>(*conns);
 
 	// create Vertex Types matrix
-	VectorMatrix oldTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
-	VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
+	VectorMatrix oldTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(),
+	                      static_cast<float>(vertexType::EXC));
+	VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(),
+	                         static_cast<float>(vertexType::EXC));
 	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-		vertexTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
-		oldTypes[i] = conns911.oldTypeMap_[i];
+		vertexTypes[i] = static_cast<float>(Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i]);
+		oldTypes[i] = static_cast<float>(conns911.oldTypeMap_[i]);
 	}
 
 	// Write XML header information:

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -67,27 +67,27 @@ void Xml911Recorder::saveSimData(const AllVertices &vertices) {
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << layout->xloc_->toXML("xloc") << endl;
-   resultOut_ << "   " << layout->yloc_->toXML("yloc") << endl;
-   resultOut_ << "   " << oldTypes.toXML("vertexTypesPreEvent") << endl;
-   resultOut_ << "   " << vertexTypes.toXML("vertexTypesPostEvent") << endl;
+   resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
+   resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
+   resultOut_ << "   " << oldTypes.toXML("vertexTypesPreEvent") << std::endl;
+   resultOut_ << "   " << vertexTypes.toXML("vertexTypesPostEvent") << std::endl;
 
    // Print out deleted edges and vertices:
-   resultOut_ << "   " << conns911.erasedVerticesToXML() << endl;
-   resultOut_ << "   " << conns911.changedEdgesToXML(false) << endl;
-   resultOut_ << "   " << conns911.changedEdgesToXML(true) << endl;
+   resultOut_ << "   " << conns911.erasedVerticesToXML() << std::endl;
+   resultOut_ << "   " << conns911.changedEdgesToXML(false) << std::endl;
+   resultOut_ << "   " << conns911.changedEdgesToXML(true) << std::endl;
 
    // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
-   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << endl;
-   resultOut_ << "</Matrix>" << endl;
+   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
+   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
 
    // write simulation end time
    resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << endl;
-   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << endl;
-   resultOut_ << "</Matrix>" << endl;
-   resultOut_ << "</SimState>" << endl;
+             << std::endl;
+   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
+   resultOut_ << "</SimState>" << std::endl;
 
 }
 

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -14,85 +14,72 @@
 #include "Connections911.h"
 
 
-Xml911Recorder::Xml911Recorder() {
+Xml911Recorder::Xml911Recorder() {}
 
-}
-
-Xml911Recorder::~Xml911Recorder() {
-
-}
+Xml911Recorder::~Xml911Recorder() {}
 
 /// Init radii and rates history matrices with default values
-void Xml911Recorder::initDefaultValues() {
-    
-}
+void Xml911Recorder::initDefaultValues() { }
 
 /// Init radii and rates history matrices with current radii and rates
-void Xml911Recorder::initValues() {
-    
-}
+void Xml911Recorder::initValues() { }
 
 /// Get the current radii and rates vlaues
-void Xml911Recorder::getValues() {
-    
-}
+void Xml911Recorder::getValues() { }
 
 /// Compile history information in every epoch
 ///
 /// @param[in] vertices   The entire list of vertices.
-void Xml911Recorder::compileHistories(AllVertices &vertices) {
-   
-}
+void Xml911Recorder::compileHistories(AllVertices& vertices) { }
 
 /// Writes simulation results to an output destination.
 ///
 /// @param  vertices the Vertex list to search from.
-void Xml911Recorder::saveSimData(const AllVertices &vertices) {
-   auto conns = Simulator::getInstance().getModel()->getConnections();
-   Connections911 &conns911 = dynamic_cast<Connections911 &>(*conns);
+void Xml911Recorder::saveSimData(const AllVertices& vertices) {
+	auto conns = Simulator::getInstance().getModel()->getConnections();
+	auto& conns911 = dynamic_cast<Connections911&>(*conns);
 
-   // create Vertex Types matrix
-   VectorMatrix oldTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
-   VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      vertexTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
-      oldTypes[i] = conns911.oldTypeMap_[i];
-   }
+	// create Vertex Types matrix
+	VectorMatrix oldTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
+	VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		vertexTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
+		oldTypes[i] = conns911.oldTypeMap_[i];
+	}
 
-   // Write XML header information:
-   resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
-             << "<!-- State output file for the 911 systems modeling-->\n";
-   //stateOut << version; TODO: version
-   auto layout = Simulator::getInstance().getModel()->getLayout();
+	// Write XML header information:
+	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
+		<< "<!-- State output file for the 911 systems modeling-->\n";
+	//stateOut << version; TODO: version
+	auto layout = Simulator::getInstance().getModel()->getLayout();
 
-   // Write the core state information:
-   resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
-   resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
-   resultOut_ << "   " << oldTypes.toXML("vertexTypesPreEvent") << std::endl;
-   resultOut_ << "   " << vertexTypes.toXML("vertexTypesPostEvent") << std::endl;
+	// Write the core state information:
+	resultOut_ << "<SimState>\n";
+	resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
+	resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
+	resultOut_ << "   " << oldTypes.toXML("vertexTypesPreEvent") << std::endl;
+	resultOut_ << "   " << vertexTypes.toXML("vertexTypesPostEvent") << std::endl;
 
-   // Print out deleted edges and vertices:
-   resultOut_ << "   " << conns911.erasedVerticesToXML() << std::endl;
-   resultOut_ << "   " << conns911.changedEdgesToXML(false) << std::endl;
-   resultOut_ << "   " << conns911.changedEdgesToXML(true) << std::endl;
+	// Print out deleted edges and vertices:
+	resultOut_ << "   " << conns911.erasedVerticesToXML() << std::endl;
+	resultOut_ << "   " << conns911.changedEdgesToXML(false) << std::endl;
+	resultOut_ << "   " << conns911.changedEdgesToXML(true) << std::endl;
 
-   // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
-   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
+	// write time between growth cycles
+	resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" <<
+		std::endl;
+	resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
 
-   // write simulation end time
-   resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << std::endl;
-   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
-   resultOut_ << "</SimState>" << std::endl;
+	// write simulation end time
+	resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
+		<< std::endl;
+	resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+	resultOut_ << "</SimState>" << std::endl;
 
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
-void Xml911Recorder::printParameters() {
-    
-}
+void Xml911Recorder::printParameters() { }

--- a/Simulator/Recorders/NG911/Xml911Recorder.h
+++ b/Simulator/Recorders/NG911/Xml911Recorder.h
@@ -14,41 +14,40 @@
 
 #include <fstream>
 
-#include "XmlRecorder.h"
 #include "Model.h"
+#include "XmlRecorder.h"
 
 class Xml911Recorder : public XmlRecorder {
-public:
-   /// The constructor and destructor
-   Xml911Recorder();
+	public:
+		/// The constructor and destructor
+		Xml911Recorder();
 
-   ~Xml911Recorder();
+		~Xml911Recorder() override;
 
-   static IRecorder* Create() { return new Xml911Recorder(); }
+		static IRecorder* Create() { return new Xml911Recorder(); }
 
-   /// Init radii and rates history matrices with default values
-   virtual void initDefaultValues() override;
+		/// Init radii and rates history matrices with default values
+		void initDefaultValues() override;
 
-   /// Init radii and rates history matrices with current radii and rates
-   virtual void initValues() override;
+		/// Init radii and rates history matrices with current radii and rates
+		void initValues() override;
 
-   /// Get the current radii and rates vlaues
-   virtual void getValues() override;
+		/// Get the current radii and rates vlaues
+		void getValues() override;
 
-   /// Compile history information in every epoch
-   ///
-   /// @param[in] vertices   The entire list of vertices.
-   virtual void compileHistories(AllVertices &vertices) override;
+		/// Compile history information in every epoch
+		///
+		/// @param[in] vertices   The entire list of vertices.
+		void compileHistories(AllVertices& vertices) override;
 
-   /// Writes simulation results to an output destination.
-   ///
-   /// @param  vertices the Vertex list to search from.
-   virtual void saveSimData(const AllVertices &vertices) override;
+		/// Writes simulation results to an output destination.
+		///
+		/// @param  vertices the Vertex list to search from.
+		void saveSimData(const AllVertices& vertices) override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() override;
 
-private:
+	private:
 };
-

--- a/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.h
+++ b/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.h
@@ -83,4 +83,3 @@ protected:
 };
 
 #endif // HDF5
-

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -15,9 +15,9 @@
 // TODO: We don't need the explicit call to the superclass constructor, right?
 //! The constructor and destructor
 XmlGrowthRecorder::XmlGrowthRecorder() :
-	ratesHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+	ratesHistory_(MATRIX_TYPE, MATRIX_INIT, Simulator::getInstance().getNumEpochs() + 1,
 	              Simulator::getInstance().getTotalVertices()),
-	radiiHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+	radiiHistory_(MATRIX_TYPE, MATRIX_INIT, Simulator::getInstance().getNumEpochs() + 1,
 	              Simulator::getInstance().getTotalVertices()) {}
 
 // TODO: Is this needed?
@@ -86,14 +86,19 @@ void XmlGrowthRecorder::compileHistories(AllVertices& neurons) {
 /// @param  neurons the Neuron list to search from.
 void XmlGrowthRecorder::saveSimData(const AllVertices& neurons) {
 	// create Neuron Types matrix
-	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
-	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) neuronTypes[i] = Simulator::getInstance().
-		getModel()->getLayout()->vertexTypeMap_[i];
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(),
+	                         static_cast<float>(vertexType::EXC));
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		neuronTypes[i] = static_cast<float>(Simulator::getInstance().
+		                                    getModel()->getLayout()->vertexTypeMap_[i]);
+	}
 
 	// create neuron threshold matrix
 	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), 0);
-	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const
-		AllIFNeurons&>(neurons).Vthresh_[i];
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		neuronThresh[i] = dynamic_cast<const
+			AllIFNeurons&>(neurons).Vthresh_[i];
+	}
 
 	// Write XML header information:
 	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -27,7 +27,7 @@ XmlGrowthRecorder::~XmlGrowthRecorder() {
 
 /// Init radii and rates history matrices with default values
 void XmlGrowthRecorder::initDefaultValues() {
-   shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
    BGFLOAT startRadius = dynamic_cast<ConnGrowth *>(conns.get())->growthParams_.startRadius;
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
@@ -38,7 +38,7 @@ void XmlGrowthRecorder::initDefaultValues() {
 
 /// Init radii and rates history matrices with current radii and rates
 void XmlGrowthRecorder::initValues() {
-   shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       radiiHistory_(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->radii_)[i];
@@ -62,7 +62,7 @@ void XmlGrowthRecorder::getValues() {
 void XmlGrowthRecorder::compileHistories(AllVertices &neurons) {
    XmlRecorder::compileHistories(neurons);
 
-   shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
 
    BGFLOAT minRadius = dynamic_cast<ConnGrowth *>(conns.get())->growthParams_.minRadius;
    VectorMatrix &rates = (*dynamic_cast<ConnGrowth *>(conns.get())->rates_);
@@ -107,47 +107,47 @@ void XmlGrowthRecorder::saveSimData(const AllVertices &neurons) {
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << radiiHistory_.toXML("radiiHistory") << endl;
-   resultOut_ << "   " << ratesHistory_.toXML("ratesHistory") << endl;
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
+   resultOut_ << "   " << radiiHistory_.toXML("radiiHistory") << std::endl;
+   resultOut_ << "   " << ratesHistory_.toXML("ratesHistory") << std::endl;
+   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
+   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
+   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
 
    // create starter neuron matrix
    int num_starter_neurons = static_cast<int>(Simulator::getInstance().getModel()->getLayout()->numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons, Simulator::getInstance().getModel()->getLayout()->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
+      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
    }
 
    // Write neuron thresold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << endl;
+   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
 
    // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
-   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << endl;
-   resultOut_ << "</Matrix>" << endl;
+   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
+   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
 
    // write simulation end time
    resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << endl;
-   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << endl;
-   resultOut_ << "</Matrix>" << endl;
-   resultOut_ << "</SimState>" << endl;
+             << std::endl;
+   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
+   resultOut_ << "</SimState>" << std::endl;
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void XmlGrowthRecorder::printParameters() {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << endl
-                                      << "\tResult file path: " << resultFileName_ << endl
-                                      << "\tBurstiness History Size: " << burstinessHist_.Size() << endl
-                                      << "\tSpikes History Size: " << spikesHistory_.Size() << endl
-                                      << "\n---XmlGrowthRecorder Parameters---" << endl
-                                      << "\tRecorder type: XmlGrowthRecorder" << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
+                                      << "\tResult file path: " << resultFileName_ << std::endl
+                                      << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
+                                      << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl
+                                      << "\n---XmlGrowthRecorder Parameters---" << std::endl
+                                      << "\tRecorder type: XmlGrowthRecorder" << std::endl);
 }
 
 ///  Get starter Neuron matrix.

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -7,159 +7,156 @@
  */
 
 #include "XmlGrowthRecorder.h"
-#include "Simulator.h"
-#include "Model.h"
 #include "AllIFNeurons.h"      // TODO: remove LIF model specific code
 #include "ConnGrowth.h"
+#include "Model.h"
+#include "Simulator.h"
 
 // TODO: We don't need the explicit call to the superclass constructor, right?
 //! The constructor and destructor
 XmlGrowthRecorder::XmlGrowthRecorder() :
-      ratesHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
-                    Simulator::getInstance().getTotalVertices()),
-      radiiHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
-                    Simulator::getInstance().getTotalVertices()) {
-}
+	ratesHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+	              Simulator::getInstance().getTotalVertices()),
+	radiiHistory_(MATRIX_TYPE, MATRIX_INIT, static_cast<int>(Simulator::getInstance().getNumEpochs() + 1),
+	              Simulator::getInstance().getTotalVertices()) {}
 
 // TODO: Is this needed?
-XmlGrowthRecorder::~XmlGrowthRecorder() {
-}
+XmlGrowthRecorder::~XmlGrowthRecorder() {}
 
 /// Init radii and rates history matrices with default values
 void XmlGrowthRecorder::initDefaultValues() {
-   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
-   BGFLOAT startRadius = dynamic_cast<ConnGrowth *>(conns.get())->growthParams_.startRadius;
+	std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+	BGFLOAT startRadius = dynamic_cast<ConnGrowth*>(conns.get())->growthParams_.startRadius;
 
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      radiiHistory_(0, i) = startRadius;
-      ratesHistory_(0, i) = 0;
-   }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		radiiHistory_(0, i) = startRadius;
+		ratesHistory_(0, i) = 0;
+	}
 }
 
 /// Init radii and rates history matrices with current radii and rates
 void XmlGrowthRecorder::initValues() {
-   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+	std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
 
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      radiiHistory_(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->radii_)[i];
-      ratesHistory_(0, i) = (*dynamic_cast<ConnGrowth *>(conns.get())->rates_)[i];
-   }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		radiiHistory_(0, i) = (*dynamic_cast<ConnGrowth*>(conns.get())->radii_)[i];
+		ratesHistory_(0, i) = (*dynamic_cast<ConnGrowth*>(conns.get())->rates_)[i];
+	}
 }
 
 /// Get the current radii and rates values
 void XmlGrowthRecorder::getValues() {
-   Connections *conns = Simulator::getInstance().getModel()->getConnections().get();
+	Connections* conns = Simulator::getInstance().getModel()->getConnections().get();
 
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      (*dynamic_cast<ConnGrowth *>(conns)->radii_)[i] = radiiHistory_(Simulator::getInstance().getCurrentStep(), i);
-      (*dynamic_cast<ConnGrowth *>(conns)->rates_)[i] = ratesHistory_(Simulator::getInstance().getCurrentStep(), i);
-   }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		(*dynamic_cast<ConnGrowth*>(conns)->radii_)[i] = radiiHistory_(Simulator::getInstance().getCurrentStep(), i);
+		(*dynamic_cast<ConnGrowth*>(conns)->rates_)[i] = ratesHistory_(Simulator::getInstance().getCurrentStep(), i);
+	}
 }
 
 /// Compile history information in every epoch
 ///
 /// @param[in] neurons 	The entire list of neurons.
-void XmlGrowthRecorder::compileHistories(AllVertices &neurons) {
-   XmlRecorder::compileHistories(neurons);
+void XmlGrowthRecorder::compileHistories(AllVertices& neurons) {
+	XmlRecorder::compileHistories(neurons);
 
-   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+	std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
 
-   BGFLOAT minRadius = dynamic_cast<ConnGrowth *>(conns.get())->growthParams_.minRadius;
-   VectorMatrix &rates = (*dynamic_cast<ConnGrowth *>(conns.get())->rates_);
-   VectorMatrix &radii = (*dynamic_cast<ConnGrowth *>(conns.get())->radii_);
+	BGFLOAT minRadius = dynamic_cast<ConnGrowth*>(conns.get())->growthParams_.minRadius;
+	VectorMatrix& rates = (*dynamic_cast<ConnGrowth*>(conns.get())->rates_);
+	VectorMatrix& radii = (*dynamic_cast<ConnGrowth*>(conns.get())->radii_);
 
-   for (int iVertex = 0; iVertex < Simulator::getInstance().getTotalVertices(); iVertex++) {
-      // record firing rate to history matrix
-      ratesHistory_(Simulator::getInstance().getCurrentStep(), iVertex) = rates[iVertex];
+	for (int iVertex = 0; iVertex < Simulator::getInstance().getTotalVertices(); iVertex++) {
+		// record firing rate to history matrix
+		ratesHistory_(Simulator::getInstance().getCurrentStep(), iVertex) = rates[iVertex];
 
-      // Cap minimum radius size and record radii to history matrix
-      // TODO: find out why we cap this here.
-      // TODO: agreed; seems like this should be capped elsewhere.
-      if (radii[iVertex] < minRadius)
-         radii[iVertex] = minRadius;
+		// Cap minimum radius size and record radii to history matrix
+		// TODO: find out why we cap this here.
+		// TODO: agreed; seems like this should be capped elsewhere.
+		if (radii[iVertex] < minRadius) radii[iVertex] = minRadius;
 
-      // record radius to history matrix
-      radiiHistory_(Simulator::getInstance().getCurrentStep(), iVertex) = radii[iVertex];
-   }
+		// record radius to history matrix
+		radiiHistory_(Simulator::getInstance().getCurrentStep(), iVertex) = radii[iVertex];
+	}
 }
 
 
 /// Writes simulation results to an output destination.
 ///
 /// @param  neurons the Neuron list to search from.
-void XmlGrowthRecorder::saveSimData(const AllVertices &neurons) {
-   // create Neuron Types matrix
-   VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      neuronTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
-   }
+void XmlGrowthRecorder::saveSimData(const AllVertices& neurons) {
+	// create Neuron Types matrix
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), EXC);
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) neuronTypes[i] = Simulator::getInstance().
+		getModel()->getLayout()->vertexTypeMap_[i];
 
-   // create neuron threshold matrix
-   VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), 0);
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      neuronThresh[i] = dynamic_cast<const AllIFNeurons &>(neurons).Vthresh_[i];
-   }
+	// create neuron threshold matrix
+	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(), 0);
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const
+		AllIFNeurons&>(neurons).Vthresh_[i];
 
-   // Write XML header information:
-   resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
-             << "<!-- State output file for the DCT growth modeling-->\n";
-   //stateOut << version; TODO: version
+	// Write XML header information:
+	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
+		<< "<!-- State output file for the DCT growth modeling-->\n";
+	//stateOut << version; TODO: version
 
-   // Write the core state information:
-   resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << radiiHistory_.toXML("radiiHistory") << std::endl;
-   resultOut_ << "   " << ratesHistory_.toXML("ratesHistory") << std::endl;
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
+	// Write the core state information:
+	resultOut_ << "<SimState>\n";
+	resultOut_ << "   " << radiiHistory_.toXML("radiiHistory") << std::endl;
+	resultOut_ << "   " << ratesHistory_.toXML("ratesHistory") << std::endl;
+	resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+	resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+	resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
+	resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
+	resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
 
-   // create starter neuron matrix
-   int num_starter_neurons = static_cast<int>(Simulator::getInstance().getModel()->getLayout()->numEndogenouslyActiveNeurons_);
-   if (num_starter_neurons > 0) {
-      VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, Simulator::getInstance().getModel()->getLayout()->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
-   }
+	// create starter neuron matrix
+	int num_starter_neurons = static_cast<int>(Simulator::getInstance().getModel()->getLayout()->
+	                                                                    numEndogenouslyActiveNeurons_);
+	if (num_starter_neurons > 0) {
+		VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
+		getStarterNeuronMatrix(starterNeurons, Simulator::getInstance().getModel()->getLayout()->starterMap_);
+		resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
+	}
 
-   // Write neuron thresold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
+	// Write neuron thresold
+	resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
 
-   // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
-   resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
+	// write time between growth cycles
+	resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" <<
+		std::endl;
+	resultOut_ << "   " << Simulator::getInstance().getEpochDuration() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
 
-   // write simulation end time
-   resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << std::endl;
-   resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
-   resultOut_ << "</SimState>" << std::endl;
+	// write simulation end time
+	resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
+		<< std::endl;
+	resultOut_ << "   " << g_simulationStep * Simulator::getInstance().getDeltaT() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+	resultOut_ << "</SimState>" << std::endl;
 }
 
 ///  Prints out all parameters to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void XmlGrowthRecorder::printParameters() {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
-                                      << "\tResult file path: " << resultFileName_ << std::endl
-                                      << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
-                                      << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl
-                                      << "\n---XmlGrowthRecorder Parameters---" << std::endl
-                                      << "\tRecorder type: XmlGrowthRecorder" << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
+	                << "\tResult file path: " << resultFileName_ << std::endl
+	                << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
+	                << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl
+	                << "\n---XmlGrowthRecorder Parameters---" << std::endl
+	                << "\tRecorder type: XmlGrowthRecorder" << std::endl);
 }
 
 ///  Get starter Neuron matrix.
 ///
 ///  @param  matrix      Starter Neuron matrix.
 ///  @param  starterMap Bool map to reference neuron matrix location from.
-void XmlGrowthRecorder::getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starterMap) {
-   int cur = 0;
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      if (starterMap[i]) {
-         matrix[cur] = i;
-         cur++;
-      }
-   }
+void XmlGrowthRecorder::getStarterNeuronMatrix(VectorMatrix& matrix, const bool* starterMap) {
+	int cur = 0;
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		if (starterMap[i]) {
+			matrix[cur] = i;
+			cur++;
+		}
+	}
 }

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.h
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.h
@@ -19,51 +19,49 @@
 
 #include <fstream>
 
-#include "XmlRecorder.h"
 #include "Model.h"
+#include "XmlRecorder.h"
 
 class XmlGrowthRecorder : public XmlRecorder {
-public:
-   /// THe constructor and destructor
-   XmlGrowthRecorder();
+	public:
+		/// THe constructor and destructor
+		XmlGrowthRecorder();
 
-   ~XmlGrowthRecorder();
+		~XmlGrowthRecorder() override;
 
-   static IRecorder* Create() { return new XmlGrowthRecorder(); }
+		static IRecorder* Create() { return new XmlGrowthRecorder(); }
 
-   /// Init radii and rates history matrices with default values
-   virtual void initDefaultValues() override;
+		/// Init radii and rates history matrices with default values
+		void initDefaultValues() override;
 
-   /// Init radii and rates history matrices with current radii and rates
-   virtual void initValues() override;
+		/// Init radii and rates history matrices with current radii and rates
+		void initValues() override;
 
-   /// Get the current radii and rates vlaues
-   virtual void getValues() override;
+		/// Get the current radii and rates vlaues
+		void getValues() override;
 
-   /// Compile history information in every epoch
-   ///
-   /// @param[in] neurons   The entire list of neurons.
-   virtual void compileHistories(AllVertices &neurons) override;
+		/// Compile history information in every epoch
+		///
+		/// @param[in] neurons   The entire list of neurons.
+		void compileHistories(AllVertices& neurons) override;
 
-   /// Writes simulation results to an output destination.
-   ///
-   /// @param  neurons the Neuron list to search from.
-   virtual void saveSimData(const AllVertices &neurons) override;
+		/// Writes simulation results to an output destination.
+		///
+		/// @param  neurons the Neuron list to search from.
+		void saveSimData(const AllVertices& neurons) override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() override;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() override;
 
-private:
-   
-   // TODO: There seems to be multiple copies of this in different classes...
-   void getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starterMap);
+	private:
+		// TODO: There seems to be multiple copies of this in different classes...
+		void getStarterNeuronMatrix(VectorMatrix& matrix, const bool* starterMap);
 
-   // track firing rate
-   CompleteMatrix ratesHistory_;
+		// track firing rate
+		CompleteMatrix ratesHistory_;
 
-   // track radii
-   CompleteMatrix radiiHistory_;
+		// track radii
+		CompleteMatrix radiiHistory_;
 
 };
-

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -1,4 +1,4 @@
- /*
+/*
  *      @file XmlSTDPRecorder.cpp
  *      @brief An implementation for recording weights of synapses for STDP on xml file
  *      @author Snigdha Singh
@@ -7,197 +7,181 @@
 
 
 #include "XmlSTDPRecorder.h"
-#include "Simulator.h"
-#include "Model.h"
+#include <vector>
 #include "AllIFNeurons.h"      // TODO: remove LIF model specific code
 #include "ConnStatic.h"
-#include <vector>
+#include "Model.h"
+#include "Simulator.h"
 
 // TODO: We don't need to explicitly call the superclass constructor, right?
 //! The constructor and destructor
 XmlSTDPRecorder::XmlSTDPRecorder() :
-XmlRecorder()
-{
-   const int numEpochs = Simulator::getInstance().getNumEpochs();
-   const int totalNeurons = Simulator::getInstance().getTotalVertices();
-   const int maxSynapsesPerNeuron = Simulator::getInstance().getMaxEdgesPerVertex();
-   
-   weightsHistory_.resize(numEpochs + 1,
-      std::vector<BGFLOAT> (totalNeurons*maxSynapsesPerNeuron,0));
-   
-   sourceNeuronIndexHistory_.resize(numEpochs + 1,
-      std::vector<int> (totalNeurons*maxSynapsesPerNeuron));
+	XmlRecorder() {
+	const int numEpochs = Simulator::getInstance().getNumEpochs();
+	const int totalNeurons = Simulator::getInstance().getTotalVertices();
+	const int maxSynapsesPerNeuron = Simulator::getInstance().getMaxEdgesPerVertex();
 
-   destNeuronIndexHistory_.resize(numEpochs + 1 ,
-      std::vector<int> (totalNeurons*maxSynapsesPerNeuron));
+	weightsHistory_.resize(numEpochs + 1,
+	                       std::vector<BGFLOAT>(totalNeurons * maxSynapsesPerNeuron, 0));
+
+	sourceNeuronIndexHistory_.resize(numEpochs + 1,
+	                                 std::vector<int>(totalNeurons * maxSynapsesPerNeuron));
+
+	destNeuronIndexHistory_.resize(numEpochs + 1,
+	                               std::vector<int>(totalNeurons * maxSynapsesPerNeuron));
 }
 
-XmlSTDPRecorder::~XmlSTDPRecorder() {
-}
+XmlSTDPRecorder::~XmlSTDPRecorder() {}
 
 ///Init radii and rates history matrices with default values
 void XmlSTDPRecorder::initDefaultValues() {
-   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
-  //AllNeuroEdges *synapses synapses)->W_[iSyn]
-   BGFLOAT startRadius = dynamic_cast<ConnStatic *>(conns.get())->getConnsRadiusThresh();
+	std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+	//AllNeuroEdges *synapses synapses)->W_[iSyn]
+	BGFLOAT startRadius = dynamic_cast<ConnStatic*>(conns.get())->getConnsRadiusThresh();
 
 
 }
 
 ///InitValues gets the values for weights, source index and dest index at the time of simulation start
 void XmlSTDPRecorder::initValues() {
-   Connections *conns = Simulator::getInstance().getModel()->getConnections().get();
+	Connections* conns = Simulator::getInstance().getModel()->getConnections().get();
 
 
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices()*Simulator::getInstance().getMaxEdgesPerVertex(); i++) {
-      weightsHistory_[0][i] = (dynamic_cast<ConnStatic *>(conns)->getWCurrentEpoch())[i];
-      sourceNeuronIndexHistory_[0][i] = (dynamic_cast<ConnStatic *>(conns)->getSourceVertexIndexCurrentEpoch())[i];
-      destNeuronIndexHistory_[0][i] = (dynamic_cast<ConnStatic *>(conns)->getDestVertexIndexCurrentEpoch())[i];
-      
-   }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices() * Simulator::getInstance().getMaxEdgesPerVertex(); i
+	     ++) {
+		weightsHistory_[0][i] = (dynamic_cast<ConnStatic*>(conns)->getWCurrentEpoch())[i];
+		sourceNeuronIndexHistory_[0][i] = (dynamic_cast<ConnStatic*>(conns)->getSourceVertexIndexCurrentEpoch())[i];
+		destNeuronIndexHistory_[0][i] = (dynamic_cast<ConnStatic*>(conns)->getDestVertexIndexCurrentEpoch())[i];
+	}
 }
 
 /// Get the current synapse weight information
 void XmlSTDPRecorder::getValues() {
-   Simulator &simulator = Simulator::getInstance();
-   std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
-   AllEdges &synapses =(*connections->getEdges());
-   const int currentStep = simulator.getCurrentStep();
+	Simulator& simulator = Simulator::getInstance();
+	std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
+	AllEdges& synapses = (*connections->getEdges());
+	const int currentStep = simulator.getCurrentStep();
 
-   for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      synapses.W_[i] = weightsHistory_[currentStep][i];
-      synapses.sourceVertexIndex_[i] = sourceNeuronIndexHistory_[currentStep][i];
-      synapses.destVertexIndex_[i] = destNeuronIndexHistory_[currentStep][i];
-   }
+	for (int i = 0; i < simulator.getTotalVertices(); i++) {
+		synapses.W_[i] = weightsHistory_[currentStep][i];
+		synapses.sourceVertexIndex_[i] = sourceNeuronIndexHistory_[currentStep][i];
+		synapses.destVertexIndex_[i] = destNeuronIndexHistory_[currentStep][i];
+	}
 }
 
 /// Compile history information in every epoch
 ///
 /// @param[in] neurons 	The entire list of neurons.
-void XmlSTDPRecorder::compileHistories(AllVertices &neurons) {
-   LOG4CPLUS_INFO(fileLogger_, "Compiling STDP HISTORY");
-   XmlRecorder::compileHistories(neurons);
-   Simulator &simulator = Simulator::getInstance();
-   std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
-   AllEdges &synapses =(*connections->getEdges());
-   const int currentStep = simulator.getCurrentStep();
+void XmlSTDPRecorder::compileHistories(AllVertices& neurons) {
+	LOG4CPLUS_INFO(fileLogger_, "Compiling STDP HISTORY");
+	XmlRecorder::compileHistories(neurons);
+	Simulator& simulator = Simulator::getInstance();
+	std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
+	AllEdges& synapses = (*connections->getEdges());
+	const int currentStep = simulator.getCurrentStep();
 
-   for (int iNeuron = 0; iNeuron < simulator.getTotalVertices()*simulator.getMaxEdgesPerVertex(); iNeuron++) {
-      // record firing rate to history matrix
-      weightsHistory_[currentStep][iNeuron]= synapses.W_[iNeuron];
-      sourceNeuronIndexHistory_[currentStep][iNeuron]= synapses.sourceVertexIndex_[iNeuron];
-      destNeuronIndexHistory_[currentStep][iNeuron]= synapses.destVertexIndex_[iNeuron];
-   }
-   LOG4CPLUS_INFO(fileLogger_, "Finished Compiling STDP HISTORY");
-}
-
-/// convert Matrix to XML std::string
-std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<BGFLOAT>> MatrixToWrite) const
-{
-    std::stringstream os;
-    
-    os << "<Matrix ";
-    if (name != "")
-        os << "name=\"" << name << "\" ";
-    os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
-    << "\" columns=\"" << MatrixToWrite[0].size()
-    << "\" multiplier=\"1.0\">" << std::endl;
-    for (int i = 0; i < MatrixToWrite.size(); i++)
-{
-    for (int j = 0; j < MatrixToWrite[i].size(); j++)
-    {
-        os << MatrixToWrite[i][j]<< " ";
-    }
-     os<<std::endl;
-}
-os <<std::endl;
-    os << "</Matrix>";
-    
-    return os.str();
+	for (int iNeuron = 0; iNeuron < simulator.getTotalVertices() * simulator.getMaxEdgesPerVertex(); iNeuron++) {
+		// record firing rate to history matrix
+		weightsHistory_[currentStep][iNeuron] = synapses.W_[iNeuron];
+		sourceNeuronIndexHistory_[currentStep][iNeuron] = synapses.sourceVertexIndex_[iNeuron];
+		destNeuronIndexHistory_[currentStep][iNeuron] = synapses.destVertexIndex_[iNeuron];
+	}
+	LOG4CPLUS_INFO(fileLogger_, "Finished Compiling STDP HISTORY");
 }
 
 /// convert Matrix to XML std::string
-std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<int>> MatrixToWrite) const
-{
-    std::stringstream os;
-    
-    os << "<Matrix ";
-    if (name != "")
-        os << "name=\"" << name << "\" ";
-    os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
-    << "\" columns=\"" << MatrixToWrite[0].size()
-    << "\" multiplier=\"1.0\">" << std::endl;
-    for (int i = 0; i < MatrixToWrite.size(); i++)
-{
-    for (int j = 0; j < MatrixToWrite[i].size(); j++)
-    {
-        os << MatrixToWrite[i][j]<<" ";
-    }
-    os<<std::endl;
+std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<BGFLOAT>> MatrixToWrite) const {
+	std::stringstream os;
+
+	os << "<Matrix ";
+	if (name != "") os << "name=\"" << name << "\" ";
+	os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
+		<< "\" columns=\"" << MatrixToWrite[0].size()
+		<< "\" multiplier=\"1.0\">" << std::endl;
+	for (int i = 0; i < MatrixToWrite.size(); i++) {
+		for (int j = 0; j < MatrixToWrite[i].size(); j++) os << MatrixToWrite[i][j] << " ";
+		os << std::endl;
+	}
+	os << std::endl;
+	os << "</Matrix>";
+
+	return os.str();
 }
-   os <<std::endl;
-    os << "</Matrix>";
-    
-    return os.str();
+
+/// convert Matrix to XML std::string
+std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<int>> MatrixToWrite) const {
+	std::stringstream os;
+
+	os << "<Matrix ";
+	if (name != "") os << "name=\"" << name << "\" ";
+	os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
+		<< "\" columns=\"" << MatrixToWrite[0].size()
+		<< "\" multiplier=\"1.0\">" << std::endl;
+	for (int i = 0; i < MatrixToWrite.size(); i++) {
+		for (int j = 0; j < MatrixToWrite[i].size(); j++) os << MatrixToWrite[i][j] << " ";
+		os << std::endl;
+	}
+	os << std::endl;
+	os << "</Matrix>";
+
+	return os.str();
 }
 
 /// Writes simulation results to an output destination.
 ///
 /// @param  neurons the Neuron list to search from.
-void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
-{
-   Simulator &simulator = Simulator::getInstance();
-   
-   // create Neuron Types matrix
-   VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
-   for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout()->vertexTypeMap_[i];
-   }
+void XmlSTDPRecorder::saveSimData(const AllVertices& neurons) {
+	Simulator& simulator = Simulator::getInstance();
 
-   // create neuron threshold matrix
-   VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
-   for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronThresh[i] = dynamic_cast<const AllIFNeurons &>(neurons).Vthresh_[i];
-   }
+	// create Neuron Types matrix
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
+	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronTypes[i] = simulator.getModel()->getLayout()->
+		vertexTypeMap_[i];
 
-   // Write XML header information:
-   resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
-             << "<!-- State output file for the DCT growth modeling-->\n";
-   //stateOut << version; TODO: version
+	// create neuron threshold matrix
+	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
+	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(neurons).
+		Vthresh_[i];
 
-   // Write the core state information:
-   resultOut_ << "<SimState>\n";
-   resultOut_ << "   " <<toXML("sourceNeuronIndexHistory",sourceNeuronIndexHistory_) << std::endl;
-   resultOut_ << "   " << toXML("destNeuronIndexHistory",destNeuronIndexHistory_) << std::endl;
-   resultOut_ << "   " <<toXML("weightsHistory",weightsHistory_) << std::endl;
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
+	// Write XML header information:
+	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
+		<< "<!-- State output file for the DCT growth modeling-->\n";
+	//stateOut << version; TODO: version
 
-   // create starter neuron matrix
-   int num_starter_neurons = static_cast<int>(simulator.getModel()->getLayout()->numEndogenouslyActiveNeurons_);
-   if (num_starter_neurons > 0) {
-      VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout()->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
-   }
+	// Write the core state information:
+	resultOut_ << "<SimState>\n";
+	resultOut_ << "   " << toXML("sourceNeuronIndexHistory", sourceNeuronIndexHistory_) << std::endl;
+	resultOut_ << "   " << toXML("destNeuronIndexHistory", destNeuronIndexHistory_) << std::endl;
+	resultOut_ << "   " << toXML("weightsHistory", weightsHistory_) << std::endl;
+	resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+	resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+	resultOut_ << "   " << simulator.getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
+	resultOut_ << "   " << simulator.getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
+	resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
 
-   // Write neuron thresold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
+	// create starter neuron matrix
+	int num_starter_neurons = static_cast<int>(simulator.getModel()->getLayout()->numEndogenouslyActiveNeurons_);
+	if (num_starter_neurons > 0) {
+		VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
+		getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout()->starterMap_);
+		resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
+	}
 
-   // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
-   resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
+	// Write neuron thresold
+	resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
 
-   // write simulation end time
-   resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << std::endl;
-   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
-   resultOut_ << "</SimState>" << std::endl;
+	// write time between growth cycles
+	resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" <<
+		std::endl;
+	resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+
+	// write simulation end time
+	resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
+		<< std::endl;
+	resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+	resultOut_ << "</SimState>" << std::endl;
 }
 
 /**
@@ -205,9 +189,8 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
  *  Registered to OperationManager as Operation::printParameters
  */
 void XmlSTDPRecorder::printParameters() {
-   XmlRecorder::printParameters();
+	XmlRecorder::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n---XmlSTDPRecorder Parameters---" << std::endl
-                                      << "\tRecorder type: XmlSTDPRecorder" << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\n---XmlSTDPRecorder Parameters---" << std::endl
+	                << "\tRecorder type: XmlSTDPRecorder" << std::endl);
 }
-

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -134,14 +134,19 @@ void XmlSTDPRecorder::saveSimData(const AllVertices& neurons) {
 	Simulator& simulator = Simulator::getInstance();
 
 	// create Neuron Types matrix
-	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
-	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronTypes[i] = simulator.getModel()->getLayout()->
-		vertexTypeMap_[i];
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(),
+	                         static_cast<float>(vertexType::EXC));
+	for (int i = 0; i < simulator.getTotalVertices(); i++) {
+		neuronTypes[i] = static_cast<float>(simulator.getModel()->getLayout()->
+		                                              vertexTypeMap_[i]);
+	}
 
 	// create neuron threshold matrix
 	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
-	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(neurons).
-		Vthresh_[i];
+	for (int i = 0; i < simulator.getTotalVertices(); i++) {
+		neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(neurons).
+			Vthresh_[i];
+	}
 
 	// Write XML header information:
 	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -23,13 +23,13 @@ XmlRecorder()
    const int maxSynapsesPerNeuron = Simulator::getInstance().getMaxEdgesPerVertex();
    
    weightsHistory_.resize(numEpochs + 1,
-      vector<BGFLOAT> (totalNeurons*maxSynapsesPerNeuron,0));
+      std::vector<BGFLOAT> (totalNeurons*maxSynapsesPerNeuron,0));
    
    sourceNeuronIndexHistory_.resize(numEpochs + 1,
-      vector<int> (totalNeurons*maxSynapsesPerNeuron));
+      std::vector<int> (totalNeurons*maxSynapsesPerNeuron));
 
    destNeuronIndexHistory_.resize(numEpochs + 1 ,
-      vector<int> (totalNeurons*maxSynapsesPerNeuron));
+      std::vector<int> (totalNeurons*maxSynapsesPerNeuron));
 }
 
 XmlSTDPRecorder::~XmlSTDPRecorder() {
@@ -37,7 +37,7 @@ XmlSTDPRecorder::~XmlSTDPRecorder() {
 
 ///Init radii and rates history matrices with default values
 void XmlSTDPRecorder::initDefaultValues() {
-   shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
+   std::shared_ptr<Connections> conns = Simulator::getInstance().getModel()->getConnections();
   //AllNeuroEdges *synapses synapses)->W_[iSyn]
    BGFLOAT startRadius = dynamic_cast<ConnStatic *>(conns.get())->getConnsRadiusThresh();
 
@@ -60,7 +60,7 @@ void XmlSTDPRecorder::initValues() {
 /// Get the current synapse weight information
 void XmlSTDPRecorder::getValues() {
    Simulator &simulator = Simulator::getInstance();
-   shared_ptr<Connections> connections = simulator.getModel()->getConnections();
+   std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
    AllEdges &synapses =(*connections->getEdges());
    const int currentStep = simulator.getCurrentStep();
 
@@ -78,7 +78,7 @@ void XmlSTDPRecorder::compileHistories(AllVertices &neurons) {
    LOG4CPLUS_INFO(fileLogger_, "Compiling STDP HISTORY");
    XmlRecorder::compileHistories(neurons);
    Simulator &simulator = Simulator::getInstance();
-   shared_ptr<Connections> connections = simulator.getModel()->getConnections();
+   std::shared_ptr<Connections> connections = simulator.getModel()->getConnections();
    AllEdges &synapses =(*connections->getEdges());
    const int currentStep = simulator.getCurrentStep();
 
@@ -91,51 +91,51 @@ void XmlSTDPRecorder::compileHistories(AllVertices &neurons) {
    LOG4CPLUS_INFO(fileLogger_, "Finished Compiling STDP HISTORY");
 }
 
-/// convert Matrix to XML string
-string XmlSTDPRecorder::toXML(string name, vector<vector<BGFLOAT>> MatrixToWrite) const
+/// convert Matrix to XML std::string
+std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<BGFLOAT>> MatrixToWrite) const
 {
-    stringstream os;
+    std::stringstream os;
     
     os << "<Matrix ";
     if (name != "")
         os << "name=\"" << name << "\" ";
     os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
     << "\" columns=\"" << MatrixToWrite[0].size()
-    << "\" multiplier=\"1.0\">" << endl;
+    << "\" multiplier=\"1.0\">" << std::endl;
     for (int i = 0; i < MatrixToWrite.size(); i++)
 {
     for (int j = 0; j < MatrixToWrite[i].size(); j++)
     {
         os << MatrixToWrite[i][j]<< " ";
     }
-     os<<endl;
+     os<<std::endl;
 }
-os <<endl;
+os <<std::endl;
     os << "</Matrix>";
     
     return os.str();
 }
 
-/// convert Matrix to XML string
-string XmlSTDPRecorder::toXML(string name, vector<vector<int>> MatrixToWrite) const
+/// convert Matrix to XML std::string
+std::string XmlSTDPRecorder::toXML(std::string name, std::vector<std::vector<int>> MatrixToWrite) const
 {
-    stringstream os;
+    std::stringstream os;
     
     os << "<Matrix ";
     if (name != "")
         os << "name=\"" << name << "\" ";
     os << "type=\"complete\" rows=\"" << MatrixToWrite.size()
     << "\" columns=\"" << MatrixToWrite[0].size()
-    << "\" multiplier=\"1.0\">" << endl;
+    << "\" multiplier=\"1.0\">" << std::endl;
     for (int i = 0; i < MatrixToWrite.size(); i++)
 {
     for (int j = 0; j < MatrixToWrite[i].size(); j++)
     {
         os << MatrixToWrite[i][j]<<" ";
     }
-    os<<endl;
+    os<<std::endl;
 }
-   os <<endl;
+   os <<std::endl;
     os << "</Matrix>";
     
     return os.str();
@@ -167,37 +167,37 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";
-   resultOut_ << "   " <<toXML("sourceNeuronIndexHistory",sourceNeuronIndexHistory_) << endl;
-   resultOut_ << "   " << toXML("destNeuronIndexHistory",destNeuronIndexHistory_) << endl;
-   resultOut_ << "   " <<toXML("weightsHistory",weightsHistory_) << endl;
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->xloc_->toXML("xloc") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->yloc_->toXML("yloc") << endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
+   resultOut_ << "   " <<toXML("sourceNeuronIndexHistory",sourceNeuronIndexHistory_) << std::endl;
+   resultOut_ << "   " << toXML("destNeuronIndexHistory",destNeuronIndexHistory_) << std::endl;
+   resultOut_ << "   " <<toXML("weightsHistory",weightsHistory_) << std::endl;
+   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+   resultOut_ << "   " << simulator.getModel()->getLayout()->xloc_->toXML("xloc") << std::endl;
+   resultOut_ << "   " << simulator.getModel()->getLayout()->yloc_->toXML("yloc") << std::endl;
+   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
 
    // create starter neuron matrix
    int num_starter_neurons = static_cast<int>(simulator.getModel()->getLayout()->numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout()->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
+      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
    }
 
    // Write neuron thresold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << endl;
+   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
 
    // write time between growth cycles
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
-   resultOut_ << "   " << simulator.getEpochDuration() << endl;
-   resultOut_ << "</Matrix>" << endl;
+   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
+   resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
 
    // write simulation end time
    resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-             << endl;
-   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << endl;
-   resultOut_ << "</Matrix>" << endl;
-   resultOut_ << "</SimState>" << endl;
+             << std::endl;
+   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
+   resultOut_ << "</SimState>" << std::endl;
 }
 
 /**
@@ -207,7 +207,7 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
 void XmlSTDPRecorder::printParameters() {
    XmlRecorder::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n---XmlSTDPRecorder Parameters---" << endl
-                                      << "\tRecorder type: XmlSTDPRecorder" << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\n---XmlSTDPRecorder Parameters---" << std::endl
+                                      << "\tRecorder type: XmlSTDPRecorder" << std::endl);
 }
 

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.h
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.h
@@ -34,60 +34,59 @@
 
 #include <fstream>
 
-#include "XmlRecorder.h"
 #include "Model.h"
+#include "XmlRecorder.h"
 
 class XmlSTDPRecorder : public XmlRecorder {
-public:
-   //! THe constructor and destructor
-   XmlSTDPRecorder();
+	public:
+		//! THe constructor and destructor
+		XmlSTDPRecorder();
 
-   ~XmlSTDPRecorder();
+		~XmlSTDPRecorder() override;
 
-   static IRecorder* Create() { return new XmlSTDPRecorder(); }
+		static IRecorder* Create() { return new XmlSTDPRecorder(); }
 
-   /**
-    * Init radii and rates history matrices with default values
-    */
-   virtual void initDefaultValues();
+		/**
+		 * Init radii and rates history matrices with default values
+		 */
+		void initDefaultValues() override;
 
-   /**
-    * Init radii and rates history matrices with current radii and rates
-    */
-   virtual void initValues();
+		/**
+		 * Init radii and rates history matrices with current radii and rates
+		 */
+		void initValues() override;
 
-   /**
-    * Get the current radii and rates vlaues
-    */
-   virtual void getValues();
+		/**
+		 * Get the current radii and rates vlaues
+		 */
+		void getValues() override;
 
-   /**
-    * Compile history information in every epoch
-    *
-    * @param[in] neurons   The entire list of neurons.
-    */
-   virtual void compileHistories(AllVertices &neurons);
+		/**
+		 * Compile history information in every epoch
+		 *
+		 * @param[in] neurons   The entire list of neurons.
+		 */
+		void compileHistories(AllVertices& neurons) override;
 
-   /**
-    * Writes simulation results to an output destination.
-    *
-    * @param  neurons the Neuron list to search from.
-    **/
-   virtual void saveSimData(const AllVertices &neurons);
+		/**
+		 * Writes simulation results to an output destination.
+		 *
+		 * @param  neurons the Neuron list to search from.
+		 **/
+		void saveSimData(const AllVertices& neurons) override;
 
-   /**
-    *  Prints out all parameters to logging file.
-    *  Registered to OperationManager as Operation::printParameters
-    */
-   virtual void printParameters();
+		/**
+		 *  Prints out all parameters to logging file.
+		 *  Registered to OperationManager as Operation::printParameters
+		 */
+		void printParameters() override;
 
-   virtual std::string toXML(std::string name,std::vector<std::vector<BGFLOAT>> MatrixToWrite ) const;
-   virtual std::string toXML(std::string name,std::vector<std::vector<int>> MatrixToWrite) const;
+		virtual std::string toXML(std::string name, std::vector<std::vector<BGFLOAT>> MatrixToWrite) const;
+		virtual std::string toXML(std::string name, std::vector<std::vector<int>> MatrixToWrite) const;
 
-protected:
-   std::vector<std::vector<BGFLOAT>> weightsHistory_;
-   std::vector<std::vector<int>> sourceNeuronIndexHistory_;
-   std::vector<std::vector<int>>  destNeuronIndexHistory_;
+	protected:
+		std::vector<std::vector<BGFLOAT>> weightsHistory_;
+		std::vector<std::vector<int>> sourceNeuronIndexHistory_;
+		std::vector<std::vector<int>> destNeuronIndexHistory_;
 
 };
-

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.h
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.h
@@ -81,13 +81,13 @@ public:
     */
    virtual void printParameters();
 
-   virtual string toXML(string name,vector<vector<BGFLOAT>> MatrixToWrite ) const;
-   virtual string toXML(string name,vector<vector<int>> MatrixToWrite) const;
+   virtual std::string toXML(std::string name,std::vector<std::vector<BGFLOAT>> MatrixToWrite ) const;
+   virtual std::string toXML(std::string name,std::vector<std::vector<int>> MatrixToWrite) const;
 
 protected:
-   vector<vector<BGFLOAT>> weightsHistory_;
-   vector<vector<int>> sourceNeuronIndexHistory_;
-   vector<vector<int>>  destNeuronIndexHistory_;
+   std::vector<std::vector<BGFLOAT>> weightsHistory_;
+   std::vector<std::vector<int>> sourceNeuronIndexHistory_;
+   std::vector<std::vector<int>>  destNeuronIndexHistory_;
 
 };
 

--- a/Simulator/Recorders/RecorderFactory.cpp
+++ b/Simulator/Recorders/RecorderFactory.cpp
@@ -8,18 +8,18 @@
 
 #include "RecorderFactory.h"
 
-#include "XmlSTDPRecorder.h"
-#include "XmlGrowthRecorder.h"
-#include "Xml911Recorder.h"
 #include "Hdf5GrowthRecorder.h"
+#include "Xml911Recorder.h"
+#include "XmlGrowthRecorder.h"
+#include "XmlSTDPRecorder.h"
 
 /// Constructor is private to keep a singleton instance of this class.
 RecorderFactory::RecorderFactory() {
-   // register recorder classes
-   registerClass("XmlRecorder", &XmlRecorder::Create);
-   registerClass("XmlGrowthRecorder", &XmlGrowthRecorder::Create);
-   registerClass("XmlSTDPRecorder", &XmlSTDPRecorder::Create);
-   registerClass("Xml911Recorder", &Xml911Recorder::Create);
+	// register recorder classes
+	registerClass("XmlRecorder", &XmlRecorder::Create);
+	registerClass("XmlGrowthRecorder", &XmlGrowthRecorder::Create);
+	registerClass("XmlSTDPRecorder", &XmlSTDPRecorder::Create);
+	registerClass("Xml911Recorder", &Xml911Recorder::Create);
 
 #if defined(HDF5)
    registerClass("Hdf5Recorder", &Hdf5Recorder::Create);
@@ -27,33 +27,30 @@ RecorderFactory::RecorderFactory() {
 #endif
 }
 
-RecorderFactory::~RecorderFactory() {
-   createFunctions.clear();
-}
+RecorderFactory::~RecorderFactory() { createFunctions.clear(); }
 
 ///  Register recorder class and its creation function to the factory.
 ///
 ///  @param  className  vertices class name.
 ///  @param  Pointer to the class creation function.
-void RecorderFactory::registerClass(const std::string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void RecorderFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired recorder class.
-std::shared_ptr<IRecorder> RecorderFactory::createRecorder(const std::string &className) {
-   recorderInstance = std::shared_ptr<IRecorder>(invokeCreateFunction(className));
-   return recorderInstance;
+std::shared_ptr<IRecorder> RecorderFactory::createRecorder(const std::string& className) {
+	recorderInstance = std::shared_ptr<IRecorder>(invokeCreateFunction(className));
+	return recorderInstance;
 }
 
 /// Create an instance of the vertices class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-IRecorder *RecorderFactory::invokeCreateFunction(const std::string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+IRecorder* RecorderFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Recorders/RecorderFactory.cpp
+++ b/Simulator/Recorders/RecorderFactory.cpp
@@ -49,8 +49,7 @@ std::shared_ptr<IRecorder> RecorderFactory::createRecorder(const std::string& cl
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
 IRecorder* RecorderFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Recorders/RecorderFactory.cpp
+++ b/Simulator/Recorders/RecorderFactory.cpp
@@ -35,14 +35,14 @@ RecorderFactory::~RecorderFactory() {
 ///
 ///  @param  className  vertices class name.
 ///  @param  Pointer to the class creation function.
-void RecorderFactory::registerClass(const string &className, CreateFunction function) {
+void RecorderFactory::registerClass(const std::string &className, CreateFunction function) {
    createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired recorder class.
-shared_ptr<IRecorder> RecorderFactory::createRecorder(const string &className) {
-   recorderInstance = shared_ptr<IRecorder>(invokeCreateFunction(className));
+std::shared_ptr<IRecorder> RecorderFactory::createRecorder(const std::string &className) {
+   recorderInstance = std::shared_ptr<IRecorder>(invokeCreateFunction(className));
    return recorderInstance;
 }
 
@@ -50,7 +50,7 @@ shared_ptr<IRecorder> RecorderFactory::createRecorder(const string &className) {
 ///
 /// The calling method uses this retrieval mechanism in
 /// value assignment.
-IRecorder *RecorderFactory::invokeCreateFunction(const string &className) {
+IRecorder *RecorderFactory::invokeCreateFunction(const std::string &className) {
    for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
       if (className == i->first)
          return i->second();

--- a/Simulator/Recorders/RecorderFactory.h
+++ b/Simulator/Recorders/RecorderFactory.h
@@ -15,44 +15,42 @@
 #include "Global.h"
 #include "IRecorder.h"
 
-using namespace std;
-
 class RecorderFactory {
 
-public:
-   ~RecorderFactory();
+	public:
+		~RecorderFactory();
 
-   static RecorderFactory *getInstance() {
-      static RecorderFactory instance;
-      return &instance;
-   }
+		static RecorderFactory* getInstance() {
+			static RecorderFactory instance;
+			return &instance;
+		}
 
-   // Invokes constructor for desired concrete class
-   shared_ptr<IRecorder> createRecorder(const string &className);
+		// Invokes constructor for desired concrete class
+		std::shared_ptr<IRecorder> createRecorder(const std::string& className);
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   RecorderFactory(RecorderFactory const &) = delete;
-   void operator=(RecorderFactory const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		RecorderFactory(RecorderFactory const&) = delete;
+		void operator=(RecorderFactory const&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   RecorderFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		RecorderFactory();
 
-   /// Pointer to neurons instance
-   shared_ptr<IRecorder> recorderInstance;
+		/// Pointer to neurons instance
+		std::shared_ptr<IRecorder> recorderInstance;
 
-   /// Defines function type for usage in internal map
-   typedef IRecorder *(*CreateFunction)(void);
+		/// Defines function type for usage in internal map
+		using CreateFunction = IRecorder *(*)(void);
 
-   /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> RecorderFunctionMap;
+		/// Defines map between class name and corresponding ::Create() function.
+		using RecorderFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   RecorderFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		RecorderFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   IRecorder *invokeCreateFunction(const string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		IRecorder* invokeCreateFunction(const std::string& className);
 
-   /// Register neuron class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+		/// Register neuron class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Simulator/Recorders/RecorderFactory.h
+++ b/Simulator/Recorders/RecorderFactory.h
@@ -29,8 +29,8 @@ class RecorderFactory {
 		std::shared_ptr<IRecorder> createRecorder(const std::string& className);
 
 		/// Delete these methods because they can cause copy instances of the singleton when using threads.
-		RecorderFactory(RecorderFactory const&) = delete;
-		void operator=(RecorderFactory const&) = delete;
+		RecorderFactory(const RecorderFactory&) = delete;
+		void operator=(const RecorderFactory&) = delete;
 
 	private:
 		/// Constructor is private to keep a singleton instance of this class.

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -25,7 +25,7 @@ XmlRecorder::XmlRecorder() :
 
    ParameterManager::getInstance().getStringByXpath("//RecorderParams/RecorderFiles/resultFileName/text()", resultFileName_);
 
-   function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
+   std::function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
@@ -133,34 +133,34 @@ void XmlRecorder::saveSimData(const AllVertices &vertices) {
    
    // Write the core state information:
    resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << layout->xloc_->toXML("xloc") << endl;
-   resultOut_ << "   " << layout->yloc_->toXML("yloc") << endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
+   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+   resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
+   resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
+   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
    
    // create starter neurons matrix
    int num_starter_neurons = static_cast<int>(layout->numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons, layout->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
+      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
    }
    
    // Write neuron threshold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << endl;
+   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
    
    // write epoch duration
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << endl;
-   resultOut_ << "   " << simulator.getEpochDuration() << endl;
-   resultOut_ << "</Matrix>" << endl;
+   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
+   resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
    
    // write simulation end time
    resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-   << endl;
-   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << endl;
-   resultOut_ << "</Matrix>" << endl;
-   resultOut_ << "</SimState>" << endl;
+   << std::endl;
+   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
+   resultOut_ << "</Matrix>" << std::endl;
+   resultOut_ << "</SimState>" << std::endl;
 }
 
 /*
@@ -184,8 +184,8 @@ void XmlRecorder::getStarterNeuronMatrix(VectorMatrix &matrix, const bool *start
  *  Registered to OperationManager as Operation::printParameters
  */
 void XmlRecorder::printParameters() {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << endl
-                   << "\tResult file path: " << resultFileName_ << endl
-                   << "\tBurstiness History Size: " << burstinessHist_.Size() << endl
-                   << "\tSpikes History Size: " << spikesHistory_.Size() << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
+                   << "\tResult file path: " << resultFileName_ << std::endl
+                   << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
+                   << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl);
 }

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -18,149 +18,143 @@
 /// constructor
 // TODO: I believe the initializer for spikesHistory_ assumes a particular deltaT
 XmlRecorder::XmlRecorder() :
-   burstinessHist_(MATRIX_TYPE, MATRIX_INIT, 1, static_cast<int>(Simulator::getInstance().getEpochDuration() *
-    Simulator::getInstance().getNumEpochs()), static_cast<BGFLOAT>(0.0)),
-   spikesHistory_(MATRIX_TYPE, MATRIX_INIT, 1, static_cast<int>(Simulator::getInstance().getEpochDuration() *
-    Simulator::getInstance().getNumEpochs() * 100), static_cast<BGFLOAT>(0.0)) {
+	burstinessHist_(MATRIX_TYPE, MATRIX_INIT, 1, static_cast<int>(Simulator::getInstance().getEpochDuration() *
+		                Simulator::getInstance().getNumEpochs()), static_cast<BGFLOAT>(0.0)),
+	spikesHistory_(MATRIX_TYPE, MATRIX_INIT, 1, static_cast<int>(Simulator::getInstance().getEpochDuration() *
+		               Simulator::getInstance().getNumEpochs() * 100), static_cast<BGFLOAT>(0.0)) {
 
-   ParameterManager::getInstance().getStringByXpath("//RecorderParams/RecorderFiles/resultFileName/text()", resultFileName_);
+	ParameterManager::getInstance().getStringByXpath("//RecorderParams/RecorderFiles/resultFileName/text()",
+	                                                 resultFileName_);
 
-   std::function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	std::function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
 
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
-   // TODO: Is this needed?
+// TODO: Is this needed?
 /// destructor
-XmlRecorder::~XmlRecorder() {
-}
+XmlRecorder::~XmlRecorder() {}
 
 /// Initialize data
 /// Create a new xml file.
 ///
 /// @param[in] stateOutputFileName	File name to save histories
 void XmlRecorder::init() {
-   resultOut_.open(resultFileName_.c_str());
+	resultOut_.open(resultFileName_.c_str());
 
-   // TODO: Log error using LOG4CPLUS for workbench
-   //       For the time being, we are terminating the program when we can't open a file for writing.
-   if (!resultOut_.is_open()) {
-      perror("Error opening output file for writing ");
-      exit(EXIT_FAILURE);
-   }
+	// TODO: Log error using LOG4CPLUS for workbench
+	//       For the time being, we are terminating the program when we can't open a file for writing.
+	if (!resultOut_.is_open()) {
+		perror("Error opening output file for writing ");
+		exit(EXIT_FAILURE);
+	}
 
 }
 
 // TODO: for the empty functions below, what should happen? Should they ever
 // TODO: be called? Is it an error if they're called?
 /// Init radii and rates history matrices with default values
-void XmlRecorder::initDefaultValues() {
-}
+void XmlRecorder::initDefaultValues() {}
 
 /// Init radii and rates history matrices with current radii and rates
-void XmlRecorder::initValues() {
-}
+void XmlRecorder::initValues() {}
 
 /// Get the current radii and rates values
-void XmlRecorder::getValues() {
-}
+void XmlRecorder::getValues() {}
 
 /// Terminate process
-void XmlRecorder::term() {
-   resultOut_.close();
-}
+void XmlRecorder::term() { resultOut_.close(); }
 
 /// Compile history information in every epoch
 ///
 /// @param[in] neurons    The entire list of neurons.
-void XmlRecorder::compileHistories(AllVertices &vertices) {
-   AllSpikingNeurons &spNeurons = dynamic_cast<AllSpikingNeurons &>(vertices);
-   Simulator& simulator = Simulator::getInstance();
-   int maxSpikes = static_cast<int>(simulator.getEpochDuration() * simulator.getMaxFiringRate());
-   
-   // output spikes
-   for (int iNeuron = 0; iNeuron < simulator.getTotalVertices(); iNeuron++) {
-      uint64_t *pSpikes = spNeurons.spikeHistory_[iNeuron];
-      
-      const int spikeCount = spNeurons.spikeCount_[iNeuron];
-      const int offset = spNeurons.spikeCountOffset_[iNeuron];
-      for (int i = 0, idxSp = offset; i < spikeCount; i++, idxSp++) {
-         // Single precision (float) gives you 23 bits of significand, 8 bits of exponent,
-         // and 1 sign bit. Double precision (double) gives you 52 bits of significand,
-         // 11 bits of exponent, and 1 sign bit.
-         // Therefore, single precision can only handle 2^23 = 8,388,608 simulation steps
-         // or 8 epochs (1 epoch = 100s, 1 simulation step = 0.1ms).
-         
-         if (idxSp >= maxSpikes) idxSp = 0;
-         // compile network wide burstiness index data in 1s bins
-         int idx1 = static_cast<int>(static_cast<double>(pSpikes[idxSp]) * simulator.getDeltaT());
-         burstinessHist_[idx1] = burstinessHist_[idx1] + 1.0;
-         
-         // compile network wide spike count in 10ms bins
-         int idx2 = static_cast<int>( static_cast<double>( pSpikes[idxSp] ) * Simulator::getInstance().getDeltaT() *
-                                     100);
-         spikesHistory_[idx2] = spikesHistory_[idx2] + 1.0;
-      }
-   }
-   
-   // clear spike count
-   spNeurons.clearSpikeCounts();
+void XmlRecorder::compileHistories(AllVertices& vertices) {
+	auto& spNeurons = dynamic_cast<AllSpikingNeurons&>(vertices);
+	Simulator& simulator = Simulator::getInstance();
+	int maxSpikes = static_cast<int>(simulator.getEpochDuration() * simulator.getMaxFiringRate());
+
+	// output spikes
+	for (int iNeuron = 0; iNeuron < simulator.getTotalVertices(); iNeuron++) {
+		uint64_t* pSpikes = spNeurons.spikeHistory_[iNeuron];
+
+		const int spikeCount = spNeurons.spikeCount_[iNeuron];
+		const int offset = spNeurons.spikeCountOffset_[iNeuron];
+		for (int i = 0, idxSp = offset; i < spikeCount; i++, idxSp++) {
+			// Single precision (float) gives you 23 bits of significand, 8 bits of exponent,
+			// and 1 sign bit. Double precision (double) gives you 52 bits of significand,
+			// 11 bits of exponent, and 1 sign bit.
+			// Therefore, single precision can only handle 2^23 = 8,388,608 simulation steps
+			// or 8 epochs (1 epoch = 100s, 1 simulation step = 0.1ms).
+
+			if (idxSp >= maxSpikes) idxSp = 0;
+			// compile network wide burstiness index data in 1s bins
+			int idx1 = static_cast<int>(static_cast<double>(pSpikes[idxSp]) * simulator.getDeltaT());
+			burstinessHist_[idx1] = burstinessHist_[idx1] + 1.0;
+
+			// compile network wide spike count in 10ms bins
+			int idx2 = static_cast<int>(static_cast<double>(pSpikes[idxSp]) * Simulator::getInstance().getDeltaT() *
+				100);
+			spikesHistory_[idx2] = spikesHistory_[idx2] + 1.0;
+		}
+	}
+
+	// clear spike count
+	spNeurons.clearSpikeCounts();
 }
 
 /// Writes simulation results to an output destination.
 ///
 /// @param  neurons the Neuron list to search from.
-void XmlRecorder::saveSimData(const AllVertices &vertices) {
-   Simulator& simulator = Simulator::getInstance();
-   // create Neuron Types matrix
-   VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
-   for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout()->vertexTypeMap_[i];
-   }
-   
-   // create neuron threshold matrix
-   VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
-   for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronThresh[i] = dynamic_cast<const AllIFNeurons &>(vertices).Vthresh_[i];
-   }
-   
-   // Write XML header information:
-   resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
-   << "<!-- State output file for the DCT growth modeling-->\n";
-   //stateOut << version; TODO: version
-   auto layout = simulator.getModel()->getLayout();
-   
-   // Write the core state information:
-   resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
-   resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
-   resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
-   resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
-   resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
-   
-   // create starter neurons matrix
-   int num_starter_neurons = static_cast<int>(layout->numEndogenouslyActiveNeurons_);
-   if (num_starter_neurons > 0) {
-      VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, layout->starterMap_);
-      resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
-   }
-   
-   // Write neuron threshold
-   resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
-   
-   // write epoch duration
-   resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" << std::endl;
-   resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
-   
-   // write simulation end time
-   resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
-   << std::endl;
-   resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
-   resultOut_ << "</Matrix>" << std::endl;
-   resultOut_ << "</SimState>" << std::endl;
+void XmlRecorder::saveSimData(const AllVertices& vertices) {
+	Simulator& simulator = Simulator::getInstance();
+	// create Neuron Types matrix
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
+	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronTypes[i] = simulator.getModel()->getLayout()->
+		vertexTypeMap_[i];
+
+	// create neuron threshold matrix
+	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
+	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(vertices)
+		.Vthresh_[i];
+
+	// Write XML header information:
+	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
+		<< "<!-- State output file for the DCT growth modeling-->\n";
+	//stateOut << version; TODO: version
+	auto layout = simulator.getModel()->getLayout();
+
+	// Write the core state information:
+	resultOut_ << "<SimState>\n";
+	resultOut_ << "   " << burstinessHist_.toXML("burstinessHist") << std::endl;
+	resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << std::endl;
+	resultOut_ << "   " << layout->xloc_->toXML("xloc") << std::endl;
+	resultOut_ << "   " << layout->yloc_->toXML("yloc") << std::endl;
+	resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << std::endl;
+
+	// create starter neurons matrix
+	int num_starter_neurons = static_cast<int>(layout->numEndogenouslyActiveNeurons_);
+	if (num_starter_neurons > 0) {
+		VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
+		getStarterNeuronMatrix(starterNeurons, layout->starterMap_);
+		resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << std::endl;
+	}
+
+	// Write neuron threshold
+	resultOut_ << "   " << neuronThresh.toXML("neuronThresh") << std::endl;
+
+	// write epoch duration
+	resultOut_ << "   <Matrix name=\"Tsim\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">" <<
+		std::endl;
+	resultOut_ << "   " << simulator.getEpochDuration() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+
+	// write simulation end time
+	resultOut_ << "   <Matrix name=\"simulationEndTime\" type=\"complete\" rows=\"1\" columns=\"1\" multiplier=\"1.0\">"
+		<< std::endl;
+	resultOut_ << "   " << g_simulationStep * simulator.getDeltaT() << std::endl;
+	resultOut_ << "</Matrix>" << std::endl;
+	resultOut_ << "</SimState>" << std::endl;
 }
 
 /*
@@ -169,14 +163,14 @@ void XmlRecorder::saveSimData(const AllVertices &vertices) {
  *  @param  matrix      Starter Neuron matrix.
  *  @param  starter_map Bool map to reference neuron matrix location from.
  */
-void XmlRecorder::getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starterMap) {
-   int cur = 0;
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      if (starterMap[i]) {
-         matrix[cur] = i;
-         cur++;
-      }
-   }
+void XmlRecorder::getStarterNeuronMatrix(VectorMatrix& matrix, const bool* starterMap) {
+	int cur = 0;
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		if (starterMap[i]) {
+			matrix[cur] = i;
+			cur++;
+		}
+	}
 }
 
 /**
@@ -184,8 +178,8 @@ void XmlRecorder::getStarterNeuronMatrix(VectorMatrix &matrix, const bool *start
  *  Registered to OperationManager as Operation::printParameters
  */
 void XmlRecorder::printParameters() {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
-                   << "\tResult file path: " << resultFileName_ << std::endl
-                   << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
-                   << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nXMLRECORDER PARAMETERS" << std::endl
+	                << "\tResult file path: " << resultFileName_ << std::endl
+	                << "\tBurstiness History Size: " << burstinessHist_.Size() << std::endl
+	                << "\tSpikes History Size: " << spikesHistory_.Size() << std::endl);
 }

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -26,8 +26,8 @@ XmlRecorder::XmlRecorder() :
 	ParameterManager::getInstance().getStringByXpath("//RecorderParams/RecorderFiles/resultFileName/text()",
 	                                                 resultFileName_);
 
-	std::function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
-	OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+	std::function<void()> printParametersFunc = [this] { printParameters(); };
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
 	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
@@ -109,14 +109,18 @@ void XmlRecorder::compileHistories(AllVertices& vertices) {
 void XmlRecorder::saveSimData(const AllVertices& vertices) {
 	Simulator& simulator = Simulator::getInstance();
 	// create Neuron Types matrix
-	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
-	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronTypes[i] = simulator.getModel()->getLayout()->
-		vertexTypeMap_[i];
+	VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), static_cast<float>(vertexType::EXC));
+	for (int i = 0; i < simulator.getTotalVertices(); i++) {
+		neuronTypes[i] = static_cast<float>(simulator.getModel()->getLayout()->
+		                                              vertexTypeMap_[i]);
+	}
 
 	// create neuron threshold matrix
 	VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
-	for (int i = 0; i < simulator.getTotalVertices(); i++) neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(vertices)
-		.Vthresh_[i];
+	for (int i = 0; i < simulator.getTotalVertices(); i++) {
+		neuronThresh[i] = dynamic_cast<const AllIFNeurons&>(vertices)
+			.Vthresh_[i];
+	}
 
 	// Write XML header information:
 	resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -60,7 +60,7 @@ public:
 
 protected:
    // a file stream for xml output
-   ofstream resultOut_;
+   std::ofstream resultOut_;
    
    // burstiness Histogram goes through the
    VectorMatrix burstinessHist_;

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -21,55 +21,54 @@
 #include "Model.h"
 
 class XmlRecorder : public IRecorder {
-public:
-   /// constructor
-   XmlRecorder();
+	public:
+		/// constructor
+		XmlRecorder();
 
-   /// destructor
-   ~XmlRecorder();
-   
-   static IRecorder* Create() { return new XmlRecorder(); }
+		/// destructor
+		~XmlRecorder() override;
 
-   /// Initialize data
-   /// Create a new xml file.
-   virtual void init() override;
+		static IRecorder* Create() { return new XmlRecorder(); }
 
-   /// Init radii and rates history matrices with default values
-   virtual void initDefaultValues() override;
+		/// Initialize data
+		/// Create a new xml file.
+		void init() override;
 
-   /// Init radii and rates history matrices with current radii and rates
-   virtual void initValues() override;
+		/// Init radii and rates history matrices with default values
+		void initDefaultValues() override;
 
-   /// Get the current radii and rates vlaues
-   virtual void getValues() override;
+		/// Init radii and rates history matrices with current radii and rates
+		void initValues() override;
 
-   /// Terminate process
-   virtual void term() override;
+		/// Get the current radii and rates vlaues
+		void getValues() override;
 
-   /// Compile history information in every epoch
-   /// @param[in] vertices   The entire list of vertices.
-   virtual void compileHistories(AllVertices &vertices) override;
+		/// Terminate process
+		void term() override;
 
-   /// Writes simulation results to an output destination.
-   /// @param  vertices the Vertex list to search from.
-   virtual void saveSimData(const AllVertices &vertices) override;
+		/// Compile history information in every epoch
+		/// @param[in] vertices   The entire list of vertices.
+		void compileHistories(AllVertices& vertices) override;
 
-   ///  Prints out all parameters to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() override;
+		/// Writes simulation results to an output destination.
+		/// @param  vertices the Vertex list to search from.
+		void saveSimData(const AllVertices& vertices) override;
 
-protected:
-   // a file stream for xml output
-   std::ofstream resultOut_;
-   
-   // burstiness Histogram goes through the
-   VectorMatrix burstinessHist_;
-   
-   // spikes history - history of accumulated spikes count of all neurons (10 ms bin)
-   VectorMatrix spikesHistory_;
+		///  Prints out all parameters to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() override;
 
-   // TODO: There seems to be multiple copies of this in different classes...
-   void getStarterNeuronMatrix(VectorMatrix &matrix, const bool *starterMap);
+	protected:
+		// a file stream for xml output
+		std::ofstream resultOut_;
+
+		// burstiness Histogram goes through the
+		VectorMatrix burstinessHist_;
+
+		// spikes history - history of accumulated spikes count of all neurons (10 ms bin)
+		VectorMatrix spikesHistory_;
+
+		// TODO: There seems to be multiple copies of this in different classes...
+		void getStarterNeuronMatrix(VectorMatrix& matrix, const bool* starterMap);
 
 };
-

--- a/Simulator/Utils/BGTypes.h
+++ b/Simulator/Utils/BGTypes.h
@@ -31,29 +31,10 @@
 //#define DOUBLEPRECISION
 //#define BGFLOAT double
 
-typedef BGFLOAT *PBGFLOAT;
+using PBGFloat =  BGFLOAT *;
 
 // TIMEFLOAT is used by the GPU code and needs to be a double
 #define TIMEFLOAT double
-
-// Platform Specific (are the typdef's redundant?)
-#ifdef __linux__
-typedef unsigned int uint32_t;
-typedef signed int int32_t;
-
-#elif defined __APPLE__
-typedef unsigned int uint32_t;
-typedef signed int int32_t;
-
-#elif defined _WIN32 || defined _WIN64
-typedef unsigned __int32 uint32_t;		// included in inttypes.h, which is not 
-                                        // available in WIN32
-typedef signed __int32 int32_t;
-typedef unsigned long long int uint64_t;
-
-#else
-#error "unknown platform"
-#endif // Platform Specific
 
 // AMP
 #ifdef USE_AMP

--- a/Simulator/Utils/BGTypes.h
+++ b/Simulator/Utils/BGTypes.h
@@ -25,13 +25,14 @@
  */
 
 #pragma once
+#include <cstdint>
 
 #define SINGLEPRECISION
 #define BGFLOAT float
 //#define DOUBLEPRECISION
 //#define BGFLOAT double
 
-using PBGFloat =  BGFLOAT *;
+using PBGFloat = BGFLOAT*;
 
 // TIMEFLOAT is used by the GPU code and needs to be a double
 #define TIMEFLOAT double
@@ -46,5 +47,3 @@ using PBGFloat =  BGFLOAT *;
 // The type for using array indexes (issue #142).
 #define BGSIZE uint32_t
 //#define BGSIZE uint64_t
-
-

--- a/Simulator/Utils/Coordinate.h
+++ b/Simulator/Utils/Coordinate.h
@@ -15,18 +15,14 @@ struct Coordinate {
 
 	//  The constructor for Coordinate.
 	Coordinate(int x = 0, int y = 0) :
-		x(x), y(y) {
-	}
+		x(x), y(y) { }
 
 	//  The copy constructor for Coordinate.
-	Coordinate(const Coordinate &cp) :
-		x(cp.x), y(cp.y) {
-	}
+	Coordinate(const Coordinate& cp) :
+		x(cp.x), y(cp.y) { }
 
 	//  The overloaded == operator.
-	bool operator==(const Coordinate& other) {
-		return other.x == x && other.y == y;
-	}
+	bool operator==(const Coordinate& other) { return other.x == x && other.y == y; }
 
 	//  The location in the x dimension.
 	int x;

--- a/Simulator/Utils/Global.cpp
+++ b/Simulator/Utils/Global.cpp
@@ -53,9 +53,9 @@ std::string coordToString(int x, int y, int z) {
 // MODEL INDEPENDENT FUNCTION NMV-BEGIN {
 std::string neuronTypeToString(vertexType t) {
 	switch (t) {
-		case INH: return "INH";
-		case EXC: return "EXC";
-		default: std::cerr << "ERROR->neuronTypeToString() failed, unknown type: " << t << std::endl;
+		case vertexType::INH: return "INH";
+		case vertexType::EXC: return "EXC";
+		default: std::cerr << "ERROR->neuronTypeToString() failed, unknown type: " << static_cast<int>(t) << std::endl;
 			assert(false);
 			return nullptr; // Must return a value -- this will probably cascade to another failure
 	}

--- a/Simulator/Utils/Global.cpp
+++ b/Simulator/Utils/Global.cpp
@@ -18,13 +18,13 @@ int g_debug_mask
 		= 0;
 #endif
 
-///  Converts the given index to a string with the indexes of a two-dimensional array.
+///  Converts the given index to a std::string with the indexes of a two-dimensional array.
 ///  @param  i   index to be converted.
 ///  @param  width   width of the two-dimensional array
 ///  @param  height  height of the two-dimensional array
-///  @return string with the converted indexes and square brackets surrounding them.
-string index2dToString(int i, int width, int height) {
-	stringstream ss;
+///  @return std::string with the converted indexes and square brackets surrounding them.
+std::string index2dToString(int i, int width, int height) {
+	std::stringstream ss;
 	ss << "[" << i % width << "][" << i / height << "]";
 	return ss.str();
 }
@@ -33,8 +33,8 @@ string index2dToString(int i, int width, int height) {
 ///  @param  x   x coordinate.
 ///  @param  y   y coordinate.
 ///  @return returns the given coordinates surrounded by square brackets.
-string coordToString(int x, int y) {
-	stringstream ss;
+std::string coordToString(int x, int y) {
+	std::stringstream ss;
 	ss << "[" << x << "][" << y << "]";
 	return ss.str();
 }
@@ -44,27 +44,27 @@ string coordToString(int x, int y) {
 ///  @param  y   y coordinate.
 ///  @param  z   z coordinate.
 ///  @return returns the given coordinates surrounded by square brackets.
-string coordToString(int x, int y, int z) {
-	stringstream ss;
+std::string coordToString(int x, int y, int z) {
+	std::stringstream ss;
 	ss << "[" << x << "][" << y << "][" << z << "]";
 	return ss.str();
 }
 
 // MODEL INDEPENDENT FUNCTION NMV-BEGIN {
-string neuronTypeToString(vertexType t) {
+std::string neuronTypeToString(vertexType t) {
 	switch (t) {
 	case INH:
 		return "INH";
 	case EXC:
 		return "EXC";
 	default:
-		cerr << "ERROR->neuronTypeToString() failed, unknown type: " << t << endl;
+		std::cerr << "ERROR->neuronTypeToString() failed, unknown type: " << t << std::endl;
 		assert(false);
 		return nullptr; // Must return a value -- this will probably cascade to another failure
 	}
 }
 // } NMV-END
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 //! CUDA device ID
 int g_deviceId = 0;
 #endif // USE_GPU
@@ -124,6 +124,6 @@ void printPerformanceMetrics(const float total_time, int steps)
 #endif // PERFORMANCE_METRICS
 
 // TODO comment
-const string MATRIX_TYPE = "complete";
+const std::string MATRIX_TYPE = "complete";
 // TODO comment
-const string MATRIX_INIT = "const";
+const std::string MATRIX_INIT = "const";

--- a/Simulator/Utils/Global.cpp
+++ b/Simulator/Utils/Global.cpp
@@ -15,7 +15,7 @@ int g_debug_mask
 #if DEBUG_OUT
 		= DEBUG_LOG_LOW;
 #else
-		= 0;
+	= 0;
 #endif
 
 ///  Converts the given index to a std::string with the indexes of a two-dimensional array.
@@ -53,27 +53,25 @@ std::string coordToString(int x, int y, int z) {
 // MODEL INDEPENDENT FUNCTION NMV-BEGIN {
 std::string neuronTypeToString(vertexType t) {
 	switch (t) {
-	case INH:
-		return "INH";
-	case EXC:
-		return "EXC";
-	default:
-		std::cerr << "ERROR->neuronTypeToString() failed, unknown type: " << t << std::endl;
-		assert(false);
-		return nullptr; // Must return a value -- this will probably cascade to another failure
+		case INH: return "INH";
+		case EXC: return "EXC";
+		default: std::cerr << "ERROR->neuronTypeToString() failed, unknown type: " << t << std::endl;
+			assert(false);
+			return nullptr; // Must return a value -- this will probably cascade to another failure
 	}
 }
+
 // } NMV-END
 #ifdef __CUDACC__
 //! CUDA device ID
 int g_deviceId = 0;
-#endif // USE_GPU
+#endif // __CUDACC__
 
 // A random number generator.
 MTRand initRNG;
 
 // A normalized random number generator.
-MTRand *noiseRNG;
+MTRand* noiseRNG;
 
 //		simulation vars
 uint64_t g_simulationStep = 0;

--- a/Simulator/Utils/Global.h
+++ b/Simulator/Utils/Global.h
@@ -61,15 +61,13 @@ typedef unsigned long long int uint64_t;	//included in inttypes.h, which is not 
 #include "Coordinate.h"
 #include "VectorMatrix.h"
 
-using namespace std;
-
 // If defined, a table with time and each neuron voltage will output to stdout.
 //#define DUMP_VOLTAGES
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 //! CUDA device ID
 extern int g_deviceId;
-#endif // USE_GPU
+#endif
 
 // The constant PI.
 extern const BGFLOAT pi;
@@ -163,14 +161,14 @@ enum edgeType {
 #define DEFAULT_delay_weight	(0)
 // } NMV-END
 
-// Converts a 1-d index into a coordinate string.
-string index2dToString(int i, int width, int height);
-// Converts a 2-d coordinate into a string.
-string coordToString(int x, int y);
-// Converts a 3-d coordinate into a string.
-string coordToString(int x, int y, int z);
-// Converts a vertexType into a string.
-string neuronTypeToString(vertexType t);
+// Converts a 1-d index into a coordinate std::string.
+std::string index2dToString(int i, int width, int height);
+// Converts a 2-d coordinate into a std::string.
+std::string coordToString(int x, int y);
+// Converts a 3-d coordinate into a std::string.
+std::string coordToString(int x, int y, int z);
+// Converts a vertexType into a std::string.
+std::string neuronTypeToString(vertexType t);
 
 #ifdef PERFORMANCE_METRICS
 // All times in seconds
@@ -190,6 +188,6 @@ void printPerformanceMetrics(const float total_time, int steps);
 #endif
 
 // TODO comment
-extern const string MATRIX_TYPE;
+extern const std::string MATRIX_TYPE;
 // TODO comment
-extern const string MATRIX_INIT;
+extern const std::string MATRIX_INIT;

--- a/Simulator/Utils/Global.h
+++ b/Simulator/Utils/Global.h
@@ -92,7 +92,7 @@ const int g_nMaxChunkSize = 100;
 // CALR: Caller radii
 // PSAP: PSAP nodes
 // RESP: Responder nodes
-enum vertexType {
+enum class vertexType {
 	// Neuro
 	INH = 1,
 	EXC = 2,
@@ -116,7 +116,7 @@ enum vertexType {
 //  RC - Responder to Caller
 //  PP - PSAP to PSAP 
 
-enum edgeType {
+enum class edgeType {
 	// NEURO
 	II = 0,
 	IE = 1,

--- a/Simulator/Utils/Global.h
+++ b/Simulator/Utils/Global.h
@@ -47,8 +47,8 @@
 
 extern int g_debug_mask;
 
-#include <sstream>
 #include <cassert>
+#include <sstream>
 #include <vector>
 #ifdef _WIN32	//needs to be before #include "bgtypes.h" or the #define BGFLOAT will cause problems
 #include <windows.h>	//warning! windows.h also defines BGFLOAT
@@ -76,7 +76,7 @@ extern const BGFLOAT pi;
 extern MTRand initRNG;
 
 // A normalized random number generator.
-extern MTRand *noiseRNG;
+extern MTRand* noiseRNG;
 
 // The current simulation step.
 extern uint64_t g_simulationStep;
@@ -92,17 +92,17 @@ const int g_nMaxChunkSize = 100;
 // CALR: Caller radii
 // PSAP: PSAP nodes
 // RESP: Responder nodes
-enum vertexType { 
-    // Neuro
-    INH = 1, 
-    EXC = 2, 
-    // NG911
-    CALR = 3,
-    PSAP = 4,
-    RESP = 5, 
-    // UNDEF
-    VTYPE_UNDEF = 0 
-    };
+enum vertexType {
+	// Neuro
+	INH = 1,
+	EXC = 2,
+	// NG911
+	CALR = 3,
+	PSAP = 4,
+	RESP = 5,
+	// UNDEF
+	VTYPE_UNDEF = 0
+};
 
 // Edge types.
 // NEURO:
@@ -116,19 +116,20 @@ enum vertexType {
 //  RC - Responder to Caller
 //  PP - PSAP to PSAP 
 
-enum edgeType { 
-    // NEURO
-    II = 0, 
-    IE = 1, 
-    EI = 2, 
-    EE = 3, 
-    // NG911
-    CP = 4,
-    PR = 5,
-    RC = 6,
-    PP = 7,
-    // UNDEF
-    ETYPE_UNDEF = -1 };
+enum edgeType {
+	// NEURO
+	II = 0,
+	IE = 1,
+	EI = 2,
+	EE = 3,
+	// NG911
+	CP = 4,
+	PR = 5,
+	RC = 6,
+	PP = 7,
+	// UNDEF
+	ETYPE_UNDEF = -1
+};
 
 // The default membrane capacitance.
 #define DEFAULT_Cm		(3e-8)

--- a/Simulator/Utils/Inputs/FSInput.cpp
+++ b/Simulator/Utils/Inputs/FSInput.cpp
@@ -9,7 +9,7 @@
 #include "FSInput.h"
 #include "HostSInputRegular.h"
 #include "HostSInputPoisson.h"
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 #include "GpuSInputRegular.h"
 #include "GpuSInputPoisson.h"
 #endif
@@ -76,7 +76,7 @@ ISInput* FSInput::CreateInstance()
 
     if (name == "SInputRegular")
     {
-#if defined(USE_GPU)
+#ifdef __CUDACC__
         pInput = new GpuSInputRegular(parms);
 #else
         pInput = new HostSInputRegular(parms);
@@ -84,7 +84,7 @@ ISInput* FSInput::CreateInstance()
     }
     else if (name == "SInputPoisson")
     {
-#if defined(USE_GPU)
+#ifdef __CUDACC__
         pInput = new GpuSInputPoisson(parms);
 #else
         pInput = new HostSInputPoisson(parms);

--- a/Simulator/Utils/Inputs/FSInput.h
+++ b/Simulator/Utils/Inputs/FSInput.h
@@ -35,7 +35,7 @@ public:
         static FSInput instance;
         return &instance;
     }
- 
+
     //! Create an instance.
     ISInput* CreateInstance();
 

--- a/Simulator/Utils/Inputs/GpuSInputPoisson.h
+++ b/Simulator/Utils/Inputs/GpuSInputPoisson.h
@@ -45,7 +45,7 @@ private:
 
     //! Synapse structures in device memory.
     AllDSSynapsesDeviceProperties* allEdgesDevice;
- 
+
     //! Pointer to synapse index map in device memory.
     EdgeIndexMap* edgeIndexMapDevice;
 

--- a/Simulator/Utils/Inputs/GpuSInputRegular.cu
+++ b/Simulator/Utils/Inputs/GpuSInputRegular.cu
@@ -67,7 +67,7 @@ void GpuSInputRegular::inputStimulus(SimulationInfo* psi)
 
     // CUDA parameters
     const int threadsPerBlock = 256;
-    int blocksPerGrid; 
+    int blocksPerGrid;
 
     // add input to each summation point
     blocksPerGrid = ( vertex_count + threadsPerBlock - 1 ) / threadsPerBlock;

--- a/Simulator/Utils/Inputs/SInputPoisson.cpp
+++ b/Simulator/Utils/Inputs/SInputPoisson.cpp
@@ -50,7 +50,7 @@ SInputPoisson::SInputPoisson(TiXmlElement* parms) :
     // allocate memory for interval counter
     nISIs = new int[Simulator::getInstance().getTotalVertices()];
     memset(nISIs, 0, sizeof(int) * Simulator::getInstance().getTotalVertices());
-    
+
     // allocate memory for input masks
     masks = new bool[Simulator::getInstance().getTotalVertices()];
 

--- a/Simulator/Utils/Matrix/CompleteMatrix.cpp
+++ b/Simulator/Utils/Matrix/CompleteMatrix.cpp
@@ -39,8 +39,10 @@ CompleteMatrix::CompleteMatrix(std::string t, std::string i, int r,
 	DEBUG_MATRIX(std::cerr << "Creating CompleteMatrix, size: ";)
 
 	// Bail out if we're being asked to create nonsense
-	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
-		"CompleteMatrix::CompleteMatrix(): Asked to create zero-size");
+	if (!((rows > 0) && (columns > 0))) {
+		throw Matrix_invalid_argument(
+			"CompleteMatrix::CompleteMatrix(): Asked to create zero-size");
+	}
 
 	// We're a 2D Matrix, even if only one row or column
 	dimensions = 2;
@@ -91,7 +93,7 @@ CompleteMatrix::CompleteMatrix(std::string t, std::string i, int r,
 		}
 		else if (type == "complete") {
 			// complete matrix with constant values
-			for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) theMatrix[i][j] = multiplier; }
+			for (int i = 0; i < rows; i++) for (int j = 0; j < columns; j++) theMatrix[i][j] = multiplier;
 		}
 		else {
 			clear();
@@ -157,7 +159,7 @@ void CompleteMatrix::copy(const CompleteMatrix& source) {
 
 	alloc(rows, columns);
 
-	for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) theMatrix[i][j] = source.theMatrix[i][j]; }
+	for (int i = 0; i < rows; i++) for (int j = 0; j < columns; j++) theMatrix[i][j] = source.theMatrix[i][j];
 	DEBUG_MATRIX(std::cerr << "\t\tdone." << std::endl;)
 }
 
@@ -173,12 +175,16 @@ void CompleteMatrix::copy(const CompleteMatrix& source) {
 void CompleteMatrix::alloc(int rows, int columns) {
 	if (theMatrix != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared Matrix");
 
-	if ((theMatrix = new BGFLOAT*[rows]) == nullptr) throw
-		Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
+	if ((theMatrix = new BGFLOAT*[rows]) == nullptr) {
+		throw
+			Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
+	}
 
 	for (int i = 0; i < rows; i++) {
-		if ((theMatrix[i] = new BGFLOAT[columns]) == nullptr) throw Matrix_bad_alloc(
-			"Failed allocating storage to copy Matrix.");
+		if ((theMatrix[i] = new BGFLOAT[columns]) == nullptr) {
+			throw Matrix_bad_alloc(
+				"Failed allocating storage to copy Matrix.");
+		}
 	}
 	DEBUG_MATRIX(std::cerr << "\tStorage allocated for "<< rows << "X" << columns << " Matrix." << std::endl;)
 
@@ -215,12 +221,14 @@ std::string CompleteMatrix::toXML(std::string name) const {
 // and including the other subclasses' headers).
 
 const CompleteMatrix CompleteMatrix::operator+(const CompleteMatrix& rhs) const {
-	if ((rhs.rows != rows) || (rhs.columns != columns)) throw Matrix_domain_error(
-		"Illegal matrix addition: dimension mismatch");
+	if ((rhs.rows != rows) || (rhs.columns != columns)) {
+		throw Matrix_domain_error(
+			"Illegal matrix addition: dimension mismatch");
+	}
 	// Start with this
 	CompleteMatrix result(*this);
 	// Add in rhs
-	for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) result.theMatrix[i][j] += rhs.theMatrix[i][j]; }
+	for (int i = 0; i < rows; i++) for (int j = 0; j < columns; j++) result.theMatrix[i][j] += rhs.theMatrix[i][j];
 
 	return result;
 }
@@ -236,9 +244,8 @@ const CompleteMatrix sqrt(const CompleteMatrix& m) {
 	// Start with vector
 	CompleteMatrix result(m);
 
-	for (int i = 0; i < result.rows; i++) {
-		for (int j = 0; j < result.columns; j++) result.theMatrix[i][j] = sqrt(result.theMatrix[i][j]);
-	}
+	for (int i = 0; i < result.rows; i++) for (int j = 0; j < result.columns; j++) result.theMatrix[i][j] = sqrt(
+		result.theMatrix[i][j]);
 
 	return result;
 }

--- a/Simulator/Utils/Matrix/CompleteMatrix.cpp
+++ b/Simulator/Utils/Matrix/CompleteMatrix.cpp
@@ -10,8 +10,8 @@
 #include <iostream>
 #include <sstream>
 
-#include "Global.h"
 #include "CompleteMatrix.h"
+#include "Global.h"
 
 // Create a complete 2D Matrix
 /// Allocate storage and initialize attributes. If "v" (values) is
@@ -35,133 +35,130 @@
 /// @param v values for initializing CompleteMatrix (this std::string is parsed as a list of floating point numbers)
 CompleteMatrix::CompleteMatrix(std::string t, std::string i, int r,
                                int c, BGFLOAT m, std::string values)
-: Matrix(t, i, r, c, m), theMatrix(nullptr)
-{
-    DEBUG_MATRIX(std::cerr << "Creating CompleteMatrix, size: ";)
-    
-    // Bail out if we're being asked to create nonsense
-    if (!((rows > 0) && (columns > 0)))
-        throw Matrix_invalid_argument("CompleteMatrix::CompleteMatrix(): Asked to create zero-size");
-    
-    // We're a 2D Matrix, even if only one row or column
-    dimensions = 2;
-    
-    DEBUG_MATRIX( std::cerr << rows << "X" << columns << ":" << std::endl;)
-    
-    // Allocate storage
-    alloc(rows, columns);
-    
-    if (values != "") {     // Initialize from the text std::string
-        std::istringstream valStream(values);
-        if (type == "diag") {       // diagonal matrix with values given
-            for (int i=0; i<rows; i++) {
-                for (int j=0; j<columns; j++) {
-                    theMatrix[i][j] = 0.0;    // Non-diagonal elements are zero
-                    if (i == j) {
-                        valStream >> theMatrix[i][j];
-                        theMatrix[i][j] *= multiplier;
-                    }
-                }
-            }
-        } else if (type == "complete") { // complete matrix with values given
-            for (int i=0; i<rows; i++) {
-                for (int j=0; j<columns; j++) {
-                    valStream >> theMatrix[i][j];
-                    theMatrix[i][j] *= multiplier;
-                }
-            }
-        } else {
-            clear();
-            throw Matrix_invalid_argument("Illegal type for CompleteMatrix with 'none' init: " + type);
-        }
-    } else if (init == "const") {
-        if (type == "diag") {       // diagonal matrix with constant values
-            for (int i=0; i<rows; i++) {
-                for (int j=0; j<columns; j++) {
-                    theMatrix[i][j] = 0.0;    // Non-diagonal elements are zero
-                    if (i == j)
-                        theMatrix[i][j] = multiplier;
-                }
-            }
-        } else if (type == "complete") { // complete matrix with constant values
-            for (int i=0; i<rows; i++) {
-                for (int j=0; j<columns; j++) {
-                    theMatrix[i][j] = multiplier;
-                }
-            }
-        } else {
-            clear();
-            throw Matrix_invalid_argument("Illegal type for CompleteMatrix with 'none' init: " + type);
-        }
-    }
-    //  else if (init == "random")
-    DEBUG_MATRIX(std::cerr << "\tInitialized " << type << " matrix" << std::endl;)
+	: Matrix(t, i, r, c, m), theMatrix(nullptr) {
+	DEBUG_MATRIX(std::cerr << "Creating CompleteMatrix, size: ";)
+
+	// Bail out if we're being asked to create nonsense
+	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
+		"CompleteMatrix::CompleteMatrix(): Asked to create zero-size");
+
+	// We're a 2D Matrix, even if only one row or column
+	dimensions = 2;
+
+	DEBUG_MATRIX(std::cerr << rows << "X" << columns << ":" << std::endl;)
+
+	// Allocate storage
+	alloc(rows, columns);
+
+	if (values != "") {
+		// Initialize from the text std::string
+		std::istringstream valStream(values);
+		if (type == "diag") {
+			// diagonal matrix with values given
+			for (int i = 0; i < rows; i++) {
+				for (int j = 0; j < columns; j++) {
+					theMatrix[i][j] = 0.0; // Non-diagonal elements are zero
+					if (i == j) {
+						valStream >> theMatrix[i][j];
+						theMatrix[i][j] *= multiplier;
+					}
+				}
+			}
+		}
+		else if (type == "complete") {
+			// complete matrix with values given
+			for (int i = 0; i < rows; i++) {
+				for (int j = 0; j < columns; j++) {
+					valStream >> theMatrix[i][j];
+					theMatrix[i][j] *= multiplier;
+				}
+			}
+		}
+		else {
+			clear();
+			throw Matrix_invalid_argument("Illegal type for CompleteMatrix with 'none' init: " + type);
+		}
+	}
+	else if (init == "const") {
+		if (type == "diag") {
+			// diagonal matrix with constant values
+			for (int i = 0; i < rows; i++) {
+				for (int j = 0; j < columns; j++) {
+					theMatrix[i][j] = 0.0; // Non-diagonal elements are zero
+					if (i == j) theMatrix[i][j] = multiplier;
+				}
+			}
+		}
+		else if (type == "complete") {
+			// complete matrix with constant values
+			for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) theMatrix[i][j] = multiplier; }
+		}
+		else {
+			clear();
+			throw Matrix_invalid_argument("Illegal type for CompleteMatrix with 'none' init: " + type);
+		}
+	}
+	//  else if (init == "random")
+	DEBUG_MATRIX(std::cerr << "\tInitialized " << type << " matrix" << std::endl;)
 }
 
 
 // "Copy Constructor"
-CompleteMatrix::CompleteMatrix(const CompleteMatrix& oldM) : theMatrix(nullptr)
-{
-    DEBUG_MATRIX(std::cerr << "CompleteMatrix copy constructor:" << std::endl;)
-    copy(oldM);
+CompleteMatrix::CompleteMatrix(const CompleteMatrix& oldM) : theMatrix(nullptr) {
+	DEBUG_MATRIX(std::cerr << "CompleteMatrix copy constructor:" << std::endl;)
+	copy(oldM);
 }
 
 // Destructor
-CompleteMatrix::~CompleteMatrix()
-{
-    DEBUG_MATRIX(std::cerr << "Destroying CompleteMatrix" << std::endl;)
-    clear();
+CompleteMatrix::~CompleteMatrix() {
+	DEBUG_MATRIX(std::cerr << "Destroying CompleteMatrix" << std::endl;)
+	clear();
 }
 
 
 // Assignment operator
-CompleteMatrix& CompleteMatrix::operator=(const CompleteMatrix& rhs)
-{
-    if (&rhs == this)
-        return *this;
-    
-    DEBUG_MATRIX(std::cerr << "CompleteMatrix::operator=" << std::endl;)
-    
-    clear();
-    DEBUG_MATRIX(std::cerr << "\t\tclear() complete, ready to copy." << std::endl;)
-    copy(rhs);
-    DEBUG_MATRIX(std::cerr << "\t\tcopy() complete; returning by reference." << std::endl;)
-    return *this;
+CompleteMatrix& CompleteMatrix::operator=(const CompleteMatrix& rhs) {
+	if (&rhs == this) return *this;
+
+	DEBUG_MATRIX(std::cerr << "CompleteMatrix::operator=" << std::endl;)
+
+	clear();
+	DEBUG_MATRIX(std::cerr << "\t\tclear() complete, ready to copy." << std::endl;)
+	copy(rhs);
+	DEBUG_MATRIX(std::cerr << "\t\tcopy() complete; returning by reference." << std::endl;)
+	return *this;
 }
 
 // Clear out storage
-void CompleteMatrix::clear(void)
-{
-    DEBUG_MATRIX(std::cerr << "\tclearing " << rows << "X" << columns << " CompleteMatrix...";)
-    
-    if (theMatrix != nullptr) {
-        for (int i=0; i<rows; i++)
-            if (theMatrix[i] != nullptr) {
-                delete [] theMatrix[i];
-                theMatrix[i] = nullptr;
-            }
-        delete [] theMatrix;
-        theMatrix = nullptr;
-    }
-    DEBUG_MATRIX(std::cerr << "done." << std::endl;)
+void CompleteMatrix::clear(void) {
+	DEBUG_MATRIX(std::cerr << "\tclearing " << rows << "X" << columns << " CompleteMatrix...";)
+
+	if (theMatrix != nullptr) {
+		for (int i = 0; i < rows; i++) {
+			if (theMatrix[i] != nullptr) {
+				delete [] theMatrix[i];
+				theMatrix[i] = nullptr;
+			}
+		}
+		delete [] theMatrix;
+		theMatrix = nullptr;
+	}
+	DEBUG_MATRIX(std::cerr << "done." << std::endl;)
 }
 
 
 // Copy matrix to this one
-void CompleteMatrix::copy(const CompleteMatrix& source)
-{
-    DEBUG_MATRIX(std::cerr << "\tcopying " << source.rows << "X" << source.columns
-                 << " CompleteMatrix...";)
-    
-    SetAttributes(source.type, source.init, source.rows,
-                  source.columns, source.multiplier, source.dimensions);
-    
-    alloc(rows, columns);
-    
-    for (int i=0; i<rows; i++)
-        for (int j=0; j<columns; j++)
-            theMatrix[i][j] = source.theMatrix[i][j];
-    DEBUG_MATRIX(std::cerr << "\t\tdone." << std::endl;)
+void CompleteMatrix::copy(const CompleteMatrix& source) {
+	DEBUG_MATRIX(std::cerr << "\tcopying " << source.rows << "X" << source.columns
+		<< " CompleteMatrix...";)
+
+	SetAttributes(source.type, source.init, source.rows,
+	              source.columns, source.multiplier, source.dimensions);
+
+	alloc(rows, columns);
+
+	for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) theMatrix[i][j] = source.theMatrix[i][j]; }
+	DEBUG_MATRIX(std::cerr << "\t\tdone." << std::endl;)
 }
 
 
@@ -173,48 +170,43 @@ void CompleteMatrix::copy(const CompleteMatrix& source)
 ///       what():  St9bad_alloc "
 ///
 /// Please refer to LIFModel::Connections()
-void CompleteMatrix::alloc(int rows, int columns)
-{
-    if (theMatrix != nullptr)
-        throw MatrixException("Attempt to allocate storage for non-cleared Matrix");
-    
-    if ((theMatrix = new BGFLOAT*[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
-    
-    for (int i=0; i<rows; i++)
-        if ((theMatrix[i] = new BGFLOAT[columns]) == nullptr)
-            throw Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
-    DEBUG_MATRIX(std::cerr << "\tStorage allocated for "<< rows << "X" << columns << " Matrix." << std::endl;)
-    
+void CompleteMatrix::alloc(int rows, int columns) {
+	if (theMatrix != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared Matrix");
+
+	if ((theMatrix = new BGFLOAT*[rows]) == nullptr) throw
+		Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
+
+	for (int i = 0; i < rows; i++) {
+		if ((theMatrix[i] = new BGFLOAT[columns]) == nullptr) throw Matrix_bad_alloc(
+			"Failed allocating storage to copy Matrix.");
+	}
+	DEBUG_MATRIX(std::cerr << "\tStorage allocated for "<< rows << "X" << columns << " Matrix." << std::endl;)
+
 }
 
 
 /// @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
 /// @param os stream to output to
-void CompleteMatrix::Print(std::ostream& os) const
-{
-    for (int i=0; i<rows; i++) {
-        for (int j=0; j<columns; j++)
-            os << theMatrix[i][j] << " ";
-        os << std::endl;
-    }
+void CompleteMatrix::Print(std::ostream& os) const {
+	for (int i = 0; i < rows; i++) {
+		for (int j = 0; j < columns; j++) os << theMatrix[i][j] << " ";
+		os << std::endl;
+	}
 }
 
 // convert Matrix to XML std::string
-std::string CompleteMatrix::toXML(std::string name) const
-{
-    std::stringstream os;
-    
-    os << "<Matrix ";
-    if (name != "")
-        os << "name=\"" << name << "\" ";
-    os << "type=\"complete\" rows=\"" << rows
-    << "\" columns=\"" << columns
-    << "\" multiplier=\"1.0\">" << std::endl;
-    os << "   " << *this << std::endl;
-    os << "</Matrix>";
-    
-    return os.str();
+std::string CompleteMatrix::toXML(std::string name) const {
+	std::stringstream os;
+
+	os << "<Matrix ";
+	if (name != "") os << "name=\"" << name << "\" ";
+	os << "type=\"complete\" rows=\"" << rows
+		<< "\" columns=\"" << columns
+		<< "\" multiplier=\"1.0\">" << std::endl;
+	os << "   " << *this << std::endl;
+	os << "</Matrix>";
+
+	return os.str();
 }
 
 
@@ -222,37 +214,31 @@ std::string CompleteMatrix::toXML(std::string name) const
 // implemented as being "aware" of each other (i.e., using "friend"
 // and including the other subclasses' headers).
 
-const CompleteMatrix CompleteMatrix::operator+(const CompleteMatrix& rhs) const
-{
-    if ((rhs.rows != rows) || (rhs.columns != columns)) {
-        throw Matrix_domain_error("Illegal matrix addition: dimension mismatch");
-    }
-    // Start with this
-    CompleteMatrix result(*this);
-    // Add in rhs
-    for (int i=0; i<rows; i++)
-        for (int j=0; j<columns; j++)
-            result.theMatrix[i][j] += rhs.theMatrix[i][j];
-    
-    return result;
+const CompleteMatrix CompleteMatrix::operator+(const CompleteMatrix& rhs) const {
+	if ((rhs.rows != rows) || (rhs.columns != columns)) throw Matrix_domain_error(
+		"Illegal matrix addition: dimension mismatch");
+	// Start with this
+	CompleteMatrix result(*this);
+	// Add in rhs
+	for (int i = 0; i < rows; i++) { for (int j = 0; j < columns; j++) result.theMatrix[i][j] += rhs.theMatrix[i][j]; }
+
+	return result;
 }
 
 
 // Multiply the rhs into the current object
-const CompleteMatrix CompleteMatrix::operator*(const CompleteMatrix& rhs) const
-{
-    throw Matrix_domain_error("CompleteMatrix product not yet implemented");
+const CompleteMatrix CompleteMatrix::operator*(const CompleteMatrix& rhs) const {
+	throw Matrix_domain_error("CompleteMatrix product not yet implemented");
 }
 
 // Element-wise square root of a vector
-const CompleteMatrix sqrt(const CompleteMatrix& m)
-{
-    // Start with vector
-    CompleteMatrix result(m);
-    
-    for (int i=0; i<result.rows; i++)
-        for (int j=0; j < result.columns; j++)
-            result.theMatrix[i][j] = sqrt(result.theMatrix[i][j]);
-    
-    return result;
+const CompleteMatrix sqrt(const CompleteMatrix& m) {
+	// Start with vector
+	CompleteMatrix result(m);
+
+	for (int i = 0; i < result.rows; i++) {
+		for (int j = 0; j < result.columns; j++) result.theMatrix[i][j] = sqrt(result.theMatrix[i][j]);
+	}
+
+	return result;
 }

--- a/Simulator/Utils/Matrix/CompleteMatrix.cpp
+++ b/Simulator/Utils/Matrix/CompleteMatrix.cpp
@@ -32,12 +32,12 @@
 /// @param r rows in Matrix (defaults to 2)
 /// @param c columns in Matrix (defaults to 2)
 /// @param m multiplier used for initialization (defaults to zero)
-/// @param v values for initializing CompleteMatrix (this string is parsed as a list of floating point numbers)
-CompleteMatrix::CompleteMatrix(string t, string i, int r,
-                               int c, BGFLOAT m, string values)
+/// @param v values for initializing CompleteMatrix (this std::string is parsed as a list of floating point numbers)
+CompleteMatrix::CompleteMatrix(std::string t, std::string i, int r,
+                               int c, BGFLOAT m, std::string values)
 : Matrix(t, i, r, c, m), theMatrix(nullptr)
 {
-    DEBUG_MATRIX(cerr << "Creating CompleteMatrix, size: ";)
+    DEBUG_MATRIX(std::cerr << "Creating CompleteMatrix, size: ";)
     
     // Bail out if we're being asked to create nonsense
     if (!((rows > 0) && (columns > 0)))
@@ -46,13 +46,13 @@ CompleteMatrix::CompleteMatrix(string t, string i, int r,
     // We're a 2D Matrix, even if only one row or column
     dimensions = 2;
     
-    DEBUG_MATRIX( cerr << rows << "X" << columns << ":" << endl;)
+    DEBUG_MATRIX( std::cerr << rows << "X" << columns << ":" << std::endl;)
     
     // Allocate storage
     alloc(rows, columns);
     
-    if (values != "") {     // Initialize from the text string
-        istringstream valStream(values);
+    if (values != "") {     // Initialize from the text std::string
+        std::istringstream valStream(values);
         if (type == "diag") {       // diagonal matrix with values given
             for (int i=0; i<rows; i++) {
                 for (int j=0; j<columns; j++) {
@@ -95,21 +95,21 @@ CompleteMatrix::CompleteMatrix(string t, string i, int r,
         }
     }
     //  else if (init == "random")
-    DEBUG_MATRIX(cerr << "\tInitialized " << type << " matrix" << endl;)
+    DEBUG_MATRIX(std::cerr << "\tInitialized " << type << " matrix" << std::endl;)
 }
 
 
 // "Copy Constructor"
 CompleteMatrix::CompleteMatrix(const CompleteMatrix& oldM) : theMatrix(nullptr)
 {
-    DEBUG_MATRIX(cerr << "CompleteMatrix copy constructor:" << endl;)
+    DEBUG_MATRIX(std::cerr << "CompleteMatrix copy constructor:" << std::endl;)
     copy(oldM);
 }
 
 // Destructor
 CompleteMatrix::~CompleteMatrix()
 {
-    DEBUG_MATRIX(cerr << "Destroying CompleteMatrix" << endl;)
+    DEBUG_MATRIX(std::cerr << "Destroying CompleteMatrix" << std::endl;)
     clear();
 }
 
@@ -120,19 +120,19 @@ CompleteMatrix& CompleteMatrix::operator=(const CompleteMatrix& rhs)
     if (&rhs == this)
         return *this;
     
-    DEBUG_MATRIX(cerr << "CompleteMatrix::operator=" << endl;)
+    DEBUG_MATRIX(std::cerr << "CompleteMatrix::operator=" << std::endl;)
     
     clear();
-    DEBUG_MATRIX(cerr << "\t\tclear() complete, ready to copy." << endl;)
+    DEBUG_MATRIX(std::cerr << "\t\tclear() complete, ready to copy." << std::endl;)
     copy(rhs);
-    DEBUG_MATRIX(cerr << "\t\tcopy() complete; returning by reference." << endl;)
+    DEBUG_MATRIX(std::cerr << "\t\tcopy() complete; returning by reference." << std::endl;)
     return *this;
 }
 
 // Clear out storage
 void CompleteMatrix::clear(void)
 {
-    DEBUG_MATRIX(cerr << "\tclearing " << rows << "X" << columns << " CompleteMatrix...";)
+    DEBUG_MATRIX(std::cerr << "\tclearing " << rows << "X" << columns << " CompleteMatrix...";)
     
     if (theMatrix != nullptr) {
         for (int i=0; i<rows; i++)
@@ -143,14 +143,14 @@ void CompleteMatrix::clear(void)
         delete [] theMatrix;
         theMatrix = nullptr;
     }
-    DEBUG_MATRIX(cerr << "done." << endl;)
+    DEBUG_MATRIX(std::cerr << "done." << std::endl;)
 }
 
 
 // Copy matrix to this one
 void CompleteMatrix::copy(const CompleteMatrix& source)
 {
-    DEBUG_MATRIX(cerr << "\tcopying " << source.rows << "X" << source.columns
+    DEBUG_MATRIX(std::cerr << "\tcopying " << source.rows << "X" << source.columns
                  << " CompleteMatrix...";)
     
     SetAttributes(source.type, source.init, source.rows,
@@ -161,7 +161,7 @@ void CompleteMatrix::copy(const CompleteMatrix& source)
     for (int i=0; i<rows; i++)
         for (int j=0; j<columns; j++)
             theMatrix[i][j] = source.theMatrix[i][j];
-    DEBUG_MATRIX(cerr << "\t\tdone." << endl;)
+    DEBUG_MATRIX(std::cerr << "\t\tdone." << std::endl;)
 }
 
 
@@ -184,34 +184,34 @@ void CompleteMatrix::alloc(int rows, int columns)
     for (int i=0; i<rows; i++)
         if ((theMatrix[i] = new BGFLOAT[columns]) == nullptr)
             throw Matrix_bad_alloc("Failed allocating storage to copy Matrix.");
-    DEBUG_MATRIX(cerr << "\tStorage allocated for "<< rows << "X" << columns << " Matrix." << endl;)
+    DEBUG_MATRIX(std::cerr << "\tStorage allocated for "<< rows << "X" << columns << " Matrix." << std::endl;)
     
 }
 
 
 /// @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
 /// @param os stream to output to
-void CompleteMatrix::Print(ostream& os) const
+void CompleteMatrix::Print(std::ostream& os) const
 {
     for (int i=0; i<rows; i++) {
         for (int j=0; j<columns; j++)
             os << theMatrix[i][j] << " ";
-        os << endl;
+        os << std::endl;
     }
 }
 
-// convert Matrix to XML string
-string CompleteMatrix::toXML(string name) const
+// convert Matrix to XML std::string
+std::string CompleteMatrix::toXML(std::string name) const
 {
-    stringstream os;
+    std::stringstream os;
     
     os << "<Matrix ";
     if (name != "")
         os << "name=\"" << name << "\" ";
     os << "type=\"complete\" rows=\"" << rows
     << "\" columns=\"" << columns
-    << "\" multiplier=\"1.0\">" << endl;
-    os << "   " << *this << endl;
+    << "\" multiplier=\"1.0\">" << std::endl;
+    os << "   " << *this << std::endl;
     os << "</Matrix>";
     
     return os.str();

--- a/Simulator/Utils/Matrix/CompleteMatrix.h
+++ b/Simulator/Utils/Matrix/CompleteMatrix.h
@@ -73,7 +73,7 @@ class CompleteMatrix : public Matrix {
 		///  @param row element row
 		///  @param column element column
 		///  @return reference to element (lvalue)
-		inline BGFLOAT& operator()(int row, int column) { return theMatrix[row][column]; }
+		BGFLOAT& operator()(int row, int column) { return theMatrix[row][column]; }
 
 		///  @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
 		///  @param os stream to output to

--- a/Simulator/Utils/Matrix/CompleteMatrix.h
+++ b/Simulator/Utils/Matrix/CompleteMatrix.h
@@ -13,8 +13,6 @@
 #include "Matrix.h"
 #include "VectorMatrix.h"
 
-using namespace std;
-
 // Forward declarations
 class CompleteMatrix;
 
@@ -57,9 +55,9 @@ public:
   ///  @param r rows in Matrix (defaults to 2)
   ///  @param c columns in Matrix (defaults to 2)
   ///  @param m multiplier used for initialization (defaults to zero)
-  ///  @param v values for initializing CompleteMatrix (this string is parsed as a list of floating point numbers)
-  CompleteMatrix(string t = "complete", string i = "const", int r = 2,
-		 int c = 2, BGFLOAT m = 0.0, string v = "");
+  ///  @param v values for initializing CompleteMatrix (this std::string is parsed as a list of floating point numbers)
+  CompleteMatrix(std::string t = "complete", std::string i = "const", int r = 2,
+		 int c = 2, BGFLOAT m = 0.0, std::string v = "");
 
   ///  @brief Copy constructor. Performs a deep copy.
   ///  @param oldM The source CompleteMatrix
@@ -82,11 +80,11 @@ public:
 
   ///  @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
   ///  @param os stream to output to
-  virtual void Print(ostream& os) const;
+  virtual void Print(std::ostream& os) const;
 
-  ///  @brief Produce XML representation of Matrix in string return value.
+  ///  @brief Produce XML representation of Matrix in std::string return value.
   ///  @param name name attribute for XML
-  virtual string toXML(string name="") const;
+  virtual std::string toXML(std::string name="") const;
 
   /******************************************
    * @name Math operations

--- a/Simulator/Utils/Matrix/CompleteMatrix.h
+++ b/Simulator/Utils/Matrix/CompleteMatrix.h
@@ -31,125 +31,118 @@ const CompleteMatrix sqrt(const CompleteMatrix& m);
 ///  most classes would be, with the hope that compilers will optimize
 ///  out unnecessary copying of objects that are intermediate results in
 ///  numerical computations.
-class CompleteMatrix : public Matrix
-{
-   friend class VectorMatrix;
+class CompleteMatrix : public Matrix {
+	friend class VectorMatrix;
 
-public:
+	public:
+		///  Allocate storage and initialize attributes. If "v" (values) is
+		///  not empty, it will be used as a source of data for initializing
+		///  the matrix (and must be a list of whitespace separated textual
+		///  numeric data with rows * columns elements, if "t" (type) is
+		///  "complete", or number of elements in diagonal, if "t" is "diag").
+		///  
+		///  If "i" (initialization) is "const", then "m" will be used to initialize either all
+		///  elements (for a "complete" matrix) or diagonal elements (for "diag").
+		/// 
+		///  "random" initialization is not yet implemented.
+		/// 
+		///  @throws Matrix_bad_alloc
+		///  @throws Matrix_invalid_argument
+		///  @param t Matrix type (defaults to "complete")
+		///  @param i Matrix initialization (defaults to "const")
+		///  @param r rows in Matrix (defaults to 2)
+		///  @param c columns in Matrix (defaults to 2)
+		///  @param m multiplier used for initialization (defaults to zero)
+		///  @param v values for initializing CompleteMatrix (this std::string is parsed as a list of floating point numbers)
+		CompleteMatrix(std::string t = "complete", std::string i = "const", int r = 2,
+		               int c = 2, BGFLOAT m = 0.0, std::string v = "");
 
-  ///  Allocate storage and initialize attributes. If "v" (values) is
-  ///  not empty, it will be used as a source of data for initializing
-  ///  the matrix (and must be a list of whitespace separated textual
-  ///  numeric data with rows * columns elements, if "t" (type) is
-  ///  "complete", or number of elements in diagonal, if "t" is "diag").
-  ///  
-  ///  If "i" (initialization) is "const", then "m" will be used to initialize either all
-  ///  elements (for a "complete" matrix) or diagonal elements (for "diag").
-  /// 
-  ///  "random" initialization is not yet implemented.
-  /// 
-  ///  @throws Matrix_bad_alloc
-  ///  @throws Matrix_invalid_argument
-  ///  @param t Matrix type (defaults to "complete")
-  ///  @param i Matrix initialization (defaults to "const")
-  ///  @param r rows in Matrix (defaults to 2)
-  ///  @param c columns in Matrix (defaults to 2)
-  ///  @param m multiplier used for initialization (defaults to zero)
-  ///  @param v values for initializing CompleteMatrix (this std::string is parsed as a list of floating point numbers)
-  CompleteMatrix(std::string t = "complete", std::string i = "const", int r = 2,
-		 int c = 2, BGFLOAT m = 0.0, std::string v = "");
+		///  @brief Copy constructor. Performs a deep copy.
+		///  @param oldM The source CompleteMatrix
+		CompleteMatrix(const CompleteMatrix& oldM);
 
-  ///  @brief Copy constructor. Performs a deep copy.
-  ///  @param oldM The source CompleteMatrix
-  CompleteMatrix(const CompleteMatrix& oldM);
+		///  @brief De-allocate storage
+		~CompleteMatrix() override;
 
-  ///  @brief De-allocate storage
-  virtual ~CompleteMatrix();
+		///  @brief Assignment operator
+		///  @param rhs right-hand side of assignment
+		///  @return returns reference to this CompleteMatrix (after assignment)
+		CompleteMatrix& operator=(const CompleteMatrix& rhs);
 
-  ///  @brief Assignment operator
-  ///  @param rhs right-hand side of assignment
-  ///  @return returns reference to this CompleteMatrix (after assignment)
-  CompleteMatrix& operator=(const CompleteMatrix& rhs);
+		///  @brief access element at (row, column) -- mutator
+		///  @param row element row
+		///  @param column element column
+		///  @return reference to element (lvalue)
+		inline BGFLOAT& operator()(int row, int column) { return theMatrix[row][column]; }
 
-  ///  @brief access element at (row, column) -- mutator
-  ///  @param row element row
-  ///  @param column element column
-  ///  @return reference to element (lvalue)
-  inline BGFLOAT& operator()(int row, int column)
-  { return theMatrix[row][column]; }
+		///  @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
+		///  @param os stream to output to
+		void Print(std::ostream& os) const override;
 
-  ///  @brief Polymorphic output. Produces text output on stream os. Used by operator<<()
-  ///  @param os stream to output to
-  virtual void Print(std::ostream& os) const;
+		///  @brief Produce XML representation of Matrix in std::string return value.
+		///  @param name name attribute for XML
+		virtual std::string toXML(std::string name = "") const;
 
-  ///  @brief Produce XML representation of Matrix in std::string return value.
-  ///  @param name name attribute for XML
-  virtual std::string toXML(std::string name="") const;
+		/******************************************
+		 * @name Math operations
+		 * 
+		 * For efficiency's sake, these methods will be 
+		 * implemented as being "aware" of each other (i.e., using "friend"
+		 * and including the other subclasses' headers).
+		******************************************/
+		//@{
 
-  /******************************************
-   * @name Math operations
-   * 
-   * For efficiency's sake, these methods will be 
-   * implemented as being "aware" of each other (i.e., using "friend"
-   * and including the other subclasses' headers).
-  ******************************************/
-  //@{
+		///  @brief Compute the sum of two CompleteMatrices of the same rows and columns.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the addition. Must have same
+		///  dimensions as this.
+		///  @return A new CompleteMatrix, with value equal to the sum of this
+		///  one and rhs and rows and columns the same as both, returned by value.
+		virtual const CompleteMatrix operator+(const CompleteMatrix& rhs) const;
 
-  ///  @brief Compute the sum of two CompleteMatrices of the same rows and columns.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the addition. Must have same
-  ///  dimensions as this.
-  ///  @return A new CompleteMatrix, with value equal to the sum of this
-  ///  one and rhs and rows and columns the same as both, returned by value.
-  virtual const CompleteMatrix operator+(const CompleteMatrix& rhs) const;
+		///  Matrix product. Number of rows of "rhs" must equal to
+		///  number of columns of this.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the product.
+		///  @return A CompleteMatrix with number of rows equal to this and
+		///  number of columns equal to "rhs".
+		virtual const CompleteMatrix operator*(const CompleteMatrix& rhs) const;
+		//@}
 
-  ///  Matrix product. Number of rows of "rhs" must equal to
-  ///  number of columns of this.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the product.
-  ///  @return A CompleteMatrix with number of rows equal to this and
-  ///  number of columns equal to "rhs".
-  virtual const CompleteMatrix operator*(const CompleteMatrix& rhs) const;
-  //@}
+		friend
+		const CompleteMatrix sqrt(const CompleteMatrix& v);
 
-  friend
-  const CompleteMatrix sqrt(const CompleteMatrix& v);
+	protected:
+		/******************************************
+		 * @name Internal Utilities
+		******************************************/
+		//@{
 
-protected:
+		///  @brief Frees up all dynamically allocated storage
+		void clear(void);
 
-  /******************************************
-   * @name Internal Utilities
-  ******************************************/
-  //@{
+		///  Performs a deep copy. It is assumed that the storage
+		///  allocate to theMatrix has already been deleted.
+		///  @param source VectorMatrix to copy from
+		void copy(const CompleteMatrix& source);
 
-  ///  @brief Frees up all dynamically allocated storage
-  void clear(void);
+		///  @brief Allocates storage for internal Matrix storage
+		///  @throws Matrix_bad_alloc
+		///  @throws MatrixException
+		///  @param rows number of Matrix rows
+		///  @param cols number of Matrix cols
+		void alloc(int rows, int cols);
 
-  ///  Performs a deep copy. It is assumed that the storage
-  ///  allocate to theMatrix has already been deleted.
-  ///  @param source VectorMatrix to copy from
-  void copy(const CompleteMatrix& source);
+		//@}
 
-  ///  @brief Allocates storage for internal Matrix storage
-  ///  @throws Matrix_bad_alloc
-  ///  @throws MatrixException
-  ///  @param rows number of Matrix rows
-  ///  @param cols number of Matrix cols
-  void alloc(int rows, int cols);
+		// access adjustment --- allow member functions in this class to
+		// access protected member of base class in other objects.
+		using Matrix::dimensions;
+		using Matrix::rows;
+		using Matrix::columns;
 
-  //@}
-
-  // access adjustment --- allow member functions in this class to
-  // access protected member of base class in other objects.
-  using Matrix::dimensions;
-  using Matrix::rows;
-  using Matrix::columns;
-
-private:
-
-  /// Pointer to dynamically allocated 2D array
-  BGFLOAT **theMatrix;
+	private:
+		/// Pointer to dynamically allocated 2D array
+		BGFLOAT** theMatrix;
 
 };
-
-

--- a/Simulator/Utils/Matrix/Matrix.cpp
+++ b/Simulator/Utils/Matrix/Matrix.cpp
@@ -21,8 +21,8 @@
 
 // Initialize attributes at construction time
 // The subclass constructor must set dimensions
-Matrix::Matrix(string t, string i, int r, int c, BGFLOAT m)
-  : type(t), init(i), rows(r), columns(c), multiplier(m), dimensions(0) {}
+Matrix::Matrix(std::string t, std::string i, int r, int c, BGFLOAT m)
+	: type(t), init(i), rows(r), columns(c), multiplier(m), dimensions(0) {}
 
 
 /// @brief Convenience mutator
@@ -32,15 +32,14 @@ Matrix::Matrix(string t, string i, int r, int c, BGFLOAT m)
 /// @param c columns in Matrix
 /// @param m multiplier used for initialization
 /// @param d indicates one or two dimensional
-void Matrix::SetAttributes(string t, string i, int r, int c,
-			   BGFLOAT m, int d)
-{
-  type = t;
-  init = i;
-  rows = r;
-  columns = c;
-  multiplier = m;
-  dimensions = d;
+void Matrix::SetAttributes(std::string t, std::string i, int r, int c,
+                           BGFLOAT m, int d) {
+	type = t;
+	init = i;
+	rows = r;
+	columns = c;
+	multiplier = m;
+	dimensions = d;
 }
 
 
@@ -49,8 +48,7 @@ void Matrix::SetAttributes(string t, string i, int r, int c,
 /// to take advantage of this.
 /// @param os the output stream
 /// @param obj the Matrix object to send to the output stream
-ostream& operator<<(ostream& os, const Matrix& obj)
-{
-  obj.Print(os);
-  return os;
+std::ostream& operator<<(std::ostream& os, const Matrix& obj) {
+	obj.Print(os);
+	return os;
 }

--- a/Simulator/Utils/Matrix/Matrix.cpp
+++ b/Simulator/Utils/Matrix/Matrix.cpp
@@ -15,8 +15,8 @@
  * using only Matrix objects.
  */
 
-#include <iostream>
 #include "Matrix.h"
+#include <iostream>
 #include "BGTypes.h"
 
 // Initialize attributes at construction time

--- a/Simulator/Utils/Matrix/Matrix.h
+++ b/Simulator/Utils/Matrix/Matrix.h
@@ -22,8 +22,6 @@
 #include "MatrixExceptions.h"
 #include "BGTypes.h"
 
-using namespace std;
-
 class Matrix
       {
       public:
@@ -31,7 +29,7 @@ class Matrix
          virtual ~Matrix() { }
 
          /// @brief Generate text representation of the Matrix to a stream
-         virtual void Print(ostream& os) const = 0;
+         virtual void Print(std::ostream& os) const = 0;
 
       protected:
          ///   Initialize attributes at construction time. This is protected to
@@ -44,7 +42,7 @@ class Matrix
          ///   @param r rows in Matrix
          ///   @param c columns in Matrix
          ///   @param m multiplier used for initialization
-         Matrix(string t = "", string i = "", int r = 0, int c = 0, BGFLOAT m = 0.0);
+         Matrix(std::string t = "", std::string i = "", int r = 0, int c = 0, BGFLOAT m = 0.0);
 
          ///  @brief Convenience mutator
          ///  @param t Matrix type (subclasses add legal values; basically, cheapo reflection)
@@ -53,7 +51,7 @@ class Matrix
          ///  @param c columns in Matrix
          ///  @param m multiplier used for initialization
          ///  @param d indicates one or two dimensional
-         void SetAttributes(string t, string i, int r, int c, BGFLOAT m, int d);
+         void SetAttributes(std::string t, std::string i, int r, int c, BGFLOAT m, int d);
 
          /******************************************
           * @name Attributes from XML files 
@@ -63,12 +61,12 @@ class Matrix
          /// "complete" == all locations nonzero,
          /// "diag" == only diagonal elements nonzero,
          /// or "sparse" == nonzero values may be anywhere
-         string type;
+         std::string type;
 
          /// "const" == nonzero values with a fixed constant,
          /// "random" == nonzero values with random numbers,
          /// or "implementation" == uses a built-in function of the specific subclass
-         string init;
+         std::string init;
 
          int rows;                  ///< Number of rows in Matrix (>0)
          int columns;               ///< Number of columns in Matrix (>0)
@@ -82,7 +80,7 @@ class Matrix
 ///  to take advantage of this.
 ///  @param os the output stream
 ///  @param obj the Matrix object to send to the output stream
-ostream& operator<<(ostream& os, const Matrix& obj);
+std::ostream& operator<<(std::ostream& os, const Matrix& obj);
 
 #endif
 

--- a/Simulator/Utils/Matrix/Matrix.h
+++ b/Simulator/Utils/Matrix/Matrix.h
@@ -19,61 +19,60 @@
 #define _MATRIX_H_
 
 #include <string>
-#include "MatrixExceptions.h"
 #include "BGTypes.h"
+#include "MatrixExceptions.h"
 
-class Matrix
-      {
-      public:
-         /// Virtual Destructor
-         virtual ~Matrix() { }
+class Matrix {
+	public:
+		/// Virtual Destructor
+		virtual ~Matrix() { }
 
-         /// @brief Generate text representation of the Matrix to a stream
-         virtual void Print(std::ostream& os) const = 0;
+		/// @brief Generate text representation of the Matrix to a stream
+		virtual void Print(std::ostream& os) const = 0;
 
-      protected:
-         ///   Initialize attributes at construction time. This is protected to
-         ///   prevent construction of Matrix objects themselves. Would be nice
-         ///   if C++ just allowed one to declare a class abstract. Really
-         ///   obsoleted since the Print() method is pure virtual now.
-         ///
-         ///   @param t Matrix type (subclasses add legal values; basically, cheapo reflection)
-         ///   @param i Matrix initialization (subclasses can also add legal values to this)
-         ///   @param r rows in Matrix
-         ///   @param c columns in Matrix
-         ///   @param m multiplier used for initialization
-         Matrix(std::string t = "", std::string i = "", int r = 0, int c = 0, BGFLOAT m = 0.0);
+	protected:
+		///   Initialize attributes at construction time. This is protected to
+		///   prevent construction of Matrix objects themselves. Would be nice
+		///   if C++ just allowed one to declare a class abstract. Really
+		///   obsoleted since the Print() method is pure virtual now.
+		///
+		///   @param t Matrix type (subclasses add legal values; basically, cheapo reflection)
+		///   @param i Matrix initialization (subclasses can also add legal values to this)
+		///   @param r rows in Matrix
+		///   @param c columns in Matrix
+		///   @param m multiplier used for initialization
+		Matrix(std::string t = "", std::string i = "", int r = 0, int c = 0, BGFLOAT m = 0.0);
 
-         ///  @brief Convenience mutator
-         ///  @param t Matrix type (subclasses add legal values; basically, cheapo reflection)
-         ///  @param i Matrix initialization (subclasses can also add legal values to this)
-         ///  @param r rows in Matrix
-         ///  @param c columns in Matrix
-         ///  @param m multiplier used for initialization
-         ///  @param d indicates one or two dimensional
-         void SetAttributes(std::string t, std::string i, int r, int c, BGFLOAT m, int d);
+		///  @brief Convenience mutator
+		///  @param t Matrix type (subclasses add legal values; basically, cheapo reflection)
+		///  @param i Matrix initialization (subclasses can also add legal values to this)
+		///  @param r rows in Matrix
+		///  @param c columns in Matrix
+		///  @param m multiplier used for initialization
+		///  @param d indicates one or two dimensional
+		void SetAttributes(std::string t, std::string i, int r, int c, BGFLOAT m, int d);
 
-         /******************************************
-          * @name Attributes from XML files 
-         ******************************************/
-         ///@{
+		/******************************************
+		 * @name Attributes from XML files 
+		******************************************/
+		///@{
 
-         /// "complete" == all locations nonzero,
-         /// "diag" == only diagonal elements nonzero,
-         /// or "sparse" == nonzero values may be anywhere
-         std::string type;
+		/// "complete" == all locations nonzero,
+		/// "diag" == only diagonal elements nonzero,
+		/// or "sparse" == nonzero values may be anywhere
+		std::string type;
 
-         /// "const" == nonzero values with a fixed constant,
-         /// "random" == nonzero values with random numbers,
-         /// or "implementation" == uses a built-in function of the specific subclass
-         std::string init;
+		/// "const" == nonzero values with a fixed constant,
+		/// "random" == nonzero values with random numbers,
+		/// or "implementation" == uses a built-in function of the specific subclass
+		std::string init;
 
-         int rows;                  ///< Number of rows in Matrix (>0)
-         int columns;               ///< Number of columns in Matrix (>0)
-         BGFLOAT multiplier;     ///< Constant used for initialization
-         int dimensions;         ///< One or two dimensional
-         ///@}
-      };
+		int rows; ///< Number of rows in Matrix (>0)
+		int columns; ///< Number of columns in Matrix (>0)
+		BGFLOAT multiplier; ///< Constant used for initialization
+		int dimensions; ///< One or two dimensional
+		///@}
+};
 
 ///  Stream output operator for the Matrix class
 ///  hierarchy. Subclasses must implement the Print() method
@@ -83,5 +82,3 @@ class Matrix
 std::ostream& operator<<(std::ostream& os, const Matrix& obj);
 
 #endif
-
-

--- a/Simulator/Utils/Matrix/MatrixExceptions.h
+++ b/Simulator/Utils/Matrix/MatrixExceptions.h
@@ -12,38 +12,31 @@
 #include <stdexcept>
 
 /// Master base class for Matrix exceptions
-class MatrixException : public std::runtime_error
-{
-public:
-  explicit MatrixException(const std::string&  __arg) : runtime_error(__arg) {}
+class MatrixException : public std::runtime_error {
+	public:
+		explicit MatrixException(const std::string& __arg) : runtime_error(__arg) {}
 };
 
 /// Signals memory allocation error for Matrix classes
-class Matrix_bad_alloc : public MatrixException
-{
-public:
-  explicit Matrix_bad_alloc(const std::string&  __arg) : MatrixException(__arg) {}
+class Matrix_bad_alloc : public MatrixException {
+	public:
+		explicit Matrix_bad_alloc(const std::string& __arg) : MatrixException(__arg) {}
 };
 
 /// Signals bad cast among Matrices for Matrix classes
-class Matrix_bad_cast : public MatrixException
-{
-public:
-  explicit Matrix_bad_cast(const std::string&  __arg) : MatrixException(__arg) {}
+class Matrix_bad_cast : public MatrixException {
+	public:
+		explicit Matrix_bad_cast(const std::string& __arg) : MatrixException(__arg) {}
 };
 
 /// Signals bad function argument for Matrix classes
-class Matrix_invalid_argument : public MatrixException
-{
-public:
-  explicit Matrix_invalid_argument(const std::string&  __arg) : MatrixException(__arg) {}
+class Matrix_invalid_argument : public MatrixException {
+	public:
+		explicit Matrix_invalid_argument(const std::string& __arg) : MatrixException(__arg) {}
 };
- 
+
 /// Signals value bad for domain for Matrix classes
-class Matrix_domain_error : public MatrixException
-{
-public:
-  explicit Matrix_domain_error(const std::string&  __arg) : MatrixException(__arg) {}
+class Matrix_domain_error : public MatrixException {
+	public:
+		explicit Matrix_domain_error(const std::string& __arg) : MatrixException(__arg) {}
 };
-
-

--- a/Simulator/Utils/Matrix/MatrixExceptions.h
+++ b/Simulator/Utils/Matrix/MatrixExceptions.h
@@ -11,41 +11,39 @@
 
 #include <stdexcept>
 
-using namespace std;
-
 /// Master base class for Matrix exceptions
-class MatrixException : public runtime_error
+class MatrixException : public std::runtime_error
 {
 public:
-  explicit MatrixException(const string&  __arg) : runtime_error(__arg) {}
+  explicit MatrixException(const std::string&  __arg) : runtime_error(__arg) {}
 };
 
 /// Signals memory allocation error for Matrix classes
 class Matrix_bad_alloc : public MatrixException
 {
 public:
-  explicit Matrix_bad_alloc(const string&  __arg) : MatrixException(__arg) {}
+  explicit Matrix_bad_alloc(const std::string&  __arg) : MatrixException(__arg) {}
 };
 
 /// Signals bad cast among Matrices for Matrix classes
 class Matrix_bad_cast : public MatrixException
 {
 public:
-  explicit Matrix_bad_cast(const string&  __arg) : MatrixException(__arg) {}
+  explicit Matrix_bad_cast(const std::string&  __arg) : MatrixException(__arg) {}
 };
 
 /// Signals bad function argument for Matrix classes
 class Matrix_invalid_argument : public MatrixException
 {
 public:
-  explicit Matrix_invalid_argument(const string&  __arg) : MatrixException(__arg) {}
+  explicit Matrix_invalid_argument(const std::string&  __arg) : MatrixException(__arg) {}
 };
  
 /// Signals value bad for domain for Matrix classes
 class Matrix_domain_error : public MatrixException
 {
 public:
-  explicit Matrix_domain_error(const string&  __arg) : MatrixException(__arg) {}
+  explicit Matrix_domain_error(const std::string&  __arg) : MatrixException(__arg) {}
 };
 
 

--- a/Simulator/Utils/Matrix/MatrixFactory.h
+++ b/Simulator/Utils/Matrix/MatrixFactory.h
@@ -14,8 +14,6 @@
 #include "CompleteMatrix.h"
 #include "VectorMatrix.h"
 
-using namespace std;
-
 ///  @class MatrixFactory
 ///  @brief Deserializes Matrix objects from XML
 ///

--- a/Simulator/Utils/Matrix/SparseMatrix.cpp
+++ b/Simulator/Utils/Matrix/SparseMatrix.cpp
@@ -33,31 +33,31 @@ SparseMatrix::Element SparseMatrix::HashTable::deleted(-1, -1, -1.0);
 /// resize hash table and initialize elements to nullptr
 /// @param s table capacity
 /// @param c number of columns in containing SparseMatrix
-void SparseMatrix::HashTable::resize(int s, int c)
-{
-    // If nothing has changed, just clear the table to nullptr
-    if ((s == capacity) && (c == columns)) {
-        DEBUG_SPARSE(cerr << "\t\t\tSM::HT::resize(): table capacity unchanged; filling with nullptr." << endl;)
-        fill(table.begin(), table.end(), static_cast<Element*>(nullptr));
-        size = 0;
-    } else {
-        DEBUG_SPARSE(cerr << "\t\t\tSM::HT::resize(): table capacity changed." << endl;)
-        capacity = s;
-        columns = c;
-        table.resize(capacity, static_cast<Element*>(nullptr));
-        size = 0;
-    }
-    
-	DEBUG_SPARSE(cerr << "\t\t\tAllocated " << capacity << " locations for hash table" << endl;)
+void SparseMatrix::HashTable::resize(int s, int c) {
+	// If nothing has changed, just clear the table to nullptr
+	if ((s == capacity) && (c == columns)) {
+		DEBUG_SPARSE(
+			std::cerr << "\t\t\tSM::HT::resize(): table capacity unchanged; filling with nullptr." << std::endl;)
+		fill(table.begin(), table.end(), static_cast<Element*>(nullptr));
+		size = 0;
+	}
+	else {
+		DEBUG_SPARSE(std::cerr << "\t\t\tSM::HT::resize(): table capacity changed." << std::endl;)
+		capacity = s;
+		columns = c;
+		table.resize(capacity, static_cast<Element*>(nullptr));
+		size = 0;
+	}
+
+	DEBUG_SPARSE(std::cerr << "\t\t\tAllocated " << capacity << " locations for hash table" << std::endl;)
 }
 
 ///
 /// @method clear
 /// removes all elements from the hash table
-void SparseMatrix::HashTable::clear(void)
-{
-    // Use resize to clean up the table
-    resize(capacity, columns);
+void SparseMatrix::HashTable::clear(void) {
+	// Use resize to clean up the table
+	resize(capacity, columns);
 }
 
 /// @method insert
@@ -67,47 +67,44 @@ void SparseMatrix::HashTable::clear(void)
 /// @param el pointer to the Element to insert
 /// @throws Matrix_bad_alloc
 /// @throws Matrix_invalid_argument
-void SparseMatrix::HashTable::insert(Element* el)
-{
-    // Don't overfill the table
-    if (capacity == size+1)
-        throw Matrix_invalid_argument("SparseMatrix hash table full");
-    
-    int start = hash(el);
-    int loc = start;
-    
-	DEBUG_SPARSE(cerr << "\tInserting value " << el->value << " at ("
-                 << el->row << ", " << el->column << ")" << endl;)
-    
-    // Find first location to insert (if Element isn't in the table)
-    while ((table[loc] != &deleted) && (table[loc] != nullptr)) {
-        if (*table[loc] == *el)
-            throw Matrix_invalid_argument("Attempt to insert duplicate Element into SparseMatrix hash table [1]");
-        loc = (loc+1)%capacity;
-        if (loc == start)
-            throw Matrix_invalid_argument("Hashtable insert wraparound: unable to insert Element [1]");
-    }
-    
-    // If that first location is a deleted entry, then we need to
-    // continue searching to ensure the Element isn't in the table
-    if (table[loc] == &deleted) {
-        int loc2 = (loc+1)%capacity;
-        while (table[loc2] != nullptr) {
-            if (loc2 == start)
-                throw Matrix_invalid_argument("Hashtable insert wraparound: unable to insert Element [2]");
-            loc2 = (loc2+1)%capacity;
-            if (*table[loc2] == *el)
-                throw Matrix_invalid_argument("Attempt to insert duplicate Element into SparseMatrix hash table [2]");
-        }
-    }
-    
-    // At this point, either table[loc] is deleted or nullptr. Note that
-    // loc2 was only used to ensure we aren't inserting duplicates;
-    // table[loc] is the first available storage location.
-    table[loc] = el;
-    size++;
-    
-	DEBUG_SPARSE(cerr << "\tInserted at table location " << loc << endl;)
+void SparseMatrix::HashTable::insert(Element* el) {
+	// Don't overfill the table
+	if (capacity == size + 1) throw Matrix_invalid_argument("SparseMatrix hash table full");
+
+	int start = hash(el);
+	int loc = start;
+
+	DEBUG_SPARSE(std::cerr << "\tInserting value " << el->value << " at ("
+		<< el->row << ", " << el->column << ")" << std::endl;)
+
+	// Find first location to insert (if Element isn't in the table)
+	while ((table[loc] != &deleted) && (table[loc] != nullptr)) {
+		if (*table[loc] == *el) throw Matrix_invalid_argument(
+			"Attempt to insert duplicate Element into SparseMatrix hash table [1]");
+		loc = (loc + 1) % capacity;
+		if (loc == start) throw Matrix_invalid_argument("Hashtable insert wraparound: unable to insert Element [1]");
+	}
+
+	// If that first location is a deleted entry, then we need to
+	// continue searching to ensure the Element isn't in the table
+	if (table[loc] == &deleted) {
+		int loc2 = (loc + 1) % capacity;
+		while (table[loc2] != nullptr) {
+			if (loc2 == start) throw Matrix_invalid_argument(
+				"Hashtable insert wraparound: unable to insert Element [2]");
+			loc2 = (loc2 + 1) % capacity;
+			if (*table[loc2] == *el) throw Matrix_invalid_argument(
+				"Attempt to insert duplicate Element into SparseMatrix hash table [2]");
+		}
+	}
+
+	// At this point, either table[loc] is deleted or nullptr. Note that
+	// loc2 was only used to ensure we aren't inserting duplicates;
+	// table[loc] is the first available storage location.
+	table[loc] = el;
+	size++;
+
+	DEBUG_SPARSE(std::cerr << "\tInserted at table location " << loc << std::endl;)
 }
 
 
@@ -119,24 +116,23 @@ void SparseMatrix::HashTable::insert(Element* el)
 /// @param r row coordinate of Element
 /// @param c column coordinate of Element
 /// @result pointer to Element (nullptr if not in table)
-SparseMatrix::Element* SparseMatrix::HashTable::retrieve(int r, int c)
-{
-    int loc = hash(r, c);
-    
-    // Keep probing while we haven't found the Element (or finished the
-    // probing). Also, eliminate any Elements found with zero value.
-    while ((table[loc] != nullptr) && (!table[loc]->is_at(r, c))) {
-        if (table[loc]->value == 0.0) {
-            theMatrix->remove_lists(table[loc]);
-            table[loc] = &deleted;
-            size--;
-        }
-        loc = (loc+1)%capacity;
-    }
-    
-    // At this point, we either have the pointer to the Element or the
-    // nullptr pointer
-    return table[loc];
+SparseMatrix::Element* SparseMatrix::HashTable::retrieve(int r, int c) {
+	int loc = hash(r, c);
+
+	// Keep probing while we haven't found the Element (or finished the
+	// probing). Also, eliminate any Elements found with zero value.
+	while ((table[loc] != nullptr) && (!table[loc]->is_at(r, c))) {
+		if (table[loc]->value == 0.0) {
+			theMatrix->remove_lists(table[loc]);
+			table[loc] = &deleted;
+			size--;
+		}
+		loc = (loc + 1) % capacity;
+	}
+
+	// At this point, we either have the pointer to the Element or the
+	// nullptr pointer
+	return table[loc];
 }
 
 /// @method update
@@ -147,13 +143,11 @@ SparseMatrix::Element* SparseMatrix::HashTable::retrieve(int r, int c)
 /// @param c column coordinate of Element
 /// @param v new value for Element
 /// @throws Matrix_invalid_argument
-void SparseMatrix::HashTable::update(int r, int c, BGFLOAT v)
-{
-    Element* el = retrieve(r, c);
-    
-    if (el == nullptr)
-        throw Matrix_invalid_argument("Attempt to update Element not in SparseMatrix hash table");
-    el->value = v;
+void SparseMatrix::HashTable::update(int r, int c, BGFLOAT v) {
+	Element* el = retrieve(r, c);
+
+	if (el == nullptr) throw Matrix_invalid_argument("Attempt to update Element not in SparseMatrix hash table");
+	el->value = v;
 }
 
 
@@ -169,34 +163,33 @@ void SparseMatrix::HashTable::update(int r, int c, BGFLOAT v)
 /// @param m multiplier used for initialization
 /// @param e pointer to Matrix element in XML
 SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, TiXmlElement* e)
-: Matrix("sparse", "none", r, c, m), theRows(nullptr), theColumns(nullptr),
-theElements(MaxElements(r,c), c, this)
-{
-	DEBUG_SPARSE(cerr << "Creating SparseMatrix, size: ";)
-    
-    // Bail out if we're being asked to create nonsense
-    if (!((rows > 0) && (columns > 0)))
-        throw Matrix_invalid_argument("SparseMatrix::SparseMatrix(): Asked to create zero-size");
-    
-    // We're a 2D Matrix, even if only one row or column
-    dimensions = 2;
-    
-	DEBUG_SPARSE(cerr << rows << "X" << columns << ":" << endl;)
-    
-    // Allocate storage for row and column lists (hash table already
-    // allocated at initialization time; see initializer list, above).
-    if ((theRows = new list<Element*>[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    if ((theColumns = new list<Element*>[columns]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    // Initialize from the XML
-    for (TiXmlElement* rowElement = e->FirstChildElement("Row");
-         rowElement != nullptr;
-         rowElement = rowElement->NextSiblingElement("Row"))
-        rowFromXML(rowElement);
-    
-	DEBUG_SPARSE(cerr << "\tInitialized " << type << " matrix" << endl;)
+	: Matrix("sparse", "none", r, c, m), theRows(nullptr), theColumns(nullptr),
+	  theElements(MaxElements(r, c), c, this) {
+	DEBUG_SPARSE(std::cerr << "Creating SparseMatrix, size: ";)
+
+	// Bail out if we're being asked to create nonsense
+	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
+		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+
+	// We're a 2D Matrix, even if only one row or column
+	dimensions = 2;
+
+	DEBUG_SPARSE(std::cerr << rows << "X" << columns << ":" << std::endl;)
+
+	// Allocate storage for row and column lists (hash table already
+	// allocated at initialization time; see initializer std::list, above).
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	// Initialize from the XML
+	for (TiXmlElement* rowElement = e->FirstChildElement("Row");
+	     rowElement != nullptr;
+	     rowElement = rowElement->NextSiblingElement("Row"))
+		rowFromXML(rowElement);
+
+	DEBUG_SPARSE(std::cerr << "\tInitialized " << type << " matrix" << std::endl;)
 }
 
 /// @method SparseMatrix
@@ -211,61 +204,61 @@ theElements(MaxElements(r,c), c, this)
 /// @param m multiplier used for initialization
 /// @param v string of initialization values
 SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, const char* v)
-: Matrix("sparse", "none", r, c, m), theRows(nullptr), theColumns(nullptr),
-theElements(MaxElements(r,c), c, this)
-{
-	DEBUG_SPARSE(cerr << "\tCreating diagonal sparse matrix" << endl;)
-    // Bail out if we're being asked to create nonsense
-    if (!((rows > 0) && (columns > 0)))
-        throw Matrix_invalid_argument("SparseMatrix::SparseMatrix(): Asked to create zero-size");
-    
-    // We're a 2D Matrix, even if only one row or column
-    dimensions = 2;
-    
-	DEBUG_SPARSE(cerr << rows << "X" << columns << ":" << endl;)
-    
-    // Allocate storage for row and column lists (hash table already
-    // allocated at initialization time; see initializer list, above).
-    if ((theRows = new list<Element*>[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    if ((theColumns = new list<Element*>[columns]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    if (multiplier == 0.0)  // If we're empty, then we're done.
-        return;
-    
-    if (v != nullptr) {     // Initialize from string of numeric data
-        istringstream valStream(v);
-        for (int i=0; i<rows; i++) {
-            Element* el;
-            BGFLOAT val;
-            valStream >> val;
-            if ((el = new Element(i, i, val*multiplier)) == nullptr)
-                throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-            theRows[i].push_back(el);
-            theColumns[i].push_back(el);
-            try {
-                theElements.insert(el);
-            } catch(Matrix_invalid_argument e) {
-                cerr << "Failure during SparseMatrix string constructor: " << e.what() << endl;
-                exit(-1);
-            }
-        }
-    } else {             // No string of data; initialize from multipler only
-        for (int i=0; i<rows; i++) {
-            Element* el;
-            if ((el = new Element(i, i, multiplier)) == nullptr)
-                throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-            theRows[i].push_back(el);
-            theColumns[i].push_back(el);
-            try {
-                theElements.insert(el);
-            } catch(Matrix_invalid_argument e) {
-                cerr << "Failure during SparseMatrix multiplier only constructor: " << e.what() << endl;
-                exit(-1);
-            }
-        }
-    }
+	: Matrix("sparse", "none", r, c, m), theRows(nullptr), theColumns(nullptr),
+	  theElements(MaxElements(r, c), c, this) {
+	DEBUG_SPARSE(std::cerr << "\tCreating diagonal sparse matrix" << std::endl;)
+	// Bail out if we're being asked to create nonsense
+	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
+		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+
+	// We're a 2D Matrix, even if only one row or column
+	dimensions = 2;
+
+	DEBUG_SPARSE(std::cerr << rows << "X" << columns << ":" << std::endl;)
+
+	// Allocate storage for row and column lists (hash table already
+	// allocated at initialization time; see initializer std::list, above).
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	if (multiplier == 0.0) // If we're empty, then we're done.
+		return;
+
+	if (v != nullptr) {
+		// Initialize from string of numeric data
+		std::istringstream valStream(v);
+		for (int i = 0; i < rows; i++) {
+			Element* el;
+			BGFLOAT val;
+			valStream >> val;
+			if ((el = new Element(i, i, val * multiplier)) == nullptr) throw Matrix_bad_alloc(
+				"Failed allocating storage for SparseMatrix.");
+			theRows[i].push_back(el);
+			theColumns[i].push_back(el);
+			try { theElements.insert(el); }
+			catch (Matrix_invalid_argument e) {
+				std::cerr << "Failure during SparseMatrix string constructor: " << e.what() << std::endl;
+				exit(-1);
+			}
+		}
+	}
+	else {
+		// No string of data; initialize from multipler only
+		for (int i = 0; i < rows; i++) {
+			Element* el;
+			if ((el = new Element(i, i, multiplier)) == nullptr) throw Matrix_bad_alloc(
+				"Failed allocating storage for SparseMatrix.");
+			theRows[i].push_back(el);
+			theColumns[i].push_back(el);
+			try { theElements.insert(el); }
+			catch (Matrix_invalid_argument e) {
+				std::cerr << "Failure during SparseMatrix multiplier only constructor: " << e.what() << std::endl;
+				exit(-1);
+			}
+		}
+	}
 }
 
 
@@ -277,269 +270,249 @@ theElements(MaxElements(r,c), c, this)
 /// @param r rows in Matrix
 /// @param c columns in Matrix
 SparseMatrix::SparseMatrix(int r, int c)
-: Matrix("sparse", "none", r, c, 0.0), theRows(nullptr), theColumns(nullptr),
-theElements(MaxElements(r,c), c, this)
-{
-	DEBUG_SPARSE(cerr << "\tCreating empty sparse matrix: ";)
-    // Bail out if we're being asked to create nonsense
-    if (!((rows > 0) && (columns > 0)))
-        throw Matrix_invalid_argument("SparseMatrix::SparseMatrix(): Asked to create zero-size");
-    
-    // We're a 2D Matrix, even if only one row or column
-    dimensions = 2;
-    
-	DEBUG_SPARSE(cerr << rows << "X" << columns << ":" << endl;)
-    
-    // Allocate storage for row and column lists (hash table already
-    // allocated at initialization time; see initializer list, above).
-    if ((theRows = new list<Element*>[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    if ((theColumns = new list<Element*>[columns]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    // And that's all, folks!
+	: Matrix("sparse", "none", r, c, 0.0), theRows(nullptr), theColumns(nullptr),
+	  theElements(MaxElements(r, c), c, this) {
+	DEBUG_SPARSE(std::cerr << "\tCreating empty sparse matrix: ";)
+	// Bail out if we're being asked to create nonsense
+	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
+		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+
+	// We're a 2D Matrix, even if only one row or column
+	dimensions = 2;
+
+	DEBUG_SPARSE(std::cerr << rows << "X" << columns << ":" << std::endl;)
+
+	// Allocate storage for row and column lists (hash table already
+	// allocated at initialization time; see initializer std::list, above).
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	// And that's all, folks!
 }
-
-
 
 
 // Copy Constructor
 SparseMatrix::SparseMatrix(const SparseMatrix& oldM)
-: Matrix("sparse", "none", oldM.rows, oldM.columns, oldM.multiplier),
-theRows(nullptr), theColumns(nullptr),
-theElements(MaxElements(oldM.rows,oldM.columns), oldM.columns, this)
-{
-	DEBUG_SPARSE(cerr << "SparseMatrix copy constructor:" << endl;)
-    
-    // We're a 2D Matrix, even if only one row or column
-    dimensions = 2;
-    
-	DEBUG_SPARSE(cerr << rows << "X" << columns << ":" << endl;)
-    
-    // Allocate storage for row and column lists (hash table already
-    // allocated at initialization time; see initializer list, above).
-    if ((theRows = new list<Element*>[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    if ((theColumns = new list<Element*>[columns]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    try {
-        copy(oldM);
-    } catch(Matrix_invalid_argument e) {
-        cerr << "Failure during SparseMatrix copy constructor\n"
-        << "\tError was: " << e.what() << endl;
-        exit(-1);
-    }
+	: Matrix("sparse", "none", oldM.rows, oldM.columns, oldM.multiplier),
+	  theRows(nullptr), theColumns(nullptr),
+	  theElements(MaxElements(oldM.rows, oldM.columns), oldM.columns, this) {
+	DEBUG_SPARSE(std::cerr << "SparseMatrix copy constructor:" << std::endl;)
+
+	// We're a 2D Matrix, even if only one row or column
+	dimensions = 2;
+
+	DEBUG_SPARSE(std::cerr << rows << "X" << columns << ":" << std::endl;)
+
+	// Allocate storage for row and column lists (hash table already
+	// allocated at initialization time; see initializer std::list, above).
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	try { copy(oldM); }
+	catch (Matrix_invalid_argument e) {
+		std::cerr << "Failure during SparseMatrix copy constructor\n"
+			<< "\tError was: " << e.what() << std::endl;
+		exit(-1);
+	}
 }
 
 // Destructor
-SparseMatrix::~SparseMatrix()
-{
-	DEBUG_SPARSE(cerr << "Destroying SparseMatrix" << endl;)
+SparseMatrix::~SparseMatrix() {
+	DEBUG_SPARSE(std::cerr << "Destroying SparseMatrix" << std::endl;)
 	clear();
 }
 
 // Assignment operator
-SparseMatrix& SparseMatrix::operator=(const SparseMatrix& rhs)
-{
-    if (&rhs == this)
-        return *this;
-    
-	DEBUG_SPARSE(cerr << "SparseMatrix::operator=" << endl;)
-    
-    clear();
-	DEBUG_SPARSE(cerr << "\t\tclear() complete, setting data member values." << endl;)
-    
-    SetAttributes(rhs.type, rhs.init, rhs.rows,
-                  rhs.columns, rhs.multiplier, rhs.dimensions);
-    
-	DEBUG_SPARSE(cerr << "\t\tvalues set, ready to allocate." << endl;)
-    
-    alloc();
-    
-	DEBUG_SPARSE(cerr << "\t\talloc() complete, ready to copy." << endl;)
-    
-    try {
-        copy(rhs);
-    } catch(Matrix_invalid_argument e) {
-        cerr << "\tFailure during SparseMatrix assignment operator\n"
-        << "\tError was: " << e.what() << endl;
-        exit(-1);
-    }
-	DEBUG_SPARSE(cerr << "\t\tcopy() complete; returning by reference." << endl;)
-    return *this;
+SparseMatrix& SparseMatrix::operator=(const SparseMatrix& rhs) {
+	if (&rhs == this) return *this;
+
+	DEBUG_SPARSE(std::cerr << "SparseMatrix::operator=" << std::endl;)
+
+	clear();
+	DEBUG_SPARSE(std::cerr << "\t\tclear() complete, setting data member values." << std::endl;)
+
+	SetAttributes(rhs.type, rhs.init, rhs.rows,
+	              rhs.columns, rhs.multiplier, rhs.dimensions);
+
+	DEBUG_SPARSE(std::cerr << "\t\tvalues set, ready to allocate." << std::endl;)
+
+	alloc();
+
+	DEBUG_SPARSE(std::cerr << "\t\talloc() complete, ready to copy." << std::endl;)
+
+	try { copy(rhs); }
+	catch (Matrix_invalid_argument e) {
+		std::cerr << "\tFailure during SparseMatrix assignment operator\n"
+			<< "\tError was: " << e.what() << std::endl;
+		exit(-1);
+	}
+	DEBUG_SPARSE(std::cerr << "\t\tcopy() complete; returning by reference." << std::endl;)
+	return *this;
 }
 
 // Clear out storage
-void SparseMatrix::clear(void)
-{
-	DEBUG_SPARSE(cerr << "\tclearing " << rows << "X" << columns << " SparseMatrix...";)
-    
-    // Since each Element is only allocated once (and shared among the
-    // row and column lists and the hash table), we only need to
-    // traverse all of the row lists and delete the Elements. This
-    // invalidates all of the column list and hash table pointers, but
-    // those lists will go away when the column list destructors are
-    // called in response to us deleting the column array and when
-    // the hash table is cleared.
-    if (theRows != nullptr) {
-        for (int i = 0; i < rows; i++)
-            for (list<Element*>::iterator it = theRows[i].begin();
-                 it != theRows[i].end(); it++)
-                delete *it;
-        delete [] theRows;
-    }
-    
-    if (theColumns != nullptr)
-        delete [] theColumns;
-    
-    theElements.clear();
-    
-    theRows = nullptr;
-    theColumns = nullptr;
-    
-	DEBUG_SPARSE(cerr << "done." << endl;)
+void SparseMatrix::clear(void) {
+	DEBUG_SPARSE(std::cerr << "\tclearing " << rows << "X" << columns << " SparseMatrix...";)
+
+	// Since each Element is only allocated once (and shared among the
+	// row and column lists and the hash table), we only need to
+	// traverse all of the row lists and delete the Elements. This
+	// invalidates all of the column std::list and hash table pointers, but
+	// those lists will go away when the column std::list destructors are
+	// called in response to us deleting the column array and when
+	// the hash table is cleared.
+	if (theRows != nullptr) {
+		for (int i = 0; i < rows; i++)
+			for (std::list<Element*>::iterator it = theRows[i].begin();
+			     it != theRows[i].end(); it++)
+				delete *it;
+		delete [] theRows;
+	}
+
+	if (theColumns != nullptr) delete [] theColumns;
+
+	theElements.clear();
+
+	theRows = nullptr;
+	theColumns = nullptr;
+
+	DEBUG_SPARSE(std::cerr << "done." << std::endl;)
 }
 
 /// @method remove_lists
 /// @discussion Remove an Element from the SparseMatrix lists (but not
 /// the hash table). This is meant to be called from a HashTable
 /// method.
-void SparseMatrix::remove_lists(Element* el)
-{
-    theRows[el->row].remove(el);
-    theColumns[el->column].remove(el);
-    
-    delete el;
+void SparseMatrix::remove_lists(Element* el) {
+	theRows[el->row].remove(el);
+	theColumns[el->column].remove(el);
+
+	delete el;
 }
 
 // Copy matrix to this one
-void SparseMatrix::copy(const SparseMatrix& source)
-{
-	DEBUG_SPARSE(cerr << "\t\t\tcopying " << source.rows << "X" << source.columns
-                 << " SparseMatrix...";)
-    
-    // We will access the source row-wise, inserting new Elements into
-    // the current SparseMatrix's row and column lists.
-    for (int i=0; i<rows; i++) {
-        for (list<Element*>::iterator it = source.theRows[i].begin();
-             it != source.theRows[i].end(); it++) {
-            Element* el = new Element(i, (*it)->column, (*it)->value);
-            theRows[i].push_back(el);
-            theColumns[el->column].push_back(el);
-            try {
-                theElements.insert(el);
-            } catch(Matrix_invalid_argument e) {
-                cerr << "\nFailure during SparseMatrix copy() for element "
-                << el->value << " at (" << el->row << "," << el->column << ")" << endl;
-                cerr << "\twith " << theElements.size << " elements already copied at i="
-                << i << ", hashed to " << theElements.hash(el) << " in table with capacity "
-                << theElements.capacity << endl;
-                cerr << "\tSource was: " << source << endl << endl;
-                throw e;
-            }
-        }
-    }
-    
-	DEBUG_SPARSE(cerr << "\t\tdone." << endl;)
+void SparseMatrix::copy(const SparseMatrix& source) {
+	DEBUG_SPARSE(std::cerr << "\t\t\tcopying " << source.rows << "X" << source.columns
+		<< " SparseMatrix...";)
+
+	// We will access the source row-wise, inserting new Elements into
+	// the current SparseMatrix's row and column lists.
+	for (int i = 0; i < rows; i++) {
+		for (std::list<Element*>::iterator it = source.theRows[i].begin();
+		     it != source.theRows[i].end(); it++) {
+			Element* el = new Element(i, (*it)->column, (*it)->value);
+			theRows[i].push_back(el);
+			theColumns[el->column].push_back(el);
+			try { theElements.insert(el); }
+			catch (Matrix_invalid_argument e) {
+				std::cerr << "\nFailure during SparseMatrix copy() for element "
+					<< el->value << " at (" << el->row << "," << el->column << ")" << std::endl;
+				std::cerr << "\twith " << theElements.size << " elements already copied at i="
+					<< i << ", hashed to " << theElements.hash(el) << " in table with capacity "
+					<< theElements.capacity << std::endl;
+				std::cerr << "\tSource was: " << source << std::endl << std::endl;
+				throw e;
+			}
+		}
+	}
+
+	DEBUG_SPARSE(std::cerr << "\t\tdone." << std::endl;)
 }
 
 // Read row from XML and add items to SparseMatrix
-void SparseMatrix::rowFromXML(TiXmlElement* rowElement)
-{
-    int rowNum;
-    if (rowElement->QueryIntAttribute("number", &rowNum)!=TIXML_SUCCESS)
-        throw Matrix_invalid_argument("Attempt to read SparseMatrix row without a number");
-    
-    // Iterate through the entries, inserting them into the row, column,
-    // and hash table
-    for (TiXmlElement* child = rowElement->FirstChildElement("Entry");
-         child != nullptr; child=child->NextSiblingElement("Entry")) {
-        int colNum;
-        BGFLOAT val;
-        if (child->QueryIntAttribute("number", &colNum)!=TIXML_SUCCESS)
-            throw Matrix_invalid_argument("Attempt to read SparseMatrix Entry without a number");
-        if (child->QueryFLOATAttribute("value", &val)!=TIXML_SUCCESS)
-            throw Matrix_invalid_argument("Attempt to read SparseMatrix Entry without a value");
-        Element* el = new Element(rowNum, colNum, val);
-        theRows[rowNum].push_back(el);
-        theColumns[colNum].push_back(el);
-        try {
-            theElements.insert(el);
-        } catch(Matrix_invalid_argument e) {
-            cerr << "Failure during SparseMatrix rowFromXML: " << e.what() << endl;
-            exit(-1);
-        }
-    }
+void SparseMatrix::rowFromXML(TiXmlElement* rowElement) {
+	int rowNum;
+	if (rowElement->QueryIntAttribute("number", &rowNum) != TIXML_SUCCESS) throw Matrix_invalid_argument(
+		"Attempt to read SparseMatrix row without a number");
+
+	// Iterate through the entries, inserting them into the row, column,
+	// and hash table
+	for (TiXmlElement* child = rowElement->FirstChildElement("Entry");
+	     child != nullptr; child = child->NextSiblingElement("Entry")) {
+		int colNum;
+		BGFLOAT val;
+		if (child->QueryIntAttribute("number", &colNum) != TIXML_SUCCESS) throw Matrix_invalid_argument(
+			"Attempt to read SparseMatrix Entry without a number");
+		if (child->QueryFLOATAttribute("value", &val) != TIXML_SUCCESS) throw Matrix_invalid_argument(
+			"Attempt to read SparseMatrix Entry without a value");
+		Element* el = new Element(rowNum, colNum, val);
+		theRows[rowNum].push_back(el);
+		theColumns[colNum].push_back(el);
+		try { theElements.insert(el); }
+		catch (Matrix_invalid_argument e) {
+			std::cerr << "Failure during SparseMatrix rowFromXML: " << e.what() << std::endl;
+			exit(-1);
+		}
+	}
 }
 
 
 // Allocate internal storage
-void SparseMatrix::alloc(void)
-{
-    if (theRows != nullptr)
-        throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
-    
-    // Allocate the 1D array
-    if ((theRows = new list<Element*>[rows]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    if (theColumns != nullptr)
-        throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
-    
-    // Allocate the 1D array
-    if ((theColumns = new list<Element*>[columns]) == nullptr)
-        throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-    
-    // Set the hash table capacity
-    theElements.resize(MaxElements(rows, columns), columns);
-    
-	DEBUG_SPARSE(cerr << "\t\tStorage allocated for "<< rows << " row by "
-                 << columns << " column SparseMatrix." << endl;)
-    
+void SparseMatrix::alloc(void) {
+	if (theRows != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
+
+	// Allocate the 1D array
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	if (theColumns != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
+
+	// Allocate the 1D array
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
+		"Failed allocating storage for SparseMatrix.");
+
+	// Set the hash table capacity
+	theElements.resize(MaxElements(rows, columns), columns);
+
+	DEBUG_SPARSE(std::cerr << "\t\tStorage allocated for "<< rows << " row by "
+		<< columns << " column SparseMatrix." << std::endl;)
+
 }
 
 
 // Polymorphic output
-void SparseMatrix::Print(ostream& os) const
-{
-    if (theElements.size == 0) // must catch this before here; not XML
-        os << "empty";
-    
-    for (int i=0; i<rows; i++) {
-        if (theRows[i].begin() == theRows[i].end())
-            continue;
-        os << "   <Row number=\"" << i << "\">" << endl;
-        for (list<Element*>::iterator it = theRows[i].begin();
-             it != theRows[i].end(); it++) {
-            // Prune out any left over zero elements
-            if ((*it)->value != 0.0)
-                os << "      <Entry number=\"" << (*it)->column
-                << "\" value=\"" << (*it)->value << "\"/>" << endl;
-        }
-        os << "   </Row>" << endl;
-    }
+void SparseMatrix::Print(std::ostream& os) const {
+	if (theElements.size == 0) // must catch this before here; not XML
+		os << "empty";
+
+	for (int i = 0; i < rows; i++) {
+		if (theRows[i].begin() == theRows[i].end()) continue;
+		os << "   <Row number=\"" << i << "\">" << std::endl;
+		for (std::list<Element*>::iterator it = theRows[i].begin();
+		     it != theRows[i].end(); it++) {
+			// Prune out any left over zero elements
+			if ((*it)->value != 0.0)
+				os << "      <Entry number=\"" << (*it)->column
+					<< "\" value=\"" << (*it)->value << "\"/>" << std::endl;
+		}
+		os << "   </Row>" << std::endl;
+	}
 }
 
 // convert Matrix to XML string
-string SparseMatrix::toXML(string name) const
-{
-    stringstream os;
-    
-    os << "<Matrix ";
-    if (name != "")
-        os << "name=\"" << name << "\" ";
-    os << "type=\"sparse\" rows=\"" << rows
-    << "\" columns=\"" << columns << "\" ";
-    if (theElements.size == 0) {           // Empty sparse matrix has special XML
-        os << "init=\"const\" multiplier=\"0.0\"/>";
-    } else {                               // Non-empty: output contents' XML
-        os << "multiplier=\"1.0\">" << endl;
-        os << "   " << *this << endl;
-        os << "</Matrix>";
-    }
-    
-    return os.str();
+std::string SparseMatrix::toXML(std::string name) const {
+	std::stringstream os;
+
+	os << "<Matrix ";
+	if (name != "") os << "name=\"" << name << "\" ";
+	os << "type=\"sparse\" rows=\"" << rows
+		<< "\" columns=\"" << columns << "\" ";
+	if (theElements.size == 0) {
+		// Empty sparse matrix has special XML
+		os << "init=\"const\" multiplier=\"0.0\"/>";
+	}
+	else {
+		// Non-empty: output contents' XML
+		os << "multiplier=\"1.0\">" << std::endl;
+		os << "   " << *this << std::endl;
+		os << "</Matrix>";
+	}
+
+	return os.str();
 }
 
 
@@ -552,43 +525,40 @@ string SparseMatrix::toXML(string name) const
 /// @param c element column
 /// @result value of element at that location
 /// @throws Matrix_bad_alloc
-BGFLOAT& SparseMatrix::operator()(int r, int c)
-{
-    Element* el = theElements.retrieve(r, c);
-    
-    // Because we're a mutator, we need to insert a zero-value element
-    // if the element wasn't found. We will rely on other methods to
-    // eliminate zero elements "on the fly".
-    if (el == nullptr) {
-        if ((el = new  Element(r, c, 0.0)) == nullptr)
-            throw Matrix_bad_alloc("Failed allocating storage for SparseMatrix.");
-        theRows[r].push_back(el);
-        theColumns[c].push_back(el);
-        try {
-            theElements.insert(el);
-        } catch(Matrix_invalid_argument e) {
-            cerr << "Failure during SparseMatrix operator() at row "
-            << r << " column " << c << ": " << e.what() << endl;
-            exit(-1);
-        }
-    }
-    
-    return el->value;
+BGFLOAT& SparseMatrix::operator()(int r, int c) {
+	Element* el = theElements.retrieve(r, c);
+
+	// Because we're a mutator, we need to insert a zero-value element
+	// if the element wasn't found. We will rely on other methods to
+	// eliminate zero elements "on the fly".
+	if (el == nullptr) {
+		if ((el = new Element(r, c, 0.0)) == nullptr) throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+		theRows[r].push_back(el);
+		theColumns[c].push_back(el);
+		try { theElements.insert(el); }
+		catch (Matrix_invalid_argument e) {
+			std::cerr << "Failure during SparseMatrix operator() at row "
+				<< r << " column " << c << ": " << e.what() << std::endl;
+			exit(-1);
+		}
+	}
+
+	return el->value;
 }
 
 /// Unary minus. Negate all elements of the SparseMatrix.
 /// @return A new SparseMatrix, with same size as the current one.
-const SparseMatrix SparseMatrix::operator-() const
-{
-    SparseMatrix result(*this);
-    
-    // Iterate over all elements, negating their values
-    for (int i=0; i<result.rows; i++)
-        for (list<Element*>::iterator it = result.theRows[i].begin();
-             it != result.theRows[i].end(); it++)
-            (*it)->value = - (*it)->value;
-    
-    return result;
+const SparseMatrix SparseMatrix::operator-() const {
+	SparseMatrix result(*this);
+
+	// Iterate over all elements, negating their values
+	for (int i = 0; i < result.rows; i++)
+		for (std::list<Element*>::iterator it = result.theRows[i].begin();
+		     it != result.theRows[i].end(); it++)
+			(*it)->value = - (*it)->value;
+
+	return result;
 }
 
 
@@ -597,43 +567,38 @@ const SparseMatrix SparseMatrix::operator-() const
 // and including the other subclasses' headers).
 
 
-
-const SparseMatrix SparseMatrix::operator+(const SparseMatrix& rhs) const
-{
-    throw Matrix_domain_error("SparseMatrix addition not yet implemented");
+const SparseMatrix SparseMatrix::operator+(const SparseMatrix& rhs) const {
+	throw Matrix_domain_error("SparseMatrix addition not yet implemented");
 }
 
 
 // Multiply the rhs into the current object
-const SparseMatrix SparseMatrix::operator*(const SparseMatrix& rhs) const
-{
-    throw Matrix_domain_error("SparseMatrix product not yet implemented");
+const SparseMatrix SparseMatrix::operator*(const SparseMatrix& rhs) const {
+	throw Matrix_domain_error("SparseMatrix product not yet implemented");
 }
 
 
 // Vector times a Sparse matrix
-const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m)
-{
-    if (m.rows != v.size) {
-        throw Matrix_domain_error("Illegal vector/matrix product. Rows of matrix must equal vector size.");
-    }
-    
-    // the result is a vector the same size as m columns
-    VectorMatrix result("complete", "const", 1, m.columns, 0.0, "");
-    
-    // To get each element of result, we will iterate down a column of m,
-    // multiplying each element found by the element in v at position
-    // equal to the row position of the m element. The result is the sum
-    // of those products.
-    for (int col=0; col<m.columns; col++) {
-        BGFLOAT sum = 0.0;
-        for (list<SparseMatrix::Element*>::iterator el=m.theColumns[col].begin();
-             el!=m.theColumns[col].end(); el++)
-            sum += (*el)->value * v[(*el)->row];
-        result[col] = sum;
-    }
-    
-    return result;
-    
-}
+const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m) {
+	if (m.rows != v.size) {
+		throw Matrix_domain_error("Illegal vector/matrix product. Rows of matrix must equal vector size.");
+	}
 
+	// the result is a vector the same size as m columns
+	VectorMatrix result("complete", "const", 1, m.columns, 0.0, "");
+
+	// To get each element of result, we will iterate down a column of m,
+	// multiplying each element found by the element in v at position
+	// equal to the row position of the m element. The result is the sum
+	// of those products.
+	for (int col = 0; col < m.columns; col++) {
+		BGFLOAT sum = 0.0;
+		for (std::list<SparseMatrix::Element*>::iterator el = m.theColumns[col].begin();
+		     el != m.theColumns[col].end(); el++)
+			sum += (*el)->value * v[(*el)->row];
+		result[col] = sum;
+	}
+
+	return result;
+
+}

--- a/Simulator/Utils/Matrix/SparseMatrix.cpp
+++ b/Simulator/Utils/Matrix/SparseMatrix.cpp
@@ -45,7 +45,7 @@ void SparseMatrix::HashTable::resize(int s, int c) {
 		DEBUG_SPARSE(std::cerr << "\t\t\tSM::HT::resize(): table capacity changed." << std::endl;)
 		capacity = s;
 		columns = c;
-		table.resize(capacity, static_cast<Element*>(nullptr));
+		table.resize(capacity, nullptr);
 		size = 0;
 	}
 
@@ -400,7 +400,7 @@ void SparseMatrix::clear(void) {
 	if (theRows != nullptr) {
 		for (int i = 0; i < rows; i++) {
 			for (auto it = theRows[i].begin();
-			     it != theRows[i].end(); it++)
+			     it != theRows[i].end(); ++it)
 				delete *it;
 		}
 		delete [] theRows;
@@ -436,7 +436,7 @@ void SparseMatrix::copy(const SparseMatrix& source) {
 	// the current SparseMatrix's row and column lists.
 	for (int i = 0; i < rows; i++) {
 		for (auto it = source.theRows[i].begin();
-		     it != source.theRows[i].end(); it++) {
+		     it != source.theRows[i].end(); ++it) {
 			auto el = new Element(i, (*it)->column, (*it)->value);
 			theRows[i].push_back(el);
 			theColumns[el->column].push_back(el);
@@ -448,7 +448,7 @@ void SparseMatrix::copy(const SparseMatrix& source) {
 					<< i << ", hashed to " << theElements.hash(el) << " in table with capacity "
 					<< theElements.capacity << std::endl;
 				std::cerr << "\tSource was: " << source << std::endl << std::endl;
-				throw e;
+				throw;
 			}
 		}
 	}
@@ -526,7 +526,7 @@ void SparseMatrix::Print(std::ostream& os) const {
 		if (theRows[i].begin() == theRows[i].end()) continue;
 		os << "   <Row number=\"" << i << "\">" << std::endl;
 		for (auto it = theRows[i].begin();
-		     it != theRows[i].end(); it++) {
+		     it != theRows[i].end(); ++it) {
 			// Prune out any left over zero elements
 			if ((*it)->value != 0.0) {
 				os << "      <Entry number=\"" << (*it)->column
@@ -601,7 +601,7 @@ const SparseMatrix SparseMatrix::operator-() const {
 	// Iterate over all elements, negating their values
 	for (int i = 0; i < result.rows; i++) {
 		for (auto it = result.theRows[i].begin();
-		     it != result.theRows[i].end(); it++)
+		     it != result.theRows[i].end(); ++it)
 			(*it)->value = - (*it)->value;
 	}
 
@@ -627,8 +627,10 @@ const SparseMatrix SparseMatrix::operator*(const SparseMatrix& rhs) const {
 
 // Vector times a Sparse matrix
 const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m) {
-	if (m.rows != v.size) throw Matrix_domain_error(
-		"Illegal vector/matrix product. Rows of matrix must equal vector size.");
+	if (m.rows != v.size) {
+		throw Matrix_domain_error(
+			"Illegal vector/matrix product. Rows of matrix must equal vector size.");
+	}
 
 	// the result is a vector the same size as m columns
 	VectorMatrix result("complete", "const", 1, m.columns, 0.0, "");
@@ -640,7 +642,7 @@ const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m) {
 	for (int col = 0; col < m.columns; col++) {
 		BGFLOAT sum = 0.0;
 		for (auto el = m.theColumns[col].begin();
-		     el != m.theColumns[col].end(); el++)
+		     el != m.theColumns[col].end(); ++el)
 			sum += (*el)->value * v[(*el)->row];
 		result[col] = sum;
 	}

--- a/Simulator/Utils/Matrix/SparseMatrix.cpp
+++ b/Simulator/Utils/Matrix/SparseMatrix.cpp
@@ -7,12 +7,12 @@
  *          Self-allocating and de-allocating.
  */
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
-#include <algorithm>
 
-#include "Global.h"
 #include "SparseMatrix.h"
+#include "Global.h"
 
 extern bool debugSparseMatrix;
 
@@ -79,8 +79,10 @@ void SparseMatrix::HashTable::insert(Element* el) {
 
 	// Find first location to insert (if Element isn't in the table)
 	while ((table[loc] != &deleted) && (table[loc] != nullptr)) {
-		if (*table[loc] == *el) throw Matrix_invalid_argument(
-			"Attempt to insert duplicate Element into SparseMatrix hash table [1]");
+		if (*table[loc] == *el) {
+			throw Matrix_invalid_argument(
+				"Attempt to insert duplicate Element into SparseMatrix hash table [1]");
+		}
 		loc = (loc + 1) % capacity;
 		if (loc == start) throw Matrix_invalid_argument("Hashtable insert wraparound: unable to insert Element [1]");
 	}
@@ -90,11 +92,15 @@ void SparseMatrix::HashTable::insert(Element* el) {
 	if (table[loc] == &deleted) {
 		int loc2 = (loc + 1) % capacity;
 		while (table[loc2] != nullptr) {
-			if (loc2 == start) throw Matrix_invalid_argument(
-				"Hashtable insert wraparound: unable to insert Element [2]");
+			if (loc2 == start) {
+				throw Matrix_invalid_argument(
+					"Hashtable insert wraparound: unable to insert Element [2]");
+			}
 			loc2 = (loc2 + 1) % capacity;
-			if (*table[loc2] == *el) throw Matrix_invalid_argument(
-				"Attempt to insert duplicate Element into SparseMatrix hash table [2]");
+			if (*table[loc2] == *el) {
+				throw Matrix_invalid_argument(
+					"Attempt to insert duplicate Element into SparseMatrix hash table [2]");
+			}
 		}
 	}
 
@@ -168,8 +174,10 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, TiXmlElement* e)
 	DEBUG_SPARSE(std::cerr << "Creating SparseMatrix, size: ";)
 
 	// Bail out if we're being asked to create nonsense
-	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
-		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	if (!((rows > 0) && (columns > 0))) {
+		throw Matrix_invalid_argument(
+			"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	}
 
 	// We're a 2D Matrix, even if only one row or column
 	dimensions = 2;
@@ -178,10 +186,14 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, TiXmlElement* e)
 
 	// Allocate storage for row and column lists (hash table already
 	// allocated at initialization time; see initializer std::list, above).
-	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
-	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	// Initialize from the XML
 	for (TiXmlElement* rowElement = e->FirstChildElement("Row");
@@ -208,8 +220,10 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, const char* v)
 	  theElements(MaxElements(r, c), c, this) {
 	DEBUG_SPARSE(std::cerr << "\tCreating diagonal sparse matrix" << std::endl;)
 	// Bail out if we're being asked to create nonsense
-	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
-		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	if (!((rows > 0) && (columns > 0))) {
+		throw Matrix_invalid_argument(
+			"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	}
 
 	// We're a 2D Matrix, even if only one row or column
 	dimensions = 2;
@@ -218,10 +232,14 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, const char* v)
 
 	// Allocate storage for row and column lists (hash table already
 	// allocated at initialization time; see initializer std::list, above).
-	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
-	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	if (multiplier == 0.0) // If we're empty, then we're done.
 		return;
@@ -233,8 +251,10 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, const char* v)
 			Element* el;
 			BGFLOAT val;
 			valStream >> val;
-			if ((el = new Element(i, i, val * multiplier)) == nullptr) throw Matrix_bad_alloc(
-				"Failed allocating storage for SparseMatrix.");
+			if ((el = new Element(i, i, val * multiplier)) == nullptr) {
+				throw Matrix_bad_alloc(
+					"Failed allocating storage for SparseMatrix.");
+			}
 			theRows[i].push_back(el);
 			theColumns[i].push_back(el);
 			try { theElements.insert(el); }
@@ -248,8 +268,10 @@ SparseMatrix::SparseMatrix(int r, int c, BGFLOAT m, const char* v)
 		// No string of data; initialize from multipler only
 		for (int i = 0; i < rows; i++) {
 			Element* el;
-			if ((el = new Element(i, i, multiplier)) == nullptr) throw Matrix_bad_alloc(
-				"Failed allocating storage for SparseMatrix.");
+			if ((el = new Element(i, i, multiplier)) == nullptr) {
+				throw Matrix_bad_alloc(
+					"Failed allocating storage for SparseMatrix.");
+			}
 			theRows[i].push_back(el);
 			theColumns[i].push_back(el);
 			try { theElements.insert(el); }
@@ -274,8 +296,10 @@ SparseMatrix::SparseMatrix(int r, int c)
 	  theElements(MaxElements(r, c), c, this) {
 	DEBUG_SPARSE(std::cerr << "\tCreating empty sparse matrix: ";)
 	// Bail out if we're being asked to create nonsense
-	if (!((rows > 0) && (columns > 0))) throw Matrix_invalid_argument(
-		"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	if (!((rows > 0) && (columns > 0))) {
+		throw Matrix_invalid_argument(
+			"SparseMatrix::SparseMatrix(): Asked to create zero-size");
+	}
 
 	// We're a 2D Matrix, even if only one row or column
 	dimensions = 2;
@@ -284,10 +308,14 @@ SparseMatrix::SparseMatrix(int r, int c)
 
 	// Allocate storage for row and column lists (hash table already
 	// allocated at initialization time; see initializer std::list, above).
-	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
-	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	// And that's all, folks!
 }
@@ -307,10 +335,14 @@ SparseMatrix::SparseMatrix(const SparseMatrix& oldM)
 
 	// Allocate storage for row and column lists (hash table already
 	// allocated at initialization time; see initializer std::list, above).
-	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
-	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	try { copy(oldM); }
 	catch (Matrix_invalid_argument e) {
@@ -366,10 +398,11 @@ void SparseMatrix::clear(void) {
 	// called in response to us deleting the column array and when
 	// the hash table is cleared.
 	if (theRows != nullptr) {
-		for (int i = 0; i < rows; i++)
-			for (std::list<Element*>::iterator it = theRows[i].begin();
+		for (int i = 0; i < rows; i++) {
+			for (auto it = theRows[i].begin();
 			     it != theRows[i].end(); it++)
 				delete *it;
+		}
 		delete [] theRows;
 	}
 
@@ -402,9 +435,9 @@ void SparseMatrix::copy(const SparseMatrix& source) {
 	// We will access the source row-wise, inserting new Elements into
 	// the current SparseMatrix's row and column lists.
 	for (int i = 0; i < rows; i++) {
-		for (std::list<Element*>::iterator it = source.theRows[i].begin();
+		for (auto it = source.theRows[i].begin();
 		     it != source.theRows[i].end(); it++) {
-			Element* el = new Element(i, (*it)->column, (*it)->value);
+			auto el = new Element(i, (*it)->column, (*it)->value);
 			theRows[i].push_back(el);
 			theColumns[el->column].push_back(el);
 			try { theElements.insert(el); }
@@ -426,8 +459,10 @@ void SparseMatrix::copy(const SparseMatrix& source) {
 // Read row from XML and add items to SparseMatrix
 void SparseMatrix::rowFromXML(TiXmlElement* rowElement) {
 	int rowNum;
-	if (rowElement->QueryIntAttribute("number", &rowNum) != TIXML_SUCCESS) throw Matrix_invalid_argument(
-		"Attempt to read SparseMatrix row without a number");
+	if (rowElement->QueryIntAttribute("number", &rowNum) != TIXML_SUCCESS) {
+		throw Matrix_invalid_argument(
+			"Attempt to read SparseMatrix row without a number");
+	}
 
 	// Iterate through the entries, inserting them into the row, column,
 	// and hash table
@@ -435,11 +470,15 @@ void SparseMatrix::rowFromXML(TiXmlElement* rowElement) {
 	     child != nullptr; child = child->NextSiblingElement("Entry")) {
 		int colNum;
 		BGFLOAT val;
-		if (child->QueryIntAttribute("number", &colNum) != TIXML_SUCCESS) throw Matrix_invalid_argument(
-			"Attempt to read SparseMatrix Entry without a number");
-		if (child->QueryFLOATAttribute("value", &val) != TIXML_SUCCESS) throw Matrix_invalid_argument(
-			"Attempt to read SparseMatrix Entry without a value");
-		Element* el = new Element(rowNum, colNum, val);
+		if (child->QueryIntAttribute("number", &colNum) != TIXML_SUCCESS) {
+			throw Matrix_invalid_argument(
+				"Attempt to read SparseMatrix Entry without a number");
+		}
+		if (child->QueryFLOATAttribute("value", &val) != TIXML_SUCCESS) {
+			throw Matrix_invalid_argument(
+				"Attempt to read SparseMatrix Entry without a value");
+		}
+		auto el = new Element(rowNum, colNum, val);
 		theRows[rowNum].push_back(el);
 		theColumns[colNum].push_back(el);
 		try { theElements.insert(el); }
@@ -456,14 +495,18 @@ void SparseMatrix::alloc(void) {
 	if (theRows != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
 
 	// Allocate the 1D array
-	if ((theRows = new std::list<Element*>[rows]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theRows = new std::list<Element*>[rows]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	if (theColumns != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared SparseMatrix");
 
 	// Allocate the 1D array
-	if ((theColumns = new std::list<Element*>[columns]) == nullptr) throw Matrix_bad_alloc(
-		"Failed allocating storage for SparseMatrix.");
+	if ((theColumns = new std::list<Element*>[columns]) == nullptr) {
+		throw Matrix_bad_alloc(
+			"Failed allocating storage for SparseMatrix.");
+	}
 
 	// Set the hash table capacity
 	theElements.resize(MaxElements(rows, columns), columns);
@@ -482,12 +525,13 @@ void SparseMatrix::Print(std::ostream& os) const {
 	for (int i = 0; i < rows; i++) {
 		if (theRows[i].begin() == theRows[i].end()) continue;
 		os << "   <Row number=\"" << i << "\">" << std::endl;
-		for (std::list<Element*>::iterator it = theRows[i].begin();
+		for (auto it = theRows[i].begin();
 		     it != theRows[i].end(); it++) {
 			// Prune out any left over zero elements
-			if ((*it)->value != 0.0)
+			if ((*it)->value != 0.0) {
 				os << "      <Entry number=\"" << (*it)->column
 					<< "\" value=\"" << (*it)->value << "\"/>" << std::endl;
+			}
 		}
 		os << "   </Row>" << std::endl;
 	}
@@ -532,8 +576,10 @@ BGFLOAT& SparseMatrix::operator()(int r, int c) {
 	// if the element wasn't found. We will rely on other methods to
 	// eliminate zero elements "on the fly".
 	if (el == nullptr) {
-		if ((el = new Element(r, c, 0.0)) == nullptr) throw Matrix_bad_alloc(
-			"Failed allocating storage for SparseMatrix.");
+		if ((el = new Element(r, c, 0.0)) == nullptr) {
+			throw Matrix_bad_alloc(
+				"Failed allocating storage for SparseMatrix.");
+		}
 		theRows[r].push_back(el);
 		theColumns[c].push_back(el);
 		try { theElements.insert(el); }
@@ -553,10 +599,11 @@ const SparseMatrix SparseMatrix::operator-() const {
 	SparseMatrix result(*this);
 
 	// Iterate over all elements, negating their values
-	for (int i = 0; i < result.rows; i++)
-		for (std::list<Element*>::iterator it = result.theRows[i].begin();
+	for (int i = 0; i < result.rows; i++) {
+		for (auto it = result.theRows[i].begin();
 		     it != result.theRows[i].end(); it++)
 			(*it)->value = - (*it)->value;
+	}
 
 	return result;
 }
@@ -580,9 +627,8 @@ const SparseMatrix SparseMatrix::operator*(const SparseMatrix& rhs) const {
 
 // Vector times a Sparse matrix
 const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m) {
-	if (m.rows != v.size) {
-		throw Matrix_domain_error("Illegal vector/matrix product. Rows of matrix must equal vector size.");
-	}
+	if (m.rows != v.size) throw Matrix_domain_error(
+		"Illegal vector/matrix product. Rows of matrix must equal vector size.");
 
 	// the result is a vector the same size as m columns
 	VectorMatrix result("complete", "const", 1, m.columns, 0.0, "");
@@ -593,7 +639,7 @@ const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m) {
 	// of those products.
 	for (int col = 0; col < m.columns; col++) {
 		BGFLOAT sum = 0.0;
-		for (std::list<SparseMatrix::Element*>::iterator el = m.theColumns[col].begin();
+		for (auto el = m.theColumns[col].begin();
 		     el != m.theColumns[col].end(); el++)
 			sum += (*el)->value * v[(*el)->row];
 		result[col] = sum;

--- a/Simulator/Utils/Matrix/SparseMatrix.h
+++ b/Simulator/Utils/Matrix/SparseMatrix.h
@@ -18,8 +18,6 @@
 #include "Matrix.h"
 #include "VectorMatrix.h"
 
-using namespace std;
-
 // Forward declarations
 class SparseMatrix;
 class VectorMatrix;
@@ -171,7 +169,7 @@ class SparseMatrix: public Matrix {
 		int columns;
         
 		/// The hash table itself
-		vector<Element*> table;
+		std::vector<Element*> table;
         
 		/// Pointer to container object, for calling its methods
 		SparseMatrix* theMatrix;
@@ -248,10 +246,10 @@ public:
     
 	/// @brief Polymorphic output. Produces text output on stream "os". Output is by row.
 	/// @param os stream to output to
-	virtual void Print(ostream& os) const override;
+	virtual void Print(std::ostream& os) const override;
     
 	/// @brief Produce XML representation of Matrix in string return value.
-	virtual string toXML(string name = "") const;
+	virtual std::string toXML(std::string name = "") const;
     
 	/******************************************
 	* @name Math Operations
@@ -342,10 +340,10 @@ private:
 	{	return r * c;}
     
 	/// 1D array of lists of elements in a row
-	list<Element*> *theRows;
+	std::list<Element*> *theRows;
     
 	/// 1D array of lists of elements in a column
-	list<Element*> *theColumns;
+	std::list<Element*> *theColumns;
     
 	/// Hash table used to access elements by coordinates
 	HashTable theElements;

--- a/Simulator/Utils/Matrix/SparseMatrix.h
+++ b/Simulator/Utils/Matrix/SparseMatrix.h
@@ -10,12 +10,12 @@
 #define _SPARSEMATRIX_H_
 
 #include <cmath>
-#include <string>
 #include <list>
+#include <string>
 #include <vector>
 
-#include "tinyxml.h"
 #include "Matrix.h"
+#include "tinyxml.h"
 #include "VectorMatrix.h"
 
 // Forward declarations
@@ -46,8 +46,8 @@ const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m);
 /// As a result, we can linearly scan a particular row or column to retrieve all of its
 /// elements, thus facilitating efficient math operations. We can also use the hash table
 /// to provide constant time random access by row and column, like a full 2D array would provide.
-class SparseMatrix: public Matrix {
-    
+class SparseMatrix : public Matrix {
+
 	/// @struct Element
 	/// @brief This structure is used to hold a non-zero element of a sparse matrix.
 	struct Element {
@@ -56,37 +56,30 @@ class SparseMatrix: public Matrix {
 		/// @param c column number
 		/// @param v value
 		Element(int r = 0, int c = 0, BGFLOAT v = 0.0) :
-        row( r ), column( c ), value( v ) {
-		}
-        
+			row(r), column(c), value(v) { }
+
 		/// @brief Two Elements are equal if they have the same (row, column) coordinates
 		/// @return true if two Elements are at the same coordinates
-		bool operator==(Element rhs) const {
-			return is_at( rhs.row, rhs.column );
-		}
-        
+		bool operator==(Element rhs) const { return is_at(rhs.row, rhs.column); }
+
 		/// @brief Two Elements are not equal if they have different (row, column) coordinates
 		/// @return true if two Elements are at different coordinates
-		bool operator!=(Element rhs) const {
-			return !is_at( rhs.row, rhs.column );
-		}
-        
+		bool operator!=(Element rhs) const { return !is_at(rhs.row, rhs.column); }
+
 		/// @brief Checks to see if Element is at particular (row, column) coordinates
 		/// @return true if Element is at specified coordinates
-		bool is_at(int r, int c) const {
-			return ( row == r ) && ( column == c );
-		}
-        
+		bool is_at(int r, int c) const { return (row == r) && (column == c); }
+
 		/// Row location of item 
 		int row;
-        
+
 		/// Column location of item
 		int column;
-        
+
 		/// The value at the current row, column
 		BGFLOAT value;
 	};
-    
+
 	/// @class HashTable
 	/// @brief Specialized hash table for pointers to Elements.
     /// 
@@ -95,260 +88,245 @@ class SparseMatrix: public Matrix {
     /// a SparseMatrix never shrinks.
 	class HashTable {
 		friend class SparseMatrix;
+		public:
+			/// @brief allocates and initializes hash table of given capacity
+			/// @param s table capacity
+			/// @param c number of columns in enclosing SparseMatrix
+			/// @param m pointer to enclosing SparseMatrix
+			HashTable(int s = 0, int c = 0, SparseMatrix* m = nullptr) :
+				capacity(s), size(0), columns(c), table(s, static_cast<Element*>(nullptr)), theMatrix(m) { }
+
+			/// @brief resize hash table and initialize elements
+			/// @param s the new table capacity
+			/// @param c the new number of columns
+			void resize(int s, int c);
+
+			/// @brief removes all elements from the hash table
+			void clear(void);
+
+			/// Inserts Element into the hash table using linear
+			/// probing. If the Element is already in the table, an exception is
+			/// thrown  (the update method should be used to update a value).
+			/// @param el pointer to the Element to insert
+			/// @throws Matrix_bad_alloc
+			/// @throws Matrix_invalid_argument
+			void insert(Element* el);
+
+			/// Retrieves Element from the hash table using linear
+			/// probing. If Element isn't in the table, returns nullptr. Any
+			/// zero-value elements found in the hash table are deleted along
+			/// the way.
+			/// @param r row coordinate of Element
+			/// @param c column coordinate of Element
+			/// @return pointer to Element (nullptr if not in table)
+			Element* retrieve(int r, int c);
+
+			/// Updates the Element already in the table using linear
+			/// probing. If Element isn't in the table, throws and exception
+			/// (use insert to add new Elements to the table).
+			/// @param r row coordinate of Element
+			/// @param c column coordinate of Element
+			/// @param v new value for Element
+			/// @throws Matrix_invalid_argument
+			void update(int r, int c, BGFLOAT v);
+
+			/// @brief returns the number of elements currently in the hash table.
+			/// @return size
+			int getSize(void) const { return size; }
+
+		private:
+			/// @brief Hashes Elements into hash table
+			int hash(Element* el) const { return hash(el->row, el->column); }
+
+			/// @brief computes initial hash location based on row and column coordinates.
+			int hash(int r, int c) const { return (r * columns + c) % capacity; }
+
+			/// A special Element to mark deleted table locations
+			static Element deleted;
+
+			/// Number of items the table can hold
+			int capacity;
+
+			/// Number of items actually in the table
+			int size;
+
+			/// Number of columns in the enclosing SparseMatrix
+			int columns;
+
+			/// The hash table itself
+			std::vector<Element*> table;
+
+			/// Pointer to container object, for calling its methods
+			SparseMatrix* theMatrix;
+	};
+
 	public:
-        
-		/// @brief allocates and initializes hash table of given capacity
-		/// @param s table capacity
-		/// @param c number of columns in enclosing SparseMatrix
-		/// @param m pointer to enclosing SparseMatrix
-		HashTable(int s = 0, int c = 0, SparseMatrix* m = nullptr) :
-        capacity( s ), size( 0 ), columns( c ), table( s, static_cast<Element*> ( nullptr ) ), theMatrix( m ) {
-		}
-		/// @brief resize hash table and initialize elements
-		/// @param s the new table capacity
-		/// @param c the new number of columns
-		void resize(int s, int c);
-        
-		/// @brief removes all elements from the hash table
-		void clear(void);
-        
-		/// Inserts Element into the hash table using linear
-		/// probing. If the Element is already in the table, an exception is
-		/// thrown  (the update method should be used to update a value).
-		/// @param el pointer to the Element to insert
+		/// Allocate storage and initialize attributes for a
+		/// sparse matrix with explicit row data. The parameter e is used as a
+		/// source of data for initializing the matrix (and must be the
+		/// pointer to the Matrix element in the XML).
 		/// @throws Matrix_bad_alloc
 		/// @throws Matrix_invalid_argument
-		void insert(Element* el);
-        
-		/// Retrieves Element from the hash table using linear
-		/// probing. If Element isn't in the table, returns nullptr. Any
-		/// zero-value elements found in the hash table are deleted along
-		/// the way.
-		/// @param r row coordinate of Element
-		/// @param c column coordinate of Element
-		/// @return pointer to Element (nullptr if not in table)
-		Element* retrieve(int r, int c);
-        
-		/// Updates the Element already in the table using linear
-		/// probing. If Element isn't in the table, throws and exception
-		/// (use insert to add new Elements to the table).
-		/// @param r row coordinate of Element
-		/// @param c column coordinate of Element
-		/// @param v new value for Element
-		/// @throws Matrix_invalid_argument
-		void update(int r, int c, BGFLOAT v);
-        
-		/// @brief returns the number of elements currently in the hash table.
-		/// @return size
-		int getSize(void) const {
-			return size;
-		}
-        
-	private:
-        
-		/// @brief Hashes Elements into hash table
-		int hash(Element* el) const {
-			return hash( el->row, el->column );
-		}
-        
-		/// @brief computes initial hash location based on row and column coordinates.
-		int hash(int r, int c) const {
-			return ( r * columns + c ) % capacity;
-		}
-        
-		/// A special Element to mark deleted table locations
-		static Element deleted;
-        
-		/// Number of items the table can hold
-		int capacity;
-        
-		/// Number of items actually in the table
-		int size;
-        
-		/// Number of columns in the enclosing SparseMatrix
-		int columns;
-        
-		/// The hash table itself
-		std::vector<Element*> table;
-        
-		/// Pointer to container object, for calling its methods
-		SparseMatrix* theMatrix;
-	};
-    
-public:
-    
-	/// Allocate storage and initialize attributes for a
-	/// sparse matrix with explicit row data. The parameter e is used as a
-	/// source of data for initializing the matrix (and must be the
-	/// pointer to the Matrix element in the XML).
-	/// @throws Matrix_bad_alloc
-	/// @throws Matrix_invalid_argument
-	/// @param r rows in Matrix
-	/// @param c columns in Matrix
-	/// @param m multiplier used for initialization
-	/// @param e pointer to Matrix element in XML
-	SparseMatrix(int r, int c, BGFLOAT m, TiXmlElement* e);
-    
-	/// Allocate storage and initialize attributes for a
-	/// diagonal sparse matrix with explicit row data. The parameter v is
-	/// used as a source of data for initializing the matrix (and must be
-	/// a string of numbers equal to the number of rows or columns). If v
-	/// is nullptr, then the multiplier is used to initialize the diagonal
-	/// elements.
-	/// @throws Matrix_bad_alloc
-	/// @throws Matrix_invalid_argument
-	/// @param r rows in Matrix
-	/// @param c columns in Matrix
-	/// @param m multiplier used for initialization (and must be non-zero)
-	/// @param v string of initialization values
-	SparseMatrix(int r, int c, BGFLOAT m, const char* v = nullptr);
-    
-	/// Allocate storage and initialize attributes for an
-	/// empty sparse matrix. This is also the default constructor.
-	/// @throws Matrix_bad_alloc
-	/// @throws Matrix_invalid_argument
-	/// @param r rows in Matrix
-	/// @param c columns in Matrix
-	SparseMatrix(int r = 1, int c = 1);
-    
-	/// @brief Copy constructor. Performs a deep copy.
-	/// @param oldM The source SparseMatrix
-	SparseMatrix(const SparseMatrix& oldM);
-    
-	/// @brief De-allocate storage
-	virtual ~SparseMatrix();
-    
-	/// @brief Assignment operator
-	/// @param rhs right-hand side of assignment
-	/// @return returns reference to this SparseMatrix (after assignment)
-	SparseMatrix& operator=(const SparseMatrix& rhs);
-    
-	/// @brief Access value of element at (row, column) -- mutator.
-    /// 
-	/// Constant time as long as number of items in the N x M SparseMatrix
-	/// is less than 4*sqrt(N*M). **If there is no element at the given
-	/// location, then a zero value one is created.** This is done because this
-    /// method is usable as a mutator: it returns a reference to the value in the
-    /// specified element. If this becomes a problem in other code, then the solution
-    /// would be to add an accessor that either throws an exception if an element
-    /// doesn't exist or that returns both the element value and a success/failure
-    /// flag.
-	/// @param r element row
-	/// @param c element column
-	/// @return reference to value of element at that location
-	BGFLOAT& operator()(int r, int c);
-    
-	/// @brief Returns the number of elements in the sparse matrix.
-	/// @return number of elements
-	int size(void) const {
-		return theElements.getSize( );
-	}
-    
-	/// @brief Polymorphic output. Produces text output on stream "os". Output is by row.
-	/// @param os stream to output to
-	virtual void Print(std::ostream& os) const override;
-    
-	/// @brief Produce XML representation of Matrix in string return value.
-	virtual std::string toXML(std::string name = "") const;
-    
-	/******************************************
-	* @name Math Operations
-    * 
-	* Math operations. For efficiency's sake, these methods will be
-	* implemented as being "aware" of each other (i.e., using "friend"
-	* and including the other subclasses' headers).
-	******************************************/
-	//@{
-    
-	/// Unary minus. Negate all elements of the SparseMatrix.
-	/// @return A new SparseMatrix, with same size as the current one.
-	virtual const SparseMatrix operator-() const;
-    
-	/// Compute the sum of two SparseMatrices of the same
-	/// rows and columns.
-	/// @throws Matrix_domain_error
-	/// @param rhs right-hand argument to the addition. Must have same
-	/// dimensions as this.
-	/// @return A new SparseMatrix, with value equal to the sum of this
-	/// one and rhs and rows and columns the same as both, returned by value.
-	virtual const SparseMatrix operator+(const SparseMatrix& rhs) const;
-    
-	/// Matrix product. Number of rows of "rhs" must equal to
-	/// number of columns of this.
-	/// @throws Matrix_domain_error
-	/// @param rhs right-hand argument to the product.
-	/// @return A SparseMatrix with number of rows equal to this and
-	/// number of columns equal to "rhs".
-	virtual const SparseMatrix operator*(const SparseMatrix& rhs) const;
-    
-	/// Matrix times vector. Size of v must equal to
-	/// number of rows of m. Size of resultant vector is equal to
-	/// number Of columns of m.
-	/// @throws Matrix_domain_error
-	/// @return A VectorMatrix with size equal to number of columns of m.
-	friend const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m);
-	//@}
-    
-protected:
-    
-	/******************************************
-	* @name Internal Utilities
-	******************************************/
-	//@{
-    
-	/// @brief Frees up all dynamically allocated storage
-	void clear(void);
-    
-	/// Remove an Element from the SparseMatrix lists (but not
-	/// the hash table). This is meant to be called from a HashTable
-	/// method.
-	void remove_lists(Element* el);
-    
-	/// Performs a deep copy. It is assumed that the correct
-	/// storage has already been allocated and all "simple" data members
-	/// have already had their values copied.
-	/// @param source VectorMatrix to copy from
-	void copy(const SparseMatrix& source);
-    
-	/// Allocates storage for internal storage. Assumes that
-	/// no storage has already been allocated (i.e., must call clear()
-	/// before this if not in a constructor) and that all
-	/// simple data members (specifically, #rows and
-	/// #columns) have been correctly set.
-	/// @throws Matrix_bad_alloc
-	/// @throws MatrixException
-	void alloc(void);
+		/// @param r rows in Matrix
+		/// @param c columns in Matrix
+		/// @param m multiplier used for initialization
+		/// @param e pointer to Matrix element in XML
+		SparseMatrix(int r, int c, BGFLOAT m, TiXmlElement* e);
 
-	/// @brief Reads a row of the sparse Matrix from XML
-	/// @param rowElement pointer to Row XML element
-	/// @throws Matrix_invalid_argument
-	void rowFromXML(TiXmlElement* rowElement);
-	//@}
-    
-	// access adjustment --- allow member functions in this class to
-	// access protected member of base class in other objects.
-    using Matrix::dimensions;
-    
-private:
-    
-	/// Determines the maximum number of elements that a
-	/// SparseMatrix can hold, based on its dimensions.
-	/// @param r number of rows in matrix
-	/// @param c number of columns in matrix
-	/// @return maximum capacity of matrix
-	int MaxElements(int r, int c)
-	{	return r * c;}
-    
-	/// 1D array of lists of elements in a row
-	std::list<Element*> *theRows;
-    
-	/// 1D array of lists of elements in a column
-	std::list<Element*> *theColumns;
-    
-	/// Hash table used to access elements by coordinates
-	HashTable theElements;
-    
+		/// Allocate storage and initialize attributes for a
+		/// diagonal sparse matrix with explicit row data. The parameter v is
+		/// used as a source of data for initializing the matrix (and must be
+		/// a string of numbers equal to the number of rows or columns). If v
+		/// is nullptr, then the multiplier is used to initialize the diagonal
+		/// elements.
+		/// @throws Matrix_bad_alloc
+		/// @throws Matrix_invalid_argument
+		/// @param r rows in Matrix
+		/// @param c columns in Matrix
+		/// @param m multiplier used for initialization (and must be non-zero)
+		/// @param v string of initialization values
+		SparseMatrix(int r, int c, BGFLOAT m, const char* v = nullptr);
+
+		/// Allocate storage and initialize attributes for an
+		/// empty sparse matrix. This is also the default constructor.
+		/// @throws Matrix_bad_alloc
+		/// @throws Matrix_invalid_argument
+		/// @param r rows in Matrix
+		/// @param c columns in Matrix
+		SparseMatrix(int r = 1, int c = 1);
+
+		/// @brief Copy constructor. Performs a deep copy.
+		/// @param oldM The source SparseMatrix
+		SparseMatrix(const SparseMatrix& oldM);
+
+		/// @brief De-allocate storage
+		~SparseMatrix() override;
+
+		/// @brief Assignment operator
+		/// @param rhs right-hand side of assignment
+		/// @return returns reference to this SparseMatrix (after assignment)
+		SparseMatrix& operator=(const SparseMatrix& rhs);
+
+		/// @brief Access value of element at (row, column) -- mutator.
+	    /// 
+		/// Constant time as long as number of items in the N x M SparseMatrix
+		/// is less than 4*sqrt(N*M). **If there is no element at the given
+		/// location, then a zero value one is created.** This is done because this
+	    /// method is usable as a mutator: it returns a reference to the value in the
+	    /// specified element. If this becomes a problem in other code, then the solution
+	    /// would be to add an accessor that either throws an exception if an element
+	    /// doesn't exist or that returns both the element value and a success/failure
+	    /// flag.
+		/// @param r element row
+		/// @param c element column
+		/// @return reference to value of element at that location
+		BGFLOAT& operator()(int r, int c);
+
+		/// @brief Returns the number of elements in the sparse matrix.
+		/// @return number of elements
+		int size(void) const { return theElements.getSize(); }
+
+		/// @brief Polymorphic output. Produces text output on stream "os". Output is by row.
+		/// @param os stream to output to
+		void Print(std::ostream& os) const override;
+
+		/// @brief Produce XML representation of Matrix in string return value.
+		virtual std::string toXML(std::string name = "") const;
+
+		/******************************************
+		* @name Math Operations
+	    * 
+		* Math operations. For efficiency's sake, these methods will be
+		* implemented as being "aware" of each other (i.e., using "friend"
+		* and including the other subclasses' headers).
+		******************************************/
+		//@{
+
+		/// Unary minus. Negate all elements of the SparseMatrix.
+		/// @return A new SparseMatrix, with same size as the current one.
+		virtual const SparseMatrix operator-() const;
+
+		/// Compute the sum of two SparseMatrices of the same
+		/// rows and columns.
+		/// @throws Matrix_domain_error
+		/// @param rhs right-hand argument to the addition. Must have same
+		/// dimensions as this.
+		/// @return A new SparseMatrix, with value equal to the sum of this
+		/// one and rhs and rows and columns the same as both, returned by value.
+		virtual const SparseMatrix operator+(const SparseMatrix& rhs) const;
+
+		/// Matrix product. Number of rows of "rhs" must equal to
+		/// number of columns of this.
+		/// @throws Matrix_domain_error
+		/// @param rhs right-hand argument to the product.
+		/// @return A SparseMatrix with number of rows equal to this and
+		/// number of columns equal to "rhs".
+		virtual const SparseMatrix operator*(const SparseMatrix& rhs) const;
+
+		/// Matrix times vector. Size of v must equal to
+		/// number of rows of m. Size of resultant vector is equal to
+		/// number Of columns of m.
+		/// @throws Matrix_domain_error
+		/// @return A VectorMatrix with size equal to number of columns of m.
+		friend const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m);
+		//@}
+
+	protected:
+		/******************************************
+		* @name Internal Utilities
+		******************************************/
+		//@{
+
+		/// @brief Frees up all dynamically allocated storage
+		void clear(void);
+
+		/// Remove an Element from the SparseMatrix lists (but not
+		/// the hash table). This is meant to be called from a HashTable
+		/// method.
+		void remove_lists(Element* el);
+
+		/// Performs a deep copy. It is assumed that the correct
+		/// storage has already been allocated and all "simple" data members
+		/// have already had their values copied.
+		/// @param source VectorMatrix to copy from
+		void copy(const SparseMatrix& source);
+
+		/// Allocates storage for internal storage. Assumes that
+		/// no storage has already been allocated (i.e., must call clear()
+		/// before this if not in a constructor) and that all
+		/// simple data members (specifically, #rows and
+		/// #columns) have been correctly set.
+		/// @throws Matrix_bad_alloc
+		/// @throws MatrixException
+		void alloc(void);
+
+		/// @brief Reads a row of the sparse Matrix from XML
+		/// @param rowElement pointer to Row XML element
+		/// @throws Matrix_invalid_argument
+		void rowFromXML(TiXmlElement* rowElement);
+		//@}
+
+		// access adjustment --- allow member functions in this class to
+		// access protected member of base class in other objects.
+		using Matrix::dimensions;
+
+	private:
+		/// Determines the maximum number of elements that a
+		/// SparseMatrix can hold, based on its dimensions.
+		/// @param r number of rows in matrix
+		/// @param c number of columns in matrix
+		/// @return maximum capacity of matrix
+		int MaxElements(int r, int c) { return r * c; }
+
+		/// 1D array of lists of elements in a row
+		std::list<Element*>* theRows;
+
+		/// 1D array of lists of elements in a column
+		std::list<Element*>* theColumns;
+
+		/// Hash table used to access elements by coordinates
+		HashTable theElements;
+
 };
 
 #endif
-

--- a/Simulator/Utils/Matrix/VectorMatrix.cpp
+++ b/Simulator/Utils/Matrix/VectorMatrix.cpp
@@ -10,8 +10,8 @@
 #include <iostream>
 #include <sstream>
 
-#include "Global.h"
 #include "VectorMatrix.h"
+#include "Global.h"
 
 // Classwide normal RNG
 Norm VectorMatrix::nRng;
@@ -34,8 +34,8 @@ VectorMatrix::VectorMatrix(std::string t, std::string i, int r, int c, BGFLOAT m
 	DEBUG_VECTOR(std::cerr << "Creating VectorMatrix, size: ";)
 
 	// Bail out if we're being asked to create nonsense
-	if (!((rows == 1) || (columns == 1)) || (rows == 0) || (columns == 0))
-		throw Matrix_invalid_argument("VectorMatrix: Asked to create 2D or zero-size");
+	if (!((rows == 1) || (columns == 1)) || (rows == 0) || (columns == 0)) throw Matrix_invalid_argument(
+		"VectorMatrix: Asked to create 2D or zero-size");
 
 	// We're a 1D Matrix
 	dimensions = 1;
@@ -45,32 +45,37 @@ VectorMatrix::VectorMatrix(std::string t, std::string i, int r, int c, BGFLOAT m
 
 	alloc(size);
 
-	if (values != "") { // Initialize from the text string
+	if (values != "") {
+		// Initialize from the text string
 		std::istringstream valStream(values);
-		if (type == "complete") { // complete matrix with values given
+		if (type == "complete") {
+			// complete matrix with values given
 			for (int i = 0; i < size; i++) {
 				valStream >> theVector[i];
 				theVector[i] *= multiplier;
 			}
-		} else {
+		}
+		else {
 			clear();
 			throw Matrix_invalid_argument("Illegal type for VectorMatrix with 'none' init: " + type);
 		}
-	} else if (init == "const") {
-		if (type == "complete") { // complete matrix with constant values
-			for (int i = 0; i < size; i++)
-				theVector[i] = multiplier;
-		} else {
+	}
+	else if (init == "const") {
+		if (type == "complete") {
+			// complete matrix with constant values
+			for (int i = 0; i < size; i++) theVector[i] = multiplier;
+		}
+		else {
 			clear();
 			throw Matrix_invalid_argument("Illegal type for VectorMatrix with 'none' init: " + type);
 		}
-	} else if (init == "random") {
+	}
+	else if (init == "random") {
 		// Initialize with normally distributed random numbers with zero
 		// mean and unit variance
-		for (int i = 0; i < size; i++) {
-			theVector[i] = nRng();
-		}
-	} else {
+		for (int i = 0; i < size; i++) theVector[i] = nRng();
+	}
+	else {
 		clear();
 		throw Matrix_invalid_argument("Illegal initialization for VectorMatrix: " + init);
 	}
@@ -79,22 +84,18 @@ VectorMatrix::VectorMatrix(std::string t, std::string i, int r, int c, BGFLOAT m
 
 // Copy constructor
 VectorMatrix::VectorMatrix(const VectorMatrix& oldV) :
-	theVector(nullptr) {
-	copy(oldV);
-}
+	theVector(nullptr) { copy(oldV); }
 
 // Assignment operator: set elements of vector to constant
 const VectorMatrix& VectorMatrix::operator=(BGFLOAT c) {
-	for (int i = 0; i < size; i++)
-		theVector[i] = c;
+	for (int i = 0; i < size; i++) theVector[i] = c;
 
 	return *this;
 }
 
 // Assignment operator
 const VectorMatrix& VectorMatrix::operator=(const VectorMatrix& rhs) {
-	if (&rhs == this)
-		return *this;
+	if (&rhs == this) return *this;
 
 	clear();
 	copy(rhs);
@@ -102,9 +103,7 @@ const VectorMatrix& VectorMatrix::operator=(const VectorMatrix& rhs) {
 }
 
 // Destructor
-VectorMatrix::~VectorMatrix() {
-	clear();
-}
+VectorMatrix::~VectorMatrix() { clear(); }
 
 // Clear out storage
 void VectorMatrix::clear(void) {
@@ -118,40 +117,32 @@ void VectorMatrix::clear(void) {
 void VectorMatrix::copy(const VectorMatrix& source) {
 	size = source.size;
 	SetAttributes(source.type, source.init, source.rows, source.columns, source.multiplier,
-			source.dimensions);
+	              source.dimensions);
 
 	alloc(size);
 
-	for (int i = 0; i < size; i++)
-		theVector[i] = source.theVector[i];
+	for (int i = 0; i < size; i++) theVector[i] = source.theVector[i];
 }
 
 // Allocate internal storage
 void VectorMatrix::alloc(int size) {
-	if (theVector != nullptr)
-		throw MatrixException("Attempt to allocate storage for non-cleared Vector.");
+	if (theVector != nullptr) throw MatrixException("Attempt to allocate storage for non-cleared Vector.");
 
-	if ((theVector = new BGFLOAT[size]) == nullptr) {
-		throw Matrix_bad_alloc("Failed allocating storage of Vector copy.");
-	}
+	if ((theVector = new BGFLOAT[size]) == nullptr) throw Matrix_bad_alloc("Failed allocating storage of Vector copy.");
 
 	DEBUG_VECTOR(std::cerr << "\tStorage allocated for "<< size << " element Vector." << std::endl;)
 
 }
 
 // Polymorphic output
-void VectorMatrix::Print(std::ostream& os) const {
-	for (int i = 0; i < size; i++)
-		os << theVector[i] << " ";
-}
+void VectorMatrix::Print(std::ostream& os) const { for (int i = 0; i < size; i++) os << theVector[i] << " "; }
 
 // convert vector to XML string
 std::string VectorMatrix::toXML(std::string name) const {
 	std::stringstream os;
 
 	os << "<Matrix ";
-	if (name != "")
-		os << "name=\"" << name << "\" ";
+	if (name != "") os << "name=\"" << name << "\" ";
 	os << "type=\"complete\" rows=\"1\" columns=\"" << size << "\" multiplier=\"1.0\">" << std::endl;
 	os << "   " << *this << std::endl;
 	os << "</Matrix>";
@@ -162,16 +153,13 @@ std::string VectorMatrix::toXML(std::string name) const {
 // The math operations
 
 const VectorMatrix VectorMatrix::operator+(const VectorMatrix& rhs) const {
-	if (rhs.size != size) {
-		throw Matrix_domain_error("Illegal vector sum. Vectors must be equal length.");
-	}
+	if (rhs.size != size) throw Matrix_domain_error("Illegal vector sum. Vectors must be equal length.");
 
 	// Start with this
 	VectorMatrix result(*this);
 
 	// Add in rhs
-	for (int i = 0; i < size; i++)
-		result.theVector[i] += rhs.theVector[i];
+	for (int i = 0; i < size; i++) result.theVector[i] += rhs.theVector[i];
 
 	return result;
 }
@@ -181,25 +169,21 @@ const VectorMatrix VectorMatrix::operator+(BGFLOAT c) const {
 	// Start with this
 	VectorMatrix result(*this);
 
-	for (int i = 0; i < size; i++)
-		result.theVector[i] += c;
+	for (int i = 0; i < size; i++) result.theVector[i] += c;
 
 	return result;
 }
 
 // There are two possible products. This is an inner product.
 BGFLOAT VectorMatrix::operator*(const VectorMatrix& rhs) const {
-	if (rhs.size != size) {
-		throw Matrix_domain_error("Illegal vector inner product. Vectors must be equal length.");
-	}
+	if (rhs.size != size) throw Matrix_domain_error("Illegal vector inner product. Vectors must be equal length.");
 
 	// the result is scalar
 	BGFLOAT result;
 
 	result = theVector[0] * rhs.theVector[0];
 
-	for (int i = 1; i < size; i++)
-		result += theVector[i] * rhs.theVector[i];
+	for (int i = 1; i < size; i++) result += theVector[i] * rhs.theVector[i];
 
 	return result;
 }
@@ -208,31 +192,28 @@ BGFLOAT VectorMatrix::operator*(const VectorMatrix& rhs) const {
 const VectorMatrix VectorMatrix::operator*(const CompleteMatrix& rhs) const {
 	if (rhs.rows != size) {
 		throw Matrix_domain_error(
-				"Illegal vector/matrix product. Rows of matrix must equal vector size.");
+			"Illegal vector/matrix product. Rows of matrix must equal vector size.");
 	}
 
 	// the result is a vector the same size as rhs columns
 	VectorMatrix result("complete", "const", 1, rhs.columns, 0.0, "");
 
-	for (int i = 0; i < result.size; i++)
+	for (int i = 0; i < result.size; i++) {
 		// Compute each element of the result
-		for (int j = 0; j < size; j++)
-			result.theVector[i] += theVector[j] * rhs.theMatrix[j][i];
+		for (int j = 0; j < size; j++) result.theVector[i] += theVector[j] * rhs.theMatrix[j][i];
+	}
 
 	return result;
 }
 
 const VectorMatrix VectorMatrix::ArrayMultiply(const VectorMatrix& rhs) const {
-	if (rhs.size != size) {
-		throw Matrix_domain_error("Illegal array product. Vectors must be equal length.");
-	}
+	if (rhs.size != size) throw Matrix_domain_error("Illegal array product. Vectors must be equal length.");
 
 	// Start with this
 	VectorMatrix result(*this);
 
 	// Multiply elements of rhs
-	for (int i = 0; i < size; i++)
-		result.theVector[i] *= rhs.theVector[i];
+	for (int i = 0; i < size; i++) result.theVector[i] *= rhs.theVector[i];
 
 	return result;
 }
@@ -242,8 +223,7 @@ const VectorMatrix VectorMatrix::operator*(BGFLOAT c) const {
 	// Start with this
 	VectorMatrix result(*this);
 
-	for (int i = 0; i < size; i++)
-		result.theVector[i] *= c;
+	for (int i = 0; i < size; i++) result.theVector[i] *= c;
 
 	return result;
 }
@@ -253,8 +233,7 @@ const VectorMatrix VectorMatrix::operator/(BGFLOAT c) const {
 	// Start with this
 	VectorMatrix result(*this);
 
-	for (int i = 0; i < size; i++)
-		result.theVector[i] /= c;
+	for (int i = 0; i < size; i++) result.theVector[i] /= c;
 
 	return result;
 }
@@ -264,8 +243,7 @@ const VectorMatrix operator-(BGFLOAT c, const VectorMatrix& v) {
 	// Start with vector
 	VectorMatrix result(v);
 
-	for (int i = 0; i < result.size; i++)
-		result.theVector[i] = c - result.theVector[i];
+	for (int i = 0; i < result.size; i++) result.theVector[i] = c - result.theVector[i];
 
 	return result;
 }
@@ -275,8 +253,7 @@ const VectorMatrix operator/(BGFLOAT c, const VectorMatrix& v) {
 	// Start with vector
 	VectorMatrix result(v);
 
-	for (int i = 0; i < result.size; i++)
-		result.theVector[i] = c / result.theVector[i];
+	for (int i = 0; i < result.size; i++) result.theVector[i] = c / result.theVector[i];
 
 	return result;
 }
@@ -287,10 +264,8 @@ const VectorMatrix VectorMatrix::Limit(BGFLOAT low, BGFLOAT high) const {
 	VectorMatrix result(*this);
 
 	for (int i = 0; i < size; i++) {
-		if (result.theVector[i] < low)
-			result.theVector[i] = low;
-		if (result.theVector[i] > high)
-			result.theVector[i] = high;
+		if (result.theVector[i] < low) result.theVector[i] = low;
+		if (result.theVector[i] > high) result.theVector[i] = high;
 	}
 
 	return result;
@@ -300,9 +275,7 @@ const VectorMatrix VectorMatrix::Limit(BGFLOAT low, BGFLOAT high) const {
 BGFLOAT VectorMatrix::Min(void) const {
 	BGFLOAT min = theVector[0];
 
-	for (int i = 1; i < size; i++)
-		if (theVector[i] < min)
-			min = theVector[i];
+	for (int i = 1; i < size; i++) { if (theVector[i] < min) min = theVector[i]; }
 
 	return min;
 }
@@ -311,9 +284,7 @@ BGFLOAT VectorMatrix::Min(void) const {
 BGFLOAT VectorMatrix::Max(void) const {
 	BGFLOAT max = theVector[0];
 
-	for (int i = 1; i < size; i++)
-		if (theVector[i] > max)
-			max = theVector[i];
+	for (int i = 1; i < size; i++) { if (theVector[i] > max) max = theVector[i]; }
 
 	return max;
 }
@@ -323,8 +294,7 @@ const VectorMatrix sqrt(const VectorMatrix& v) {
 	// Start with vector
 	VectorMatrix result(v);
 
-	for (int i = 0; i < result.size; i++)
-		result.theVector[i] = sqrt(result.theVector[i]);
+	for (int i = 0; i < result.size; i++) result.theVector[i] = sqrt(result.theVector[i]);
 
 	return result;
 }
@@ -334,21 +304,16 @@ const VectorMatrix exp(const VectorMatrix& v) {
 	// Start with vector
 	VectorMatrix result(v);
 
-	for (int i = 0; i < result.size; i++)
-		result.theVector[i] = exp(result.theVector[i]);
+	for (int i = 0; i < result.size; i++) result.theVector[i] = exp(result.theVector[i]);
 
 	return result;
 }
 
 const VectorMatrix& VectorMatrix::operator+=(const VectorMatrix& rhs) {
-	if (rhs.size != size) {
-		throw Matrix_domain_error("Illegal vector sum. Vectors must be equal length.");
-	}
+	if (rhs.size != size) throw Matrix_domain_error("Illegal vector sum. Vectors must be equal length.");
 
 	// Add in rhs
-	for (int i = 0; i < size; i++)
-		theVector[i] += rhs.theVector[i];
+	for (int i = 0; i < size; i++) theVector[i] += rhs.theVector[i];
 
 	return *this;
 }
-

--- a/Simulator/Utils/Matrix/VectorMatrix.cpp
+++ b/Simulator/Utils/Matrix/VectorMatrix.cpp
@@ -29,9 +29,9 @@ Norm VectorMatrix::nRng;
 /// @param c columns in Matrix
 /// @param m multiplier used for initialization
 /// @param v values for initializing VectorMatrix
-VectorMatrix::VectorMatrix(string t, string i, int r, int c, BGFLOAT m, string values) :
+VectorMatrix::VectorMatrix(std::string t, std::string i, int r, int c, BGFLOAT m, std::string values) :
 	Matrix(t, i, r, c, m), theVector(nullptr) {
-	DEBUG_VECTOR(cerr << "Creating VectorMatrix, size: ";)
+	DEBUG_VECTOR(std::cerr << "Creating VectorMatrix, size: ";)
 
 	// Bail out if we're being asked to create nonsense
 	if (!((rows == 1) || (columns == 1)) || (rows == 0) || (columns == 0))
@@ -41,12 +41,12 @@ VectorMatrix::VectorMatrix(string t, string i, int r, int c, BGFLOAT m, string v
 	dimensions = 1;
 	size = (rows > columns) ? rows : columns;
 
-	DEBUG_VECTOR(cerr << rows << "X" << columns << ":" << endl;)
+	DEBUG_VECTOR(std::cerr << rows << "X" << columns << ":" << std::endl;)
 
 	alloc(size);
 
 	if (values != "") { // Initialize from the text string
-		istringstream valStream(values);
+		std::istringstream valStream(values);
 		if (type == "complete") { // complete matrix with values given
 			for (int i = 0; i < size; i++) {
 				valStream >> theVector[i];
@@ -74,7 +74,7 @@ VectorMatrix::VectorMatrix(string t, string i, int r, int c, BGFLOAT m, string v
 		clear();
 		throw Matrix_invalid_argument("Illegal initialization for VectorMatrix: " + init);
 	}
-	DEBUG_VECTOR(cerr << "\tInitialized " << type << " vector to " << *this << endl;)
+	DEBUG_VECTOR(std::cerr << "\tInitialized " << type << " vector to " << *this << std::endl;)
 }
 
 // Copy constructor
@@ -135,25 +135,25 @@ void VectorMatrix::alloc(int size) {
 		throw Matrix_bad_alloc("Failed allocating storage of Vector copy.");
 	}
 
-	DEBUG_VECTOR(cerr << "\tStorage allocated for "<< size << " element Vector." << endl;)
+	DEBUG_VECTOR(std::cerr << "\tStorage allocated for "<< size << " element Vector." << std::endl;)
 
 }
 
 // Polymorphic output
-void VectorMatrix::Print(ostream& os) const {
+void VectorMatrix::Print(std::ostream& os) const {
 	for (int i = 0; i < size; i++)
 		os << theVector[i] << " ";
 }
 
 // convert vector to XML string
-string VectorMatrix::toXML(string name) const {
-	stringstream os;
+std::string VectorMatrix::toXML(std::string name) const {
+	std::stringstream os;
 
 	os << "<Matrix ";
 	if (name != "")
 		os << "name=\"" << name << "\" ";
-	os << "type=\"complete\" rows=\"1\" columns=\"" << size << "\" multiplier=\"1.0\">" << endl;
-	os << "   " << *this << endl;
+	os << "type=\"complete\" rows=\"1\" columns=\"" << size << "\" multiplier=\"1.0\">" << std::endl;
+	os << "   " << *this << std::endl;
 	os << "</Matrix>";
 
 	return os.str();

--- a/Simulator/Utils/Matrix/VectorMatrix.cpp
+++ b/Simulator/Utils/Matrix/VectorMatrix.cpp
@@ -34,8 +34,10 @@ VectorMatrix::VectorMatrix(std::string t, std::string i, int r, int c, BGFLOAT m
 	DEBUG_VECTOR(std::cerr << "Creating VectorMatrix, size: ";)
 
 	// Bail out if we're being asked to create nonsense
-	if (!((rows == 1) || (columns == 1)) || (rows == 0) || (columns == 0)) throw Matrix_invalid_argument(
-		"VectorMatrix: Asked to create 2D or zero-size");
+	if (!((rows == 1) || (columns == 1)) || (rows == 0) || (columns == 0)) {
+		throw Matrix_invalid_argument(
+			"VectorMatrix: Asked to create 2D or zero-size");
+	}
 
 	// We're a 1D Matrix
 	dimensions = 1;
@@ -275,7 +277,7 @@ const VectorMatrix VectorMatrix::Limit(BGFLOAT low, BGFLOAT high) const {
 BGFLOAT VectorMatrix::Min(void) const {
 	BGFLOAT min = theVector[0];
 
-	for (int i = 1; i < size; i++) { if (theVector[i] < min) min = theVector[i]; }
+	for (int i = 1; i < size; i++) if (theVector[i] < min) min = theVector[i];
 
 	return min;
 }
@@ -284,7 +286,7 @@ BGFLOAT VectorMatrix::Min(void) const {
 BGFLOAT VectorMatrix::Max(void) const {
 	BGFLOAT max = theVector[0];
 
-	for (int i = 1; i < size; i++) { if (theVector[i] > max) max = theVector[i]; }
+	for (int i = 1; i < size; i++) if (theVector[i] > max) max = theVector[i];
 
 	return max;
 }

--- a/Simulator/Utils/Matrix/VectorMatrix.h
+++ b/Simulator/Utils/Matrix/VectorMatrix.h
@@ -98,12 +98,12 @@ class VectorMatrix : public Matrix {
 		///  @brief Access element of a VectorMatrix. Zero-based index; constant-time.
 		///  @param i index
 		///  @return item within this VectorMatrix
-		inline const BGFLOAT& operator[](int i) const { return theVector[i]; }
+		const BGFLOAT& operator[](int i) const { return theVector[i]; }
 
 		///  @brief access element of a VectorMatrix. Zero-based index; constant-time.
 		///  @param i index
 		///  @return item within this VectorMatrix
-		inline const BGFLOAT& at(int i) const { return theVector[i]; }
+		const BGFLOAT& at(int i) const { return theVector[i]; }
 
 		///  @brief The length of a VectorMatrix elements.
 		///  @return The number of elements in the VectorMatrix
@@ -119,12 +119,12 @@ class VectorMatrix : public Matrix {
 		///  @brief mutate element of a VectorMatrix. Zero-based index; constant time.
 		///  @param i index
 		///  @return Reference to item within this VectorMatrix
-		inline BGFLOAT& operator[](int i) { return theVector[i]; }
+		BGFLOAT& operator[](int i) { return theVector[i]; }
 
 		///  @brief mutate element of a VectorMatrix. Zero-based index.
 		///  @param i index
 		///  @return reference to item within this VectorMatrix
-		inline BGFLOAT& at(int i) { return theVector[i]; }
+		BGFLOAT& at(int i) { return theVector[i]; }
 		//@}
 
 		/******************************************
@@ -211,7 +211,7 @@ class VectorMatrix : public Matrix {
 		///  @param rhs The vector
 		///  @return A vector the same size as the rhs
 		friend
-		inline const VectorMatrix operator*(BGFLOAT c, const VectorMatrix& rhs) { return rhs * c; }
+		const VectorMatrix operator*(BGFLOAT c, const VectorMatrix& rhs) { return rhs * c; }
 
 		///  @brief Vector times sparse matrix.
 		///
@@ -240,7 +240,7 @@ class VectorMatrix : public Matrix {
 		///  @param rhs The vector
 		///  @return A vector the same size as the rhs
 		friend
-		inline const VectorMatrix operator+(BGFLOAT c, const VectorMatrix& rhs) { return rhs + c; }
+		const VectorMatrix operator+(BGFLOAT c, const VectorMatrix& rhs) { return rhs + c; }
 
 		///  @brief Element-wise square root of vector. Computes square root of each element of vector.
 		///  @param v The vector

--- a/Simulator/Utils/Matrix/VectorMatrix.h
+++ b/Simulator/Utils/Matrix/VectorMatrix.h
@@ -17,8 +17,6 @@
 #include "SparseMatrix.h"
 #include "Norm.h"
 
-using namespace std;
-
 // Forward declarations
 class VectorMatrix;
 class CompleteMatrix;
@@ -68,8 +66,8 @@ public:
   ///  @param c columns in Matrix
   ///  @param m multiplier used for initialization
   ///  @param v values for initializing VectorMatrix
-  VectorMatrix(string t = "complete", string i = "const", int r = 1,
-	       int c = 1, BGFLOAT m = 0.0, string v = "");
+  VectorMatrix(std::string t = "complete", std::string i = "const", int r = 1,
+	       int c = 1, BGFLOAT m = 0.0, std::string v = "");
 
   ///  @brief Copy constructor. Performs a deep copy.
   ///  @param oldV The source VectorMatrix
@@ -89,10 +87,10 @@ public:
 
   ///  @brief Polymorphic output. Produces text output on stream "os"
   ///  @param os stream to output to
-  virtual void Print(ostream& os) const;
+  virtual void Print(std::ostream& os) const;
 
-  ///  @brief Produce XML representation of vector in string return value.
-  virtual string toXML(string name="") const;
+  ///  @brief Produce XML representation of vector in std::string return value.
+  virtual std::string toXML(std::string name="") const;
 
   /******************************************
   *  @name Accessors

--- a/Simulator/Utils/Matrix/VectorMatrix.h
+++ b/Simulator/Utils/Matrix/VectorMatrix.h
@@ -12,10 +12,10 @@
 
 #include <string>
 
-#include "Matrix.h"
 #include "CompleteMatrix.h"
-#include "SparseMatrix.h"
+#include "Matrix.h"
 #include "Norm.h"
+#include "SparseMatrix.h"
 
 // Forward declarations
 class VectorMatrix;
@@ -49,257 +49,247 @@ const VectorMatrix exp(const VectorMatrix& v);
 ///  the number of rows and columns it has, no distinction is made
 ///  between row and column vectors, and in fact it is treated as either,
 ///  depending on the context of the mathematical operation.
-class VectorMatrix : public Matrix
-{
-public:
+class VectorMatrix : public Matrix {
+	public:
+		///  Allocate storage and initialize attributes. Either
+		///  "rows" or "columns" must be equal to 1. If "v" is not empty, it
+		///  will be used as a source of data for initializing the vector (and
+		///  must be a list of whitespace separated textual numeric data with the
+		///  same number of elements as this VectorMatrix).
+		///  @throws Matrix_bad_alloc
+		///  @throws Matrix_invalid_argument
+		///  @param t Matrix type
+		///  @param i Matrix initialization
+		///  @param r rows in Matrix
+		///  @param c columns in Matrix
+		///  @param m multiplier used for initialization
+		///  @param v values for initializing VectorMatrix
+		VectorMatrix(std::string t = "complete", std::string i = "const", int r = 1,
+		             int c = 1, BGFLOAT m = 0.0, std::string v = "");
 
-  ///  Allocate storage and initialize attributes. Either
-  ///  "rows" or "columns" must be equal to 1. If "v" is not empty, it
-  ///  will be used as a source of data for initializing the vector (and
-  ///  must be a list of whitespace separated textual numeric data with the
-  ///  same number of elements as this VectorMatrix).
-  ///  @throws Matrix_bad_alloc
-  ///  @throws Matrix_invalid_argument
-  ///  @param t Matrix type
-  ///  @param i Matrix initialization
-  ///  @param r rows in Matrix
-  ///  @param c columns in Matrix
-  ///  @param m multiplier used for initialization
-  ///  @param v values for initializing VectorMatrix
-  VectorMatrix(std::string t = "complete", std::string i = "const", int r = 1,
-	       int c = 1, BGFLOAT m = 0.0, std::string v = "");
+		///  @brief Copy constructor. Performs a deep copy.
+		///  @param oldV The source VectorMatrix
+		VectorMatrix(const VectorMatrix& oldV);
 
-  ///  @brief Copy constructor. Performs a deep copy.
-  ///  @param oldV The source VectorMatrix
-  VectorMatrix(const VectorMatrix& oldV);
+		///  @brief De-allocate storage
+		~VectorMatrix() override;
 
-  ///  @brief De-allocate storage
-  virtual ~VectorMatrix();
+		///  @brief Set elements of vector to a constant. Doesn't change its size.
+		///  @param c the constant
+		const VectorMatrix& operator=(BGFLOAT c);
 
-  ///  @brief Set elements of vector to a constant. Doesn't change its size.
-  ///  @param c the constant
-  const VectorMatrix& operator=(BGFLOAT c);
+		///  @brief Assignment operator
+		///  @param rhs right-hand side of assignment
+		///  @return returns reference to this VectorMatrix (after assignment)
+		const VectorMatrix& operator=(const VectorMatrix& rhs);
 
-  ///  @brief Assignment operator
-  ///  @param rhs right-hand side of assignment
-  ///  @return returns reference to this VectorMatrix (after assignment)
-  const VectorMatrix& operator=(const VectorMatrix& rhs);
+		///  @brief Polymorphic output. Produces text output on stream "os"
+		///  @param os stream to output to
+		void Print(std::ostream& os) const override;
 
-  ///  @brief Polymorphic output. Produces text output on stream "os"
-  ///  @param os stream to output to
-  virtual void Print(std::ostream& os) const;
+		///  @brief Produce XML representation of vector in std::string return value.
+		virtual std::string toXML(std::string name = "") const;
 
-  ///  @brief Produce XML representation of vector in std::string return value.
-  virtual std::string toXML(std::string name="") const;
+		/******************************************
+		*  @name Accessors
+		******************************************/
+		//@{
 
-  /******************************************
-  *  @name Accessors
-  ******************************************/
-  //@{
+		///  @brief Access element of a VectorMatrix. Zero-based index; constant-time.
+		///  @param i index
+		///  @return item within this VectorMatrix
+		inline const BGFLOAT& operator[](int i) const { return theVector[i]; }
 
-  ///  @brief Access element of a VectorMatrix. Zero-based index; constant-time.
-  ///  @param i index
-  ///  @return item within this VectorMatrix
-  inline const BGFLOAT& operator[](int i) const { return theVector[i]; }
+		///  @brief access element of a VectorMatrix. Zero-based index; constant-time.
+		///  @param i index
+		///  @return item within this VectorMatrix
+		inline const BGFLOAT& at(int i) const { return theVector[i]; }
 
-  ///  @brief access element of a VectorMatrix. Zero-based index; constant-time.
-  ///  @param i index
-  ///  @return item within this VectorMatrix
-  inline const BGFLOAT& at(int i) const { return theVector[i]; }
-
-  ///  @brief The length of a VectorMatrix elements.
-  ///  @return The number of elements in the VectorMatrix
-  int Size(void) const { return size; }
-  //@}
+		///  @brief The length of a VectorMatrix elements.
+		///  @return The number of elements in the VectorMatrix
+		int Size(void) const { return size; }
+		//@}
 
 
-  /******************************************
-  * @name Mutators
-  ******************************************/
-  //@{
+		/******************************************
+		* @name Mutators
+		******************************************/
+		//@{
 
-  ///  @brief mutate element of a VectorMatrix. Zero-based index; constant time.
-  ///  @param i index
-  ///  @return Reference to item within this VectorMatrix
-  inline BGFLOAT& operator[](int i) { return theVector[i]; }
+		///  @brief mutate element of a VectorMatrix. Zero-based index; constant time.
+		///  @param i index
+		///  @return Reference to item within this VectorMatrix
+		inline BGFLOAT& operator[](int i) { return theVector[i]; }
 
-  ///  @brief mutate element of a VectorMatrix. Zero-based index.
-  ///  @param i index
-  ///  @return reference to item within this VectorMatrix
-  inline BGFLOAT& at(int i) { return theVector[i]; }
-  //@}
+		///  @brief mutate element of a VectorMatrix. Zero-based index.
+		///  @param i index
+		///  @return reference to item within this VectorMatrix
+		inline BGFLOAT& at(int i) { return theVector[i]; }
+		//@}
 
-  /******************************************
-  * @name Math Operations
-  ******************************************/
-  //@{
+		/******************************************
+		* @name Math Operations
+		******************************************/
+		//@{
 
-  ///  @brief Compute the sum of two VectorMatrices of the same length.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the addition. Must be same
-  ///  length as this.
-  ///  @return A new VectorMatrix, with value equal to the sum of this
-  ///  one and rhs and length the same as both, returned by value.
-  virtual const VectorMatrix operator+(const VectorMatrix& rhs) const;
+		///  @brief Compute the sum of two VectorMatrices of the same length.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the addition. Must be same
+		///  length as this.
+		///  @return A new VectorMatrix, with value equal to the sum of this
+		///  one and rhs and length the same as both, returned by value.
+		virtual const VectorMatrix operator+(const VectorMatrix& rhs) const;
 
-  ///  @brief vector plus a constant. Adds each element of the vector
-  ///  plus a constant. Method version (vector on LHS).
-  ///  @param c The constant
-  ///  @return A vector the same size as the current one
-  virtual const VectorMatrix operator+(BGFLOAT c) const;
+		///  @brief vector plus a constant. Adds each element of the vector
+		///  plus a constant. Method version (vector on LHS).
+		///  @param c The constant
+		///  @return A vector the same size as the current one
+		virtual const VectorMatrix operator+(BGFLOAT c) const;
 
-  ///  @brief There are two possible vector products. This is an inner product.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the inner product.
-  ///  @return A scalar of type BGFLOAT
-  virtual BGFLOAT operator*(const VectorMatrix& rhs) const;
+		///  @brief There are two possible vector products. This is an inner product.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the inner product.
+		///  @return A scalar of type BGFLOAT
+		virtual BGFLOAT operator*(const VectorMatrix& rhs) const;
 
-  ///  @brief Vector times a Complete Matrix.
-  ///
-  ///  Treats this vector as a row
-  ///  vector; multiplies by matrix with same number of rows as size of
-  ///  this vector to produce a new vector the same size as the number of
-  ///  columns of the matrix
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the vector/matrix product
-  ///  @return A vector the same size as the number of columns of rhs
-  virtual const VectorMatrix operator*(const CompleteMatrix& rhs) const;
+		///  @brief Vector times a Complete Matrix.
+		///
+		///  Treats this vector as a row
+		///  vector; multiplies by matrix with same number of rows as size of
+		///  this vector to produce a new vector the same size as the number of
+		///  columns of the matrix
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the vector/matrix product
+		///  @return A vector the same size as the number of columns of rhs
+		virtual const VectorMatrix operator*(const CompleteMatrix& rhs) const;
 
-  ///  @brief Element-by-element multiplication of two vectors.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the vector/matrix product. Must
-  ///  be same size as current vector
-  ///  @return A vector the same size as the current vector
-  virtual const VectorMatrix ArrayMultiply(const VectorMatrix& rhs) const;
+		///  @brief Element-by-element multiplication of two vectors.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the vector/matrix product. Must
+		///  be same size as current vector
+		///  @return A vector the same size as the current vector
+		virtual const VectorMatrix ArrayMultiply(const VectorMatrix& rhs) const;
 
-  ///  @brief Constant times a vector.
-  ///  Multiplies each element of the vector by a constant. Method
-  ///  version (vector on LHS)
-  ///  @param c The constant
-  ///  @return A vector the same size as the current one
-  virtual const VectorMatrix operator*(BGFLOAT c) const;
+		///  @brief Constant times a vector.
+		///  Multiplies each element of the vector by a constant. Method
+		///  version (vector on LHS)
+		///  @param c The constant
+		///  @return A vector the same size as the current one
+		virtual const VectorMatrix operator*(BGFLOAT c) const;
 
-  ///  @brief Vector divided by a constant. Divides each element of the vector by a constant.
-  ///  @param c The constant
-  ///  @return A vector the same size as the current one
-  virtual const VectorMatrix operator/(BGFLOAT c) const;
+		///  @brief Vector divided by a constant. Divides each element of the vector by a constant.
+		///  @param c The constant
+		///  @return A vector the same size as the current one
+		virtual const VectorMatrix operator/(BGFLOAT c) const;
 
-  ///  @brief Limit values of a vector. Clip values to lie within range.
-  ///  @param low lower limit
-  ///  @param high upper limit
-  ///  @return A vector the same size as the current one
-  virtual const VectorMatrix Limit(BGFLOAT low, BGFLOAT high) const;
+		///  @brief Limit values of a vector. Clip values to lie within range.
+		///  @param low lower limit
+		///  @param high upper limit
+		///  @return A vector the same size as the current one
+		virtual const VectorMatrix Limit(BGFLOAT low, BGFLOAT high) const;
 
-  ///  @brief Find minimum value of vector
-  ///  @return A scalar
-  virtual BGFLOAT Min(void) const;
+		///  @brief Find minimum value of vector
+		///  @return A scalar
+		virtual BGFLOAT Min(void) const;
 
-  ///  @brief Find maximum value of vector
-  ///  @return A scalar
-  virtual BGFLOAT Max(void) const;
+		///  @brief Find maximum value of vector
+		///  @return A scalar
+		virtual BGFLOAT Max(void) const;
 
-  ///  @brief Compute and assign the sum of two VectorMatrices of the same length.
-  ///  @throws Matrix_domain_error
-  ///  @param rhs right-hand argument to the addition. Must be same
-  ///  length as this.
-  ///  @return reference to this
-  virtual const VectorMatrix& operator+=(const VectorMatrix& rhs);
+		///  @brief Compute and assign the sum of two VectorMatrices of the same length.
+		///  @throws Matrix_domain_error
+		///  @param rhs right-hand argument to the addition. Must be same
+		///  length as this.
+		///  @return reference to this
+		virtual const VectorMatrix& operator+=(const VectorMatrix& rhs);
 
-  ///  @brief Constant times a vector.
-  ///
-  ///  Multiplies each element of the vector by a constant. Function
-  ///  version (constant on LHS)
-  ///  @param c The constant
-  ///  @param rhs The vector
-  ///  @return A vector the same size as the rhs
-  friend 
-  inline const VectorMatrix operator*(BGFLOAT c, const VectorMatrix& rhs)
-  {
-    return rhs * c;
-  }
+		///  @brief Constant times a vector.
+		///
+		///  Multiplies each element of the vector by a constant. Function
+		///  version (constant on LHS)
+		///  @param c The constant
+		///  @param rhs The vector
+		///  @return A vector the same size as the rhs
+		friend
+		inline const VectorMatrix operator*(BGFLOAT c, const VectorMatrix& rhs) { return rhs * c; }
 
-  ///  @brief Vector times sparse matrix.
-  ///
-  ///  Size of v must equal to number of rows of m. Size of resultant
-  ///  vector is equal to number Of columns of m.
-  ///  @throws Matrix_domain_error
-  ///  @return A VectorMatrix with size equal to number of columns of m.
-  friend const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m);
+		///  @brief Vector times sparse matrix.
+		///
+		///  Size of v must equal to number of rows of m. Size of resultant
+		///  vector is equal to number Of columns of m.
+		///  @throws Matrix_domain_error
+		///  @return A VectorMatrix with size equal to number of columns of m.
+		friend const VectorMatrix operator*(const VectorMatrix& v, const SparseMatrix& m);
 
-  ///  @brief Constant minus a vector. Subtracts each element of the vector from a constant.
-  ///  @param c The constant
-  ///  @param v The vector
-  ///  @return A vector the same size as the rhs
-  friend
-  const VectorMatrix operator-(BGFLOAT c, const VectorMatrix& v);
+		///  @brief Constant minus a vector. Subtracts each element of the vector from a constant.
+		///  @param c The constant
+		///  @param v The vector
+		///  @return A vector the same size as the rhs
+		friend
+		const VectorMatrix operator-(BGFLOAT c, const VectorMatrix& v);
 
-  ///  @brief Constant divided by a vector. Divides the constant by each element of a vector
-  ///  @param c The constant
-  ///  @param v The vector
-  ///  @return A vector the same size as the rhs
-  friend
-  const VectorMatrix operator/(BGFLOAT c, const VectorMatrix& v);
+		///  @brief Constant divided by a vector. Divides the constant by each element of a vector
+		///  @param c The constant
+		///  @param v The vector
+		///  @return A vector the same size as the rhs
+		friend
+		const VectorMatrix operator/(BGFLOAT c, const VectorMatrix& v);
 
-  ///  @brief Constant plus a vector. Adds each element of the vector and a constant
-  ///  @param c The constant
-  ///  @param rhs The vector
-  ///  @return A vector the same size as the rhs
-  friend
-  inline const VectorMatrix operator+(BGFLOAT c, const VectorMatrix& rhs)
-  {
-    return rhs + c;
-  }
+		///  @brief Constant plus a vector. Adds each element of the vector and a constant
+		///  @param c The constant
+		///  @param rhs The vector
+		///  @return A vector the same size as the rhs
+		friend
+		inline const VectorMatrix operator+(BGFLOAT c, const VectorMatrix& rhs) { return rhs + c; }
 
-  ///  @brief Element-wise square root of vector. Computes square root of each element of vector.
-  ///  @param v The vector
-  ///  @return A vector the same size as the v
-  friend
-  const VectorMatrix sqrt(const VectorMatrix& v);
+		///  @brief Element-wise square root of vector. Computes square root of each element of vector.
+		///  @param v The vector
+		///  @return A vector the same size as the v
+		friend
+		const VectorMatrix sqrt(const VectorMatrix& v);
 
-  ///  @brief Element-wise e^x for vector. Computes exp(v[i]) of each element of vector.
-  ///  @param v The vector
-  ///  @return A vector the same size as the v
-  friend
-  const VectorMatrix exp(const VectorMatrix& v);
-  //@}
+		///  @brief Element-wise e^x for vector. Computes exp(v[i]) of each element of vector.
+		///  @param v The vector
+		///  @return A vector the same size as the v
+		friend
+		const VectorMatrix exp(const VectorMatrix& v);
+		//@}
 
-protected:
+	protected:
+		/******************************************
+		* @name Internal Utilities
+		******************************************/
+		//@{
 
-  /******************************************
-  * @name Internal Utilities
-  ******************************************/
-  //@{
+		///  @brief Frees up all dynamically allocated storage
+		void clear(void);
 
-  ///  @brief Frees up all dynamically allocated storage
-  void clear(void);
+		///  @brief Performs a deep copy
+		///  @param source VectorMatrix to copy from
+		void copy(const VectorMatrix& source);
 
-  ///  @brief Performs a deep copy
-  ///  @param source VectorMatrix to copy from
-  void copy(const VectorMatrix& source);
+		///  @brief Allocates storage for internal Vector storage
+		///  @throws Matrix_bad_alloc
+		///  @throws MatrixException
+		///  @param size number of Vector elements
+		void alloc(int size);
+		//@}
 
-  ///  @brief Allocates storage for internal Vector storage
-  ///  @throws Matrix_bad_alloc
-  ///  @throws MatrixException
-  ///  @param size number of Vector elements
-  void alloc(int size);
-  //@}
+		// access adjustment --- allow member functions in this class to
+		// access protected member of base class in other objects.
+		using Matrix::dimensions;
+		using Matrix::rows;
+		using Matrix::columns;
 
-  // access adjustment --- allow member functions in this class to
-  // access protected member of base class in other objects.
-  using Matrix::dimensions;
-  using Matrix::rows;
-  using Matrix::columns;
+	private:
+		/// Pointer to dynamically allocated 1D array
+		BGFLOAT* theVector;
 
-private:
+		/// The number of elements in "theVector"
+		int size;
 
-  /// Pointer to dynamically allocated 1D array
-  BGFLOAT *theVector;
-
-  /// The number of elements in "theVector"
-  int size;
-
-  /// A normal RNG for the whole class
-  static Norm nRng;
+		/// A normal RNG for the whole class
+		static Norm nRng;
 
 };
 

--- a/Simulator/Utils/ParameterManager.cpp
+++ b/Simulator/Utils/ParameterManager.cpp
@@ -127,7 +127,7 @@ bool ParameterManager::getIntByXpath(std::string xpath, int& referenceVar) {
 			<< tmp << std::endl;
 		return false;
 	}
-	else if (regex_match(tmp, std::regex(".*[^\\def.]+.*"))) {
+	if (regex_match(tmp, std::regex(".*[^\\def.]+.*"))) {
 		std::cerr << "Parsed parameter is likely a std::string. "
 			<< "Terminating integer cast. Value: "
 			<< tmp << std::endl;

--- a/Simulator/Utils/ParameterManager.cpp
+++ b/Simulator/Utils/ParameterManager.cpp
@@ -26,10 +26,10 @@
 #include "ParameterManager.h"
 #include <iostream>
 #include <regex>
-#include <string>
 #include <stdexcept>
-#include <tinyxml.h>
+#include <string>
 #include <tinystr.h>
+#include <tinyxml.h>
 #include <vector>
 
 #include "BGTypes.h"
@@ -118,7 +118,7 @@ bool ParameterManager::getStringByXpath(std::string xpath, std::string& referenc
 bool ParameterManager::getIntByXpath(std::string xpath, int& referenceVar) {
 	if (!checkDocumentStatus()) return false;
 	std::string tmp;
-	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (!getStringByXpath(xpath, tmp)) return false;
 	// Workaround for standard value conversion functions.
 	// stoi() will cast floats to ints.
 	if (regex_match(tmp, std::regex("\\d+[.]\\d+(e[+-]?\\d+)?f?|\\d+[.]?\\d+(e[+-]?\\d+)?f"))) {
@@ -156,7 +156,7 @@ bool ParameterManager::getIntByXpath(std::string xpath, int& referenceVar) {
 bool ParameterManager::getDoubleByXpath(std::string xpath, double& referenceVar) {
 	if (!checkDocumentStatus()) return false;
 	std::string tmp;
-	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (!getStringByXpath(xpath, tmp)) return false;
 	if (regex_match(tmp, std::regex(".*[^\\def.+-]+.*"))) {
 		std::cerr << "Parsed parameter is likely a std::string. "
 			<< "Terminating double conversion. Value: "
@@ -186,7 +186,7 @@ bool ParameterManager::getDoubleByXpath(std::string xpath, double& referenceVar)
 bool ParameterManager::getFloatByXpath(std::string xpath, float& referenceVariable) {
 	if (!checkDocumentStatus()) return false;
 	std::string tmp;
-	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (!getStringByXpath(xpath, tmp)) return false;
 	if (regex_match(tmp, std::regex(".*[^\\def.+-]+.*"))) {
 		std::cerr << "Parsed parameter is likely a std::string. "
 			<< "Terminating double conversion. Value: "
@@ -240,7 +240,7 @@ bool ParameterManager::getBGFloatByXpath(std::string xpath, BGFLOAT& referenceVa
 bool ParameterManager::getLongByXpath(std::string xpath, long& referenceVar) {
 	if (!checkDocumentStatus()) return false;
 	std::string tmp;
-	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (!getStringByXpath(xpath, tmp)) return false;
 	if (!regex_match(tmp, std::regex("[\\d]+l?"))) {
 		std::cerr << "Parsed parameter is not a valid long format. "
 			<< "Terminating long conversion. Value: "

--- a/Simulator/Utils/ParameterManager.cpp
+++ b/Simulator/Utils/ParameterManager.cpp
@@ -42,10 +42,7 @@
 
 /// Private Class constructor
 /// Initialize any heap variables to null
-ParameterManager::ParameterManager() {
-	xmlDocument_ = nullptr;
-	root_ = nullptr;
-}
+ParameterManager::ParameterManager(): root_(nullptr), xmlDocument_(nullptr) { }
 
 /// Class destructor
 /// Deallocate all heap memory managed by the class

--- a/Simulator/Utils/ParameterManager.cpp
+++ b/Simulator/Utils/ParameterManager.cpp
@@ -24,9 +24,8 @@
  */
 
 #include "ParameterManager.h"
-
-#include <regex>
 #include <iostream>
+#include <regex>
 #include <string>
 #include <stdexcept>
 #include <tinyxml.h>
@@ -44,73 +43,69 @@
 /// Private Class constructor
 /// Initialize any heap variables to null
 ParameterManager::ParameterManager() {
-   xmlDocument_ = nullptr;
-   root_ = nullptr;
+	xmlDocument_ = nullptr;
+	root_ = nullptr;
 }
 
 /// Class destructor
 /// Deallocate all heap memory managed by the class
-ParameterManager::~ParameterManager() {
-   if (xmlDocument_ != nullptr) delete xmlDocument_;
-}
+ParameterManager::~ParameterManager() { if (xmlDocument_ != nullptr) delete xmlDocument_; }
 
 /// Get Instance method that returns a reference to this object.
-ParameterManager &ParameterManager::getInstance() {
-   static ParameterManager instance;
-   return instance;
+ParameterManager& ParameterManager::getInstance() {
+	static ParameterManager instance;
+	return instance;
 }
 
 /// Loads the XML file into a TinyXML tree.
 /// This is the starting point for all XPath retrieval calls 
 /// for the client classes to use.
-bool ParameterManager::loadParameterFile(string path) {
-   // load the XML document
-   if (xmlDocument_) delete xmlDocument_;
-   xmlDocument_ = new TiXmlDocument(path.c_str());
-   if (!xmlDocument_->LoadFile()) {
-      cerr << "Failed loading simulation parameter file "
-           << path << ":" << "\n\t" << xmlDocument_->ErrorDesc()
-           << endl;
-      cerr << " error row: " << xmlDocument_->ErrorRow() << ", error col: " << xmlDocument_->ErrorCol()
-           << endl;
-      return false;
-   }
-   // assign the document root_ object
-   root_ = xmlDocument_->RootElement();
-   return true;
+bool ParameterManager::loadParameterFile(std::string path) {
+	// load the XML document
+	if (xmlDocument_) delete xmlDocument_;
+	xmlDocument_ = new TiXmlDocument(path.c_str());
+	if (!xmlDocument_->LoadFile()) {
+		std::cerr << "Failed loading simulation parameter file "
+			<< path << ":" << "\n\t" << xmlDocument_->ErrorDesc()
+			<< std::endl;
+		std::cerr << " error row: " << xmlDocument_->ErrorRow() << ", error col: " << xmlDocument_->ErrorCol()
+			<< std::endl;
+		return false;
+	}
+	// assign the document root_ object
+	root_ = xmlDocument_->RootElement();
+	return true;
 }
 
 /// A utility method to ensure the XML document objects exist.
 /// If they don't exist, an XPath can't be computed and the 
 /// interface methods should terminate early.
-bool ParameterManager::checkDocumentStatus() {
-   return xmlDocument_ != nullptr && root_ != nullptr;
-}
+bool ParameterManager::checkDocumentStatus() { return xmlDocument_ != nullptr && root_ != nullptr; }
 
 /******************************************
 * INTERFACE METHODS
 ******************************************/
 
-/// Interface method to pull a string object from the xml 
+/// Interface method to pull a std::string object from the xml 
 /// schema. The calling object must know the xpath to retrieve 
 /// the value.
 /// 
-/// @param xpath The xpath for the desired string value in the XML file
-/// @param referenceVar The variable to store the string result into
+/// @param xpath The xpath for the desired std::string value in the XML file
+/// @param referenceVar The variable to store the std::string result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getStringByXpath(string xpath, string &referenceVar) {
-   if (!checkDocumentStatus()) return false;
+bool ParameterManager::getStringByXpath(std::string xpath, std::string& referenceVar) {
+	if (!checkDocumentStatus()) return false;
 
-   // temp string holds evaluation of value at xpath
-   string temp;
-   // raise error if tinyxml cannot compute the xpath's value or returns empty
-   if (!TinyXPath::o_xpath_string(root_, xpath.c_str(), temp) || temp == "") {
-      cerr << "Failed loading simulation parameter for xpath "
-           << xpath << endl;
-      return false;
-   }
-   referenceVar = temp;
-   return true;
+	// temp std::string holds evaluation of value at xpath
+	std::string temp;
+	// raise error if tinyxml cannot compute the xpath's value or returns empty
+	if (!TinyXPath::o_xpath_string(root_, xpath.c_str(), temp) || temp == "") {
+		std::cerr << "Failed loading simulation parameter for xpath "
+			<< xpath << std::endl;
+		return false;
+	}
+	referenceVar = temp;
+	return true;
 }
 
 /// Interface method to pull an integer value from the xml 
@@ -120,37 +115,35 @@ bool ParameterManager::getStringByXpath(string xpath, string &referenceVar) {
 /// @param xpath The xpath for the desired int value in the XML file
 /// @param referenceVar The variable to store the int result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getIntByXpath(string xpath, int &referenceVar) {
-   if (!checkDocumentStatus()) return false;
-   string tmp;
-   if (!getStringByXpath(xpath, tmp)) {
-      return false;
-   }
-   // Workaround for standard value conversion functions.
-   // stoi() will cast floats to ints.
-   if (regex_match(tmp, regex("\\d+[.]\\d+(e[+-]?\\d+)?f?|\\d+[.]?\\d+(e[+-]?\\d+)?f"))) {
-      cerr << "Parsed parameter is likely a float/double value. "
-           << "Terminating integer cast. Value: "
-           << tmp << endl;
-      return false;
-   } else if (regex_match(tmp, regex(".*[^\\def.]+.*"))) {
-      cerr << "Parsed parameter is likely a string. "
-           << "Terminating integer cast. Value: "
-           << tmp << endl;
-      return false;
-   }
-   try {
-      referenceVar = stoi(tmp);
-   } catch (invalid_argument &arg_exception) {
-      cerr << "Parsed parameter could not be parsed as an integer. Value: "
-           << tmp << endl;
-      return false;
-   } catch (out_of_range &range_exception) {
-      cerr << "Parsed string parameter could not be converted to an integer. Value: "
-           << tmp << endl;
-      return false;
-   }
-   return true;
+bool ParameterManager::getIntByXpath(std::string xpath, int& referenceVar) {
+	if (!checkDocumentStatus()) return false;
+	std::string tmp;
+	if (!getStringByXpath(xpath, tmp)) { return false; }
+	// Workaround for standard value conversion functions.
+	// stoi() will cast floats to ints.
+	if (regex_match(tmp, std::regex("\\d+[.]\\d+(e[+-]?\\d+)?f?|\\d+[.]?\\d+(e[+-]?\\d+)?f"))) {
+		std::cerr << "Parsed parameter is likely a float/double value. "
+			<< "Terminating integer cast. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	else if (regex_match(tmp, std::regex(".*[^\\def.]+.*"))) {
+		std::cerr << "Parsed parameter is likely a std::string. "
+			<< "Terminating integer cast. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	try { referenceVar = stoi(tmp); }
+	catch (std::invalid_argument& arg_exception) {
+		std::cerr << "Parsed parameter could not be parsed as an integer. Value: "
+			<< tmp << std::endl;
+		return false;
+	} catch (std::out_of_range& range_exception) {
+		std::cerr << "Parsed std::string parameter could not be converted to an integer. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	return true;
 }
 
 /// Interface method to pull a double value from the xml 
@@ -160,30 +153,27 @@ bool ParameterManager::getIntByXpath(string xpath, int &referenceVar) {
 /// @param xpath The xpath for the desired double value in the XML file
 /// @param referenceVar The variable to store the double result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getDoubleByXpath(string xpath, double &referenceVar) {
-   if (!checkDocumentStatus()) return false;
-   string tmp;
-   if (!getStringByXpath(xpath, tmp)) {
-      return false;
-   }
-   if (regex_match(tmp, regex(".*[^\\def.+-]+.*"))) {
-      cerr << "Parsed parameter is likely a string. "
-           << "Terminating double conversion. Value: "
-           << tmp << endl;
-      return false;
-   }
-   try {
-      referenceVar = stod(tmp);
-   } catch (invalid_argument &arg_exception) {
-      cerr << "Parsed parameter could not be parsed as a double. Value: "
-           << tmp << endl;
-      return false;
-   } catch (out_of_range &range_exception) {
-      cerr << "Parsed string parameter could not be converted to a double. Value: "
-           << tmp << endl;
-      return false;
-   }
-   return true;
+bool ParameterManager::getDoubleByXpath(std::string xpath, double& referenceVar) {
+	if (!checkDocumentStatus()) return false;
+	std::string tmp;
+	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (regex_match(tmp, std::regex(".*[^\\def.+-]+.*"))) {
+		std::cerr << "Parsed parameter is likely a std::string. "
+			<< "Terminating double conversion. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	try { referenceVar = stod(tmp); }
+	catch (std::invalid_argument& arg_exception) {
+		std::cerr << "Parsed parameter could not be parsed as a double. Value: "
+			<< tmp << std::endl;
+		return false;
+	} catch (std::out_of_range& range_exception) {
+		std::cerr << "Parsed std::string parameter could not be converted to a double. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	return true;
 }
 
 /// Interface method to pull a float value from the xml 
@@ -193,30 +183,27 @@ bool ParameterManager::getDoubleByXpath(string xpath, double &referenceVar) {
 /// @param xpath The xpath for the desired float value in the XML file
 /// @param referenceVariable The variable to store the float result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getFloatByXpath(string xpath, float &referenceVariable) {
-   if (!checkDocumentStatus()) return false;
-   string tmp;
-   if (!getStringByXpath(xpath, tmp)) {
-      return false;
-   }
-   if (regex_match(tmp, regex(".*[^\\def.+-]+.*"))) {
-      cerr << "Parsed parameter is likely a string. "
-           << "Terminating double conversion. Value: "
-           << tmp << endl;
-      return false;
-   }
-   try {
-      referenceVariable = stof(tmp);
-   } catch (invalid_argument &arg_exception) {
-      cerr << "Parsed parameter could not be parsed as a float. Value: "
-           << tmp << endl;
-      return false;
-   } catch (out_of_range &range_exception) {
-      cerr << "Parsed string parameter could not be converted to a float. Value: "
-           << tmp << endl;
-      return false;
-   }
-   return true;
+bool ParameterManager::getFloatByXpath(std::string xpath, float& referenceVariable) {
+	if (!checkDocumentStatus()) return false;
+	std::string tmp;
+	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (regex_match(tmp, std::regex(".*[^\\def.+-]+.*"))) {
+		std::cerr << "Parsed parameter is likely a std::string. "
+			<< "Terminating double conversion. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	try { referenceVariable = stof(tmp); }
+	catch (std::invalid_argument& arg_exception) {
+		std::cerr << "Parsed parameter could not be parsed as a float. Value: "
+			<< tmp << std::endl;
+		return false;
+	} catch (std::out_of_range& range_exception) {
+		std::cerr << "Parsed std::string parameter could not be converted to a float. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	return true;
 }
 
 /// Interface method to pull a BGFLOAT value from the xml 
@@ -231,16 +218,16 @@ bool ParameterManager::getFloatByXpath(string xpath, float &referenceVariable) {
 /// @param xpath The xpath for the desired float value in the XML file
 /// @param referenceVar The variable to store the float result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getBGFloatByXpath(string xpath, BGFLOAT &referenceVar) {
+bool ParameterManager::getBGFloatByXpath(std::string xpath, BGFLOAT& referenceVar) {
 #ifdef SINGLEPRECISION
-   return getFloatByXpath(xpath, referenceVar);
+	return getFloatByXpath(xpath, referenceVar);
 #endif
 #ifdef DOUBLEPRECISION
    return getDoubleByXpath(xpath, referenceVar);
 #endif
-   cerr << "Could not infer primitive type for BGFLOAT variable."
-        << endl;
-   return false;
+	std::cerr << "Could not infer primitive type for BGFLOAT variable."
+		<< std::endl;
+	return false;
 }
 
 /// Interface method to pull a long value from the xml
@@ -250,30 +237,27 @@ bool ParameterManager::getBGFloatByXpath(string xpath, BGFLOAT &referenceVar) {
 /// @param xpath The xpath for the desired float value in the XML file
 /// @param referenceVariable The variable to store the long result into
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getLongByXpath(string xpath, long &referenceVar) {
-   if (!checkDocumentStatus()) return false;
-   string tmp;
-   if (!getStringByXpath(xpath, tmp)) {
-      return false;
-   }
-   if (!regex_match(tmp, regex("[\\d]+l?"))) {
-      cerr << "Parsed parameter is not a valid long format. "
-           << "Terminating long conversion. Value: "
-           << tmp << endl;
-      return false;
-   }
-   try {
-      referenceVar = stol(tmp);
-   } catch (invalid_argument &arg_exception) {
-      cerr << "Parsed parameter could not be parsed as a long. Value: "
-           << tmp << endl;
-      return false;
-   } catch (out_of_range &range_exception) {
-      cerr << "Parsed string parameter could not be converted to a long. Value: "
-           << tmp << endl;
-      return false;
-   }
-   return true;
+bool ParameterManager::getLongByXpath(std::string xpath, long& referenceVar) {
+	if (!checkDocumentStatus()) return false;
+	std::string tmp;
+	if (!getStringByXpath(xpath, tmp)) { return false; }
+	if (!regex_match(tmp, std::regex("[\\d]+l?"))) {
+		std::cerr << "Parsed parameter is not a valid long format. "
+			<< "Terminating long conversion. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	try { referenceVar = stol(tmp); }
+	catch (std::invalid_argument& arg_exception) {
+		std::cerr << "Parsed parameter could not be parsed as a long. Value: "
+			<< tmp << std::endl;
+		return false;
+	} catch (std::out_of_range& range_exception) {
+		std::cerr << "Parsed std::string parameter could not be converted to a long. Value: "
+			<< tmp << std::endl;
+		return false;
+	}
+	return true;
 }
 
 /// Interface method to pull a list of ints into a vector<int> from the xml
@@ -288,31 +272,31 @@ bool ParameterManager::getLongByXpath(string xpath, long &referenceVar) {
 /// @param elementName The name of the element that stores the list of ints
 /// @param referenceVariable The reference variable to store the list of ints
 /// @return bool A T/F flag indicating whether the retrieval succeeded
-bool ParameterManager::getIntVectorByXpath(const string &path, const string &elementName, vector<int> &referenceVar) {
-   // Open file using a local XmlDocument object
-   TiXmlDocument xmlDocument(path.c_str());
-   if (!xmlDocument.LoadFile()) {
-      cerr << "Failed to load " << path.c_str() << ":" << "\n\t"
-           << xmlDocument.ErrorDesc() << endl;
-      return false;
-   }
+bool ParameterManager::getIntVectorByXpath(const std::string& path, const std::string& elementName,
+                                           std::vector<int>& referenceVar) {
+	// Open file using a local XmlDocument object
+	TiXmlDocument xmlDocument(path.c_str());
+	if (!xmlDocument.LoadFile()) {
+		std::cerr << "Failed to load " << path.c_str() << ":" << "\n\t"
+			<< xmlDocument.ErrorDesc() << std::endl;
+		return false;
+	}
 
-   // Check file for matching element
-   TiXmlNode *xmlNode = nullptr;
-   if ((xmlNode = xmlDocument.FirstChildElement(elementName)) == nullptr) {
-      cerr << "Could not find <" << elementName << "> in vertex list file " << path << endl;
-      return false;
-   }
+	// Check file for matching element
+	TiXmlNode* xmlNode = nullptr;
+	if ((xmlNode = xmlDocument.FirstChildElement(elementName)) == nullptr) {
+		std::cerr << "Could not find <" << elementName << "> in vertex list file " << path << std::endl;
+		return false;
+	}
 
-   // Get list of ints as a string stream
-   std::istringstream valueStream(xmlNode->ToElement()->GetText());
+	// Get list of ints as a std::string stream
+	std::istringstream valueStream(xmlNode->ToElement()->GetText());
 
-   // Parse integers out of the string and add them to a list
-   int i;
-   while (valueStream.good()) {
-      valueStream >> i;
-      referenceVar.push_back(i);
-   }
-   return true;
+	// Parse integers out of the std::string and add them to a list
+	int i;
+	while (valueStream.good()) {
+		valueStream >> i;
+		referenceVar.push_back(i);
+	}
+	return true;
 }
-

--- a/Simulator/Utils/ParameterManager.h
+++ b/Simulator/Utils/ParameterManager.h
@@ -33,8 +33,6 @@
 #include "BGTypes.h"
 #include "tinyxml.h"
 
-using namespace std;
-
 class ParameterManager {
 public:
 
@@ -44,22 +42,22 @@ public:
    /// Utility Methods
    ~ParameterManager();
 
-   bool loadParameterFile(string path);
+   bool loadParameterFile(std::string path);
 
    /// Interface methods for simulator objects
-   bool getStringByXpath(string xpath, string &referenceVar);
+   bool getStringByXpath(std::string xpath, std::string &referenceVar);
 
-   bool getIntByXpath(string xpath, int &referenceVar);
+   bool getIntByXpath(std::string xpath, int &referenceVar);
 
-   bool getDoubleByXpath(string xpath, double &referenceVar);
+   bool getDoubleByXpath(std::string xpath, double &referenceVar);
 
-   bool getFloatByXpath(string xpath, float &referenceVariable);
+   bool getFloatByXpath(std::string xpath, float &referenceVariable);
 
-   bool getBGFloatByXpath(string xpath, BGFLOAT &referenceVar);
+   bool getBGFloatByXpath(std::string xpath, BGFLOAT &referenceVar);
 
-   bool getLongByXpath(string xpath, long &referenceVar);
+   bool getLongByXpath(std::string xpath, long &referenceVar);
 
-   bool getIntVectorByXpath(const string &path, const string &elementName, vector<int> &referenceVar);
+   bool getIntVectorByXpath(const std::string &path, const std::string &elementName, std::vector<int> &referenceVar);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    ParameterManager(ParameterManager const &) = delete;

--- a/Simulator/Utils/ParameterManager.h
+++ b/Simulator/Utils/ParameterManager.h
@@ -34,41 +34,41 @@
 #include "tinyxml.h"
 
 class ParameterManager {
-public:
+	public:
+		/// Get Instance method that returns a reference to this object.
+		static ParameterManager& getInstance();
 
-   /// Get Instance method that returns a reference to this object.
-   static ParameterManager &getInstance();
+		/// Utility Methods
+		~ParameterManager();
 
-   /// Utility Methods
-   ~ParameterManager();
+		bool loadParameterFile(std::string path);
 
-   bool loadParameterFile(std::string path);
+		/// Interface methods for simulator objects
+		bool getStringByXpath(std::string xpath, std::string& referenceVar);
 
-   /// Interface methods for simulator objects
-   bool getStringByXpath(std::string xpath, std::string &referenceVar);
+		bool getIntByXpath(std::string xpath, int& referenceVar);
 
-   bool getIntByXpath(std::string xpath, int &referenceVar);
+		bool getDoubleByXpath(std::string xpath, double& referenceVar);
 
-   bool getDoubleByXpath(std::string xpath, double &referenceVar);
+		bool getFloatByXpath(std::string xpath, float& referenceVariable);
 
-   bool getFloatByXpath(std::string xpath, float &referenceVariable);
+		bool getBGFloatByXpath(std::string xpath, BGFLOAT& referenceVar);
 
-   bool getBGFloatByXpath(std::string xpath, BGFLOAT &referenceVar);
+		bool getLongByXpath(std::string xpath, long& referenceVar);
 
-   bool getLongByXpath(std::string xpath, long &referenceVar);
+		bool getIntVectorByXpath(const std::string& path, const std::string& elementName,
+		                         std::vector<int>& referenceVar);
 
-   bool getIntVectorByXpath(const std::string &path, const std::string &elementName, std::vector<int> &referenceVar);
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		ParameterManager(const ParameterManager&) = delete;
+		void operator=(const ParameterManager&) = delete;
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   ParameterManager(ParameterManager const &) = delete;
-   void operator=(ParameterManager const &) = delete;
+	private:
+		TiXmlDocument* xmlDocument_;
+		TiXmlElement* root_;
 
-private:
-   TiXmlDocument *xmlDocument_;
-   TiXmlElement *root_;
+		/// Constructor is private to keep a singleton instance of this class.
+		ParameterManager();
 
-   /// Constructor is private to keep a singleton instance of this class.
-   ParameterManager();
-
-   bool checkDocumentStatus();
+		bool checkDocumentStatus();
 };

--- a/Simulator/Utils/ParseParamError.cpp
+++ b/Simulator/Utils/ParseParamError.cpp
@@ -9,15 +9,13 @@
 
 #include "ParseParamError.h"
 
-ParseParamError::ParseParamError(const string paramName, const string errorMessage) :
-     m_paramName(paramName)
-    ,m_errorMessage(errorMessage)
-{
-    // Constructor
+ParseParamError::ParseParamError(const std::string paramName, const std::string errorMessage) :
+	m_paramName(paramName)
+	, m_errorMessage(errorMessage) {
+	// Constructor
 }
 
-void ParseParamError::print(ostream &output) const
-{
-    output << "ERROR :: Failed to parse parameter \"" << m_paramName << "\".";
-    output << " Cause: " << m_errorMessage;
+void ParseParamError::print(std::ostream& output) const {
+	output << "ERROR :: Failed to parse parameter \"" << m_paramName << "\".";
+	output << " Cause: " << m_errorMessage;
 }

--- a/Simulator/Utils/ParseParamError.h
+++ b/Simulator/Utils/ParseParamError.h
@@ -13,16 +13,14 @@
 #include <iostream>
 #include <string>
 
-using namespace std;
-
 class ParseParamError {
-    public:
-        ParseParamError(const string paramName, const string errorMessage);
-        void print(ostream &output) const;
-    
-    private:
-        const string m_paramName;
-        const string m_errorMessage;
+	public:
+		ParseParamError(const std::string paramName, const std::string errorMessage);
+		void print(std::ostream& output) const;
+
+	private:
+		const std::string m_paramName;
+		const std::string m_errorMessage;
 };
 
 #endif

--- a/Simulator/Utils/ParseParamError.h
+++ b/Simulator/Utils/ParseParamError.h
@@ -15,7 +15,7 @@
 
 class ParseParamError {
 	public:
-		ParseParamError(const std::string paramName, const std::string errorMessage);
+		ParseParamError(std::string paramName, std::string errorMessage);
 		void print(std::ostream& output) const;
 
 	private:

--- a/Simulator/Utils/RNG/MTRand.cpp
+++ b/Simulator/Utils/RNG/MTRand.cpp
@@ -68,274 +68,251 @@
 */
 #include "MTRand.h"
 
-MTRand::MTRand( uint32_t oneSeed )
-{ seed(oneSeed); }
+MTRand::MTRand(uint32_t oneSeed) { seed(oneSeed); }
 
-MTRand::MTRand( uint32_t *const bigSeed, uint32_t seedLength )
-{ seed(bigSeed,seedLength); }
+MTRand::MTRand(uint32_t* const bigSeed, uint32_t seedLength) { seed(bigSeed, seedLength); }
 
-MTRand::MTRand()
-{ seed(); }
+MTRand::MTRand() { seed(); }
 
-BGFLOAT MTRand::rand()
-{ return static_cast<BGFLOAT>(randInt()) * (1.0/4294967295.0); }
+BGFLOAT MTRand::rand() { return static_cast<BGFLOAT>(randInt()) * (1.0 / 4294967295.0); }
 
-BGFLOAT MTRand::rand( BGFLOAT n )
-{ return rand() * n; }
+BGFLOAT MTRand::rand(BGFLOAT n) { return rand() * n; }
 
-BGFLOAT MTRand::randExc()
-{ return static_cast<BGFLOAT>(randInt()) * (1.0/4294967296.0); }
+BGFLOAT MTRand::randExc() { return static_cast<BGFLOAT>(randInt()) * (1.0 / 4294967296.0); }
 
-BGFLOAT MTRand::randExc( BGFLOAT n )
-{ return randExc() * n; }
+BGFLOAT MTRand::randExc(BGFLOAT n) { return randExc() * n; }
 
-BGFLOAT MTRand::randDblExc()
-{ return ( static_cast<BGFLOAT>(randInt()) + 0.5 ) * (1.0/4294967296.0); }
+BGFLOAT MTRand::randDblExc() { return (static_cast<BGFLOAT>(randInt()) + 0.5) * (1.0 / 4294967296.0); }
 
-BGFLOAT MTRand::randDblExc( BGFLOAT n )
-{ return randDblExc() * n; }
+BGFLOAT MTRand::randDblExc(BGFLOAT n) { return randDblExc() * n; }
 
-uint32_t MTRand::randInt()
-{
-  // Pull a 32-bit integer from the generator state
-  // Every other access function simply transforms the numbers extracted here
+uint32_t MTRand::randInt() {
+	// Pull a 32-bit integer from the generator state
+	// Every other access function simply transforms the numbers extracted here
 
-  if( left == 0 ) reload();
-  --left;
+	if (left == 0) reload();
+	--left;
 
-  register uint32_t s1;
-  s1 = *pNext++;
-  s1 ^= (s1 >> 11);
-  s1 ^= (s1 <<  7) & 0x9d2c5680UL;
-  s1 ^= (s1 << 15) & 0xefc60000UL;
-  return ( s1 ^ (s1 >> 18) );
+	register uint32_t s1;
+	s1 = *pNext++;
+	s1 ^= (s1 >> 11);
+	s1 ^= (s1 << 7) & 0x9d2c5680UL;
+	s1 ^= (s1 << 15) & 0xefc60000UL;
+	return (s1 ^ (s1 >> 18));
 }
 
-uint32_t MTRand::randInt( uint32_t n )
-{
-  // Find which bits are used in n
-  // Optimized by Magnus Jonsson (magnus@smartelectronix.com)
-  uint32_t used = n;
-  used |= used >> 1;
-  used |= used >> 2;
-  used |= used >> 4;
-  used |= used >> 8;
-  used |= used >> 16;
+uint32_t MTRand::randInt(uint32_t n) {
+	// Find which bits are used in n
+	// Optimized by Magnus Jonsson (magnus@smartelectronix.com)
+	uint32_t used = n;
+	used |= used >> 1;
+	used |= used >> 2;
+	used |= used >> 4;
+	used |= used >> 8;
+	used |= used >> 16;
 
-  // Draw numbers until one is found in [0,n]
-  uint32_t i;
-  do {
-    i = randInt() & used;  // toss unused bits to shorten search
-  } while( i > n );
-  return i;
+	// Draw numbers until one is found in [0,n]
+	uint32_t i;
+	do {
+		i = randInt() & used; // toss unused bits to shorten search
+	}
+	while (i > n);
+	return i;
 }
 
 BGFLOAT MTRand::inRange(BGFLOAT min, BGFLOAT max) {
-  BGFLOAT val = this->operator ()();
-  BGFLOAT range = max - min;
-  val *= range;
-  val += min;
-  return val;
+	BGFLOAT val = this->operator ()();
+	BGFLOAT range = max - min;
+	val *= range;
+	val += min;
+	return val;
 }
 
-BGFLOAT MTRand::rand53()
-{
-  uint32_t a = randInt() >> 5, b = randInt() >> 6;
-  return ( a * 67108864.0 + b ) * (1.0/9007199254740992.0);  // by Isaku Wada
+BGFLOAT MTRand::rand53() {
+	uint32_t a = randInt() >> 5, b = randInt() >> 6;
+	return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0); // by Isaku Wada
 }
 
-BGFLOAT MTRand::randNorm( BGFLOAT mean, BGFLOAT variance )
-{
-  // Return a real number from a normal (Gaussian) distribution with given
-  // mean and variance by Box-Muller method
-  double r = sqrt( -2.0 * log( 1.0-randDblExc()) ) * variance;
-  double phi = 2.0 * 3.14159265358979323846264338328 * randExc();
-  return static_cast<BGFLOAT>(mean + r * cos(phi));
-}
-
-
-void MTRand::seed( uint32_t oneSeed )
-{
-  // Seed the generator with a simple uint32_t
-  initialize(oneSeed);
-  reload();
+BGFLOAT MTRand::randNorm(BGFLOAT mean, BGFLOAT variance) {
+	// Return a real number from a normal (Gaussian) distribution with given
+	// mean and variance by Box-Muller method
+	double r = sqrt(-2.0 * log(1.0 - randDblExc())) * variance;
+	double phi = 2.0 * 3.14159265358979323846264338328 * randExc();
+	return static_cast<BGFLOAT>(mean + r * cos(phi));
 }
 
 
-void MTRand::seed( uint32_t *const bigSeed, uint32_t seedLength )
-{
-  // Seed the generator with an array of uint32_t's
-  // There are 2^19937-1 possible initial states.  This function allows
-  // all of those to be accessed by providing at least 19937 bits (with a
-  // default seed length of N = 624 uint32_t's).  Any bits above the lower 32
-  // in each element are discarded.
-  // Just call seed() if you want to get array from /dev/urandom
-  initialize(19650218UL);
-  register int i = 1;
-  register uint32_t j = 0;
-  register int k = ( N > seedLength ? N : seedLength );
-  for( ; k; --k )
-    {
-      state[i] =
-	state[i] ^ ( (state[i-1] ^ (state[i-1] >> 30)) * 1664525UL );
-      state[i] += ( bigSeed[j] & 0xffffffffUL ) + j;
-      state[i] &= 0xffffffffUL;
-      ++i;  ++j;
-      if( i >= N ) { state[0] = state[N-1];  i = 1; }
-      if( j >= seedLength ) j = 0;
-    }
-  for( k = N - 1; k; --k )
-    {
-      state[i] =
-	state[i] ^ ( (state[i-1] ^ (state[i-1] >> 30)) * 1566083941UL );
-      state[i] -= i;
-      state[i] &= 0xffffffffUL;
-      ++i;
-      if( i >= N ) { state[0] = state[N-1];  i = 1; }
-    }
-  state[0] = 0x80000000UL;  // MSB is 1, assuring non-zero initial array
-  reload();
+void MTRand::seed(uint32_t oneSeed) {
+	// Seed the generator with a simple uint32_t
+	initialize(oneSeed);
+	reload();
 }
 
 
-void MTRand::seed()
-{
-  // Seed the generator with an array from /dev/urandom if available
-  // Otherwise use a hash of time() and clock() values
-
-  // First try getting an array from /dev/urandom
-  FILE* urandom = fopen( "/dev/urandom", "rb" );
-  if( urandom )
-    {
-      uint32_t bigSeed[N];
-      register uint32_t *s = bigSeed;
-      register int i = N;
-      register bool success = true;
-      while( success && i-- )
-	success = fread( s++, sizeof(uint32_t), 1, urandom );
-      fclose(urandom);
-      if( success ) { seed( bigSeed, N );  return; }
-    }
-
-  // Was not successful, so use time() and clock() instead
-  seed( hash( time(nullptr), clock() ) );
+void MTRand::seed(uint32_t* const bigSeed, uint32_t seedLength) {
+	// Seed the generator with an array of uint32_t's
+	// There are 2^19937-1 possible initial states.  This function allows
+	// all of those to be accessed by providing at least 19937 bits (with a
+	// default seed length of N = 624 uint32_t's).  Any bits above the lower 32
+	// in each element are discarded.
+	// Just call seed() if you want to get array from /dev/urandom
+	initialize(19650218UL);
+	register int i = 1;
+	register uint32_t j = 0;
+	register int k = (N > seedLength ? N : seedLength);
+	for (; k; --k) {
+		state[i] =
+			state[i] ^ ((state[i - 1] ^ (state[i - 1] >> 30)) * 1664525UL);
+		state[i] += (bigSeed[j] & 0xffffffffUL) + j;
+		state[i] &= 0xffffffffUL;
+		++i;
+		++j;
+		if (i >= N) {
+			state[0] = state[N - 1];
+			i = 1;
+		}
+		if (j >= seedLength) j = 0;
+	}
+	for (k = N - 1; k; --k) {
+		state[i] =
+			state[i] ^ ((state[i - 1] ^ (state[i - 1] >> 30)) * 1566083941UL);
+		state[i] -= i;
+		state[i] &= 0xffffffffUL;
+		++i;
+		if (i >= N) {
+			state[0] = state[N - 1];
+			i = 1;
+		}
+	}
+	state[0] = 0x80000000UL; // MSB is 1, assuring non-zero initial array
+	reload();
 }
 
 
-void MTRand::save( uint32_t* saveArray ) const
-{
-  register uint32_t *sa = saveArray;
-  register const uint32_t *s = state;
-  register int i = N;
-  for( ; i--; *sa++ = *s++ ) {}
-  *sa = left;
+void MTRand::seed() {
+	// Seed the generator with an array from /dev/urandom if available
+	// Otherwise use a hash of time() and clock() values
+
+	// First try getting an array from /dev/urandom
+	FILE* urandom = fopen("/dev/urandom", "rb");
+	if (urandom) {
+		uint32_t bigSeed[N];
+		register uint32_t* s = bigSeed;
+		register int i = N;
+		register bool success = true;
+		while (success && i--) success = fread(s++, sizeof(uint32_t), 1, urandom);
+		fclose(urandom);
+		if (success) {
+			seed(bigSeed, N);
+			return;
+		}
+	}
+
+	// Was not successful, so use time() and clock() instead
+	seed(hash(time(nullptr), clock()));
 }
 
 
-void MTRand::load( uint32_t *const loadArray )
-{
-  register uint32_t *s = state;
-  register uint32_t *la = loadArray;
-  register int i = N;
-  for( ; i--; *s++ = *la++ ) {}
-  left = *la;
-  pNext = &state[N-left];
+void MTRand::save(uint32_t* saveArray) const {
+	register uint32_t* sa = saveArray;
+	register const uint32_t* s = state;
+	register int i = N;
+	for (; i--; *sa++ = *s++) {}
+	*sa = left;
 }
 
 
-std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
-{
-  register const uint32_t *s = mtrand.state;
-  register int i = mtrand.N;
-  for( ; i--; os << *s++ << "\t" ) {}
-  return os << mtrand.left;
+void MTRand::load(uint32_t* const loadArray) {
+	register uint32_t* s = state;
+	register uint32_t* la = loadArray;
+	register int i = N;
+	for (; i--; *s++ = *la++) {}
+	left = *la;
+	pNext = &state[N - left];
 }
 
 
-std::istream& operator>>( std::istream& is, MTRand& mtrand )
-{
-  register uint32_t *s = mtrand.state;
-  register int i = mtrand.N;
-  for( ; i--; is >> *s++ ) {}
-  is >> mtrand.left;
-  mtrand.pNext = &mtrand.state[mtrand.N-mtrand.left];
-  return is;
-}
-
-void MTRand::initialize( uint32_t seed )
-{
-  // Initialize generator state with seed
-  // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
-  // In previous versions, most significant bits (MSBs) of the seed affect
-  // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-  register uint32_t *s = state;
-  register uint32_t *r = state;
-  register int i = 1;
-  *s++ = seed & 0xffffffffUL;
-  for( ; i < N; ++i )
-    {
-      *s++ = ( 1812433253UL * ( *r ^ (*r >> 30) ) + i ) & 0xffffffffUL;
-      r++;
-    }
+std::ostream& operator<<(std::ostream& os, const MTRand& mtrand) {
+	register const uint32_t* s = mtrand.state;
+	register int i = mtrand.N;
+	for (; i--; os << *s++ << "\t") {}
+	return os << mtrand.left;
 }
 
 
-void MTRand::reload()
-{
-  // Generate N new values in state
-  // Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
-  register uint32_t *p = state;
-  register int i;
-  for( i = N - M; i--; ++p )
-    *p = twist( p[M], p[0], p[1] );
-  for( i = M; --i; ++p )
-    *p = twist( p[M-N], p[0], p[1] );
-  *p = twist( p[M-N], p[0], state[0] );
+std::istream& operator>>(std::istream& is, MTRand& mtrand) {
+	register uint32_t* s = mtrand.state;
+	register int i = mtrand.N;
+	for (; i--; is >> *s++) {}
+	is >> mtrand.left;
+	mtrand.pNext = &mtrand.state[mtrand.N - mtrand.left];
+	return is;
+}
 
-  left = N, pNext = state;
+void MTRand::initialize(uint32_t seed) {
+	// Initialize generator state with seed
+	// See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
+	// In previous versions, most significant bits (MSBs) of the seed affect
+	// only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
+	register uint32_t* s = state;
+	register uint32_t* r = state;
+	register int i = 1;
+	*s++ = seed & 0xffffffffUL;
+	for (; i < N; ++i) {
+		*s++ = (1812433253UL * (*r ^ (*r >> 30)) + i) & 0xffffffffUL;
+		r++;
+	}
 }
 
 
-uint32_t MTRand::hash( time_t t, clock_t c )
-{
-  // Get a uint32_t from t and c
-  // Better than uint32_t(x) in case x is floating point in [0,1]
-  // Based on code by Lawrence Kirby (fred@genesis.demon.co.uk)
+void MTRand::reload() {
+	// Generate N new values in state
+	// Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
+	register uint32_t* p = state;
+	register int i;
+	for (i = N - M; i--; ++p) *p = twist(p[M], p[0], p[1]);
+	for (i = M; --i; ++p) *p = twist(p[M - N], p[0], p[1]);
+	*p = twist(p[M - N], p[0], state[0]);
 
-  static uint32_t differ = 0;  // guarantee time-based seeds will change
+	left = N, pNext = state;
+}
 
-  uint32_t h1 = 0;
-  unsigned char *p = (unsigned char *) &t;
-  for( size_t i = 0; i < sizeof(t); ++i )
-    {
-      h1 *= UCHAR_MAX + 2U;
-      h1 += p[i];
-    }
-  uint32_t h2 = 0;
-  p = (unsigned char *) &c;
-  for( size_t j = 0; j < sizeof(c); ++j )
-    {
-      h2 *= UCHAR_MAX + 2U;
-      h2 += p[j];
-    }
-  return ( h1 + differ++ ) ^ h2;
+
+uint32_t MTRand::hash(time_t t, clock_t c) {
+	// Get a uint32_t from t and c
+	// Better than uint32_t(x) in case x is floating point in [0,1]
+	// Based on code by Lawrence Kirby (fred@genesis.demon.co.uk)
+
+	static uint32_t differ = 0; // guarantee time-based seeds will change
+
+	uint32_t h1 = 0;
+	auto p = (unsigned char*)&t;
+	for (size_t i = 0; i < sizeof(t); ++i) {
+		h1 *= UCHAR_MAX + 2U;
+		h1 += p[i];
+	}
+	uint32_t h2 = 0;
+	p = (unsigned char*)&c;
+	for (size_t j = 0; j < sizeof(c); ++j) {
+		h2 *= UCHAR_MAX + 2U;
+		h2 += p[j];
+	}
+	return (h1 + differ++) ^ h2;
 }
 
 MTRand::~MTRand() {}
 
 // same as rand()
-BGFLOAT MTRand::operator()() {
-  return rand();
+BGFLOAT MTRand::operator()() { return rand(); }
+
+uint32_t MTRand::hiBit(uint32_t u) const { return u & 0x80000000UL; }
+
+uint32_t MTRand::loBit(uint32_t u) const { return u & 0x00000001UL; }
+
+uint32_t MTRand::loBits(uint32_t u) const { return u & 0x7fffffffUL; }
+
+uint32_t MTRand::mixBits(uint32_t u, uint32_t v) const { return hiBit(u) | loBits(v); }
+
+uint32_t MTRand::twist(uint32_t m, uint32_t s0, uint32_t s1) const {
+	return m ^ (mixBits(s0, s1) >> 1) ^ (-loBit(s1) & 0x9908b0dfUL);
 }
-
-uint32_t MTRand::hiBit( uint32_t u ) const { return u & 0x80000000UL; }
-
-uint32_t MTRand::loBit( uint32_t u ) const { return u & 0x00000001UL; }
-
-uint32_t MTRand::loBits( uint32_t u ) const { return u & 0x7fffffffUL; }
-
-uint32_t MTRand::mixBits( uint32_t u, uint32_t v ) const
-  { return hiBit(u) | loBits(v); }
-
-uint32_t MTRand::twist( uint32_t m, uint32_t s0, uint32_t s1 ) const
-  { return m ^ (mixBits(s0,s1)>>1) ^ (-loBit(s1) & 0x9908b0dfUL); }

--- a/Simulator/Utils/RNG/MTRand.h
+++ b/Simulator/Utils/RNG/MTRand.h
@@ -104,7 +104,7 @@ class MTRand {
 		//Methods
 	public:
 		MTRand(uint32_t oneSeed); // initialize with a simple uint32_t
-		MTRand(uint32_t* const bigSeed, uint32_t seedLength = N); // or an array
+		MTRand(uint32_t* bigSeed, uint32_t seedLength = N); // or an array
 		MTRand(); // auto-initialize with /dev/urandom or time() and clock()
 		virtual ~MTRand();
 
@@ -135,12 +135,12 @@ class MTRand {
 
 		// Re-seeding functions with same behavior as initializers
 		virtual void seed(uint32_t oneSeed);
-		void seed(uint32_t* const bigSeed, uint32_t seedLength = N);
+		void seed(uint32_t* bigSeed, uint32_t seedLength = N);
 		virtual void seed();
 
 		// Saving and loading generator state
 		void save(uint32_t* saveArray) const; // to array of size SAVE
-		void load(uint32_t* const loadArray); // from such array
+		void load(uint32_t* loadArray); // from such array
 		friend std::ostream& operator<<(std::ostream& os, const MTRand& mtrand);
 		friend std::istream& operator>>(std::istream& is, MTRand& mtrand);
 

--- a/Simulator/Utils/RNG/MTRand.h
+++ b/Simulator/Utils/RNG/MTRand.h
@@ -75,84 +75,84 @@
 
 #pragma once
 
-#include <iostream>
 #include <climits>
+#include <cmath>
 #include <cstdio>
 #include <ctime>
-#include <cmath>
+#include <iostream>
 #include <stdint.h>
 #include "BGTypes.h" // for BGFLOAT
 
 class MTRand {
-  // Data
- public:
-  static const int N = 624;       // length of state vector
-  static const int SAVE = N + 1;  // length of array for save()
+	// Data
+	public:
+		static const int N = 624; // length of state vector
+		static const int SAVE = N + 1; // length of array for save()
 
-  ///  Creates an instance of the class.
-  ///
-  ///  @return Reference to the instance of the class.
-  static MTRand *Create() { return new MTRand(); }
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static MTRand* Create() { return new MTRand(); }
 
- protected:
-  static const int M = 397;  // period parameter
+	protected:
+		static const int M = 397; // period parameter
 
-  uint32_t state[N];   // internal state
-  uint32_t *pNext;     // next value to get from state
-  int left;            // number of values left before reload needed
+		uint32_t state[N]; // internal state
+		uint32_t* pNext; // next value to get from state
+		int left; // number of values left before reload needed
 
-  //Methods
- public:
-  MTRand( uint32_t oneSeed );  // initialize with a simple uint32_t
-  MTRand( uint32_t *const bigSeed, uint32_t seedLength = N );  // or an array
-  MTRand();  // auto-initialize with /dev/urandom or time() and clock()
-  virtual ~MTRand();
+		//Methods
+	public:
+		MTRand(uint32_t oneSeed); // initialize with a simple uint32_t
+		MTRand(uint32_t* const bigSeed, uint32_t seedLength = N); // or an array
+		MTRand(); // auto-initialize with /dev/urandom or time() and clock()
+		virtual ~MTRand();
 
-  // Do NOT use for CRYPTOGRAPHY without securely hashing several returned
-  // values together, otherwise the generator state can be learned after
-  // reading 624 consecutive values.
+		// Do NOT use for CRYPTOGRAPHY without securely hashing several returned
+		// values together, otherwise the generator state can be learned after
+		// reading 624 consecutive values.
 
-  // Access to 32-bit random numbers
-  BGFLOAT rand();                            // real number in [0,1]
-  BGFLOAT rand( BGFLOAT n );          // real number in [0,n]
-  BGFLOAT randExc();                  // real number in [0,1)
-  BGFLOAT randExc( BGFLOAT n );       // real number in [0,n)
-  BGFLOAT randDblExc();               // real number in (0,1)
-  BGFLOAT randDblExc( BGFLOAT n );    // real number in (0,n)
-  uint32_t randInt();                 // integer in [0,2^32-1]
-  uint32_t randInt( uint32_t n );     // integer in [0,n] for n < 2^32
-  virtual BGFLOAT operator()();       // same as rand()
+		// Access to 32-bit random numbers
+		BGFLOAT rand(); // real number in [0,1]
+		BGFLOAT rand(BGFLOAT n); // real number in [0,n]
+		BGFLOAT randExc(); // real number in [0,1)
+		BGFLOAT randExc(BGFLOAT n); // real number in [0,n)
+		BGFLOAT randDblExc(); // real number in (0,1)
+		BGFLOAT randDblExc(BGFLOAT n); // real number in (0,n)
+		uint32_t randInt(); // integer in [0,2^32-1]
+		uint32_t randInt(uint32_t n); // integer in [0,n] for n < 2^32
+		virtual BGFLOAT operator()(); // same as rand()
 
-  BGFLOAT inRange(BGFLOAT min, BGFLOAT max); // real number in [min, max]
+		BGFLOAT inRange(BGFLOAT min, BGFLOAT max); // real number in [min, max]
 
-  // Access to 53-bit random numbers (capacity of IEEE floating point
-  // precision). May not be true with 64-bit machines anymore; someone
-  // could look into this.
-  BGFLOAT rand53();                   // real number in [0,1)
+		// Access to 53-bit random numbers (capacity of IEEE floating point
+		// precision). May not be true with 64-bit machines anymore; someone
+		// could look into this.
+		BGFLOAT rand53(); // real number in [0,1)
 
-  // Access to nonuniform random number distributions
-  BGFLOAT randNorm( BGFLOAT mean = 0.0, BGFLOAT variance = 0.0 );
+		// Access to nonuniform random number distributions
+		BGFLOAT randNorm(BGFLOAT mean = 0.0, BGFLOAT variance = 0.0);
 
-  // Re-seeding functions with same behavior as initializers
-  virtual void seed( uint32_t oneSeed );
-  void seed( uint32_t *const bigSeed, uint32_t seedLength = N );
-  virtual void seed();
+		// Re-seeding functions with same behavior as initializers
+		virtual void seed(uint32_t oneSeed);
+		void seed(uint32_t* const bigSeed, uint32_t seedLength = N);
+		virtual void seed();
 
-  // Saving and loading generator state
-  void save( uint32_t* saveArray ) const;  // to array of size SAVE
-  void load( uint32_t *const loadArray );  // from such array
-  friend std::ostream& operator<<( std::ostream& os, const MTRand& mtrand );
-  friend std::istream& operator>>( std::istream& is, MTRand& mtrand );
+		// Saving and loading generator state
+		void save(uint32_t* saveArray) const; // to array of size SAVE
+		void load(uint32_t* const loadArray); // from such array
+		friend std::ostream& operator<<(std::ostream& os, const MTRand& mtrand);
+		friend std::istream& operator>>(std::istream& is, MTRand& mtrand);
 
- protected:
-  void initialize( uint32_t oneSeed );
-  void reload();
-  uint32_t hiBit( uint32_t u ) const;
-  uint32_t loBit( uint32_t u ) const;
-  uint32_t loBits( uint32_t u ) const;
-  uint32_t mixBits( uint32_t u, uint32_t v ) const;
-  uint32_t twist( uint32_t m, uint32_t s0, uint32_t s1 ) const;
-  static uint32_t hash( time_t t, clock_t c );
+	protected:
+		void initialize(uint32_t oneSeed);
+		void reload();
+		uint32_t hiBit(uint32_t u) const;
+		uint32_t loBit(uint32_t u) const;
+		uint32_t loBits(uint32_t u) const;
+		uint32_t mixBits(uint32_t u, uint32_t v) const;
+		uint32_t twist(uint32_t m, uint32_t s0, uint32_t s1) const;
+		static uint32_t hash(time_t t, clock_t c);
 };
 
 

--- a/Simulator/Utils/RNG/MersenneTwister_d.cu
+++ b/Simulator/Utils/RNG/MersenneTwister_d.cu
@@ -121,7 +121,7 @@ __global__ void RandomGPU(
 	const int      tid = blockDim.x * blockIdx.x + threadIdx.x;
 	int iState, iState1, iStateM, iOut;
 	unsigned int mti, mti1, mtiM, x;
-	unsigned int matrix_a, mask_b, mask_c; 
+	unsigned int matrix_a, mask_b, mask_c;
 
     //Load bit-vector Mersenne Twister parameters
 	matrix_a = ds_MT[tid].matrix_a;

--- a/Simulator/Utils/RNG/MersenneTwister_d.cu
+++ b/Simulator/Utils/RNG/MersenneTwister_d.cu
@@ -35,8 +35,6 @@
 
 #include <iostream>
 #include <stdio.h>
-
-using namespace std;
 #include "MersenneTwister_d.h"
 
 __device__ static mt_struct_stripped ds_MT[MT_RNG_COUNT];

--- a/Simulator/Utils/RNG/MersenneTwister_d.h
+++ b/Simulator/Utils/RNG/MersenneTwister_d.h
@@ -26,7 +26,7 @@
 #define  MT_RNG_PERIOD 607
 
 
-typedef struct{
+using mt_struct_stripped = struct{
     unsigned int matrix_a;
     unsigned int mask_b;
     unsigned int mask_c;
@@ -37,7 +37,7 @@ typedef struct{
 //    unsigned int seed;
 	unsigned int iState;
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-} mt_struct_stripped;
+};
 
 
 #define MT_DATAFILE "RuntimeFiles/Data/MersenneTwister.dat"

--- a/Simulator/Utils/RNG/MersenneTwister_d.h
+++ b/Simulator/Utils/RNG/MersenneTwister_d.h
@@ -14,7 +14,7 @@
  * is strictly prohibited.
  *
  */
- 
+
 // #ifndef MERSENNETWISTER_H
 //#define MERSENNETWISTER_H
 #ifndef mersennetwister_h

--- a/Simulator/Utils/RNG/MersenneTwister_demo.cu
+++ b/Simulator/Utils/RNG/MersenneTwister_demo.cu
@@ -140,10 +140,10 @@ int main(int argc, char **argv)
         shrLog(" ...generating random numbers on CPU using reference generator\n");
         RandomRef(h_RandCPU, N_PER_RNG, SEED);
 
-        #ifdef DO_BOXMULLER
+#ifdef DO_BOXMULLER
             shrLog(" ...applying Box-Muller transformation on CPU\n");
             BoxMullerRef(h_RandCPU, N_PER_RNG);
-        #endif
+#endif
 
         shrLog(" ...comparing the results\n\n");
         max_delta = 0;

--- a/Simulator/Utils/RNG/Norm.cpp
+++ b/Simulator/Utils/RNG/Norm.cpp
@@ -101,4 +101,4 @@ void Norm::seed(BGFLOAT m, BGFLOAT s, uint32_t seed) {
 
 void Norm::seed(uint32_t seed) { Norm::seed(DEFAULT_m, DEFAULT_s, seed); }
 
-void Norm::seed() { Norm::seed(DEFAULT_m, DEFAULT_s, DEFAULT_seed); }
+void Norm::seed() { seed(DEFAULT_m, DEFAULT_s, DEFAULT_seed); }

--- a/Simulator/Utils/RNG/Norm.cpp
+++ b/Simulator/Utils/RNG/Norm.cpp
@@ -54,58 +54,51 @@
 
 #include "Norm.h"
 
- 
 
 /*!
    This method makes instances functors; it returns normally
    distributed random numbers. Just a cute way of doing things.
    @return pseudorandom number drawn from a normal distribution.
 */
-BGFLOAT Norm::operator() ()
-{
-   BGFLOAT U1, U2,             // Uniformly distributed.
-      V1, V2, W, Y,            //Work variables (see above).
-      X1;                      // First value computed (returned immediately)
+BGFLOAT Norm::operator()() {
+	BGFLOAT U1, U2, // Uniformly distributed.
+	        V1, V2, W, Y, //Work variables (see above).
+	        X1; // First value computed (returned immediately)
 
-   // Check to see if we need to compute anything, complement indicator.
-   if ((odd_ = !odd_))
-      return(mu_ + sigma_ * X2_);
+	// Check to see if we need to compute anything, complement indicator.
+	if ((odd_ = !odd_)) return (mu_ + sigma_ * X2_);
 
-   // Do the computation step 1 (until W <= 1)
-   do {
+	// Do the computation step 1 (until W <= 1)
+	do {
+		U1 = MTRand::operator()(); /* Generate U(0,1) */
+		U2 = MTRand::operator()();
+		V1 = 2 * U1 - 1;
+		V2 = 2 * U2 - 1;
+		W = V1 * V1 + V2 * V2;
+	}
+	while (W > 1);
 
-      U1 = MTRand::operator()();  /* Generate U(0,1) */
-      U2 = MTRand::operator()();
-      V1 = 2 * U1 - 1;
-      V2 = 2 * U2 - 1;
-      W = V1 * V1 + V2 * V2;
-   } while (W > 1);
+	// Do the computation step 2
+	Y = sqrt(-2 * log(W) / W);
+	X1 = V1 * Y;
+	X2_ = V2 * Y;
 
-   // Do the computation step 2
-   Y = sqrt(-2 * log(W) / W);
-   X1 = V1 * Y;
-   X2_ = V2 * Y;
-
-   // Return X1 this time, X2 next time
-   return(mu_ + sigma_ * X1);
+	// Return X1 this time, X2 next time
+	return (mu_ + sigma_ * X1);
 }
 
 Norm::~Norm() {}
 
 Norm::Norm(BGFLOAT m, BGFLOAT s, uint32_t seed)
-   : MTRand(seed), odd_(true), mu_(m), sigma_(s) {}
+	: MTRand(seed), odd_(true), mu_(m), sigma_(s) {}
 
 void Norm::seed(BGFLOAT m, BGFLOAT s, uint32_t seed) {
-   MTRand::seed(seed);
-   odd_ = true;
-   mu_ = m;
-   sigma_ = s;
+	MTRand::seed(seed);
+	odd_ = true;
+	mu_ = m;
+	sigma_ = s;
 }
 
-void Norm::seed(uint32_t seed) {
-   Norm::seed(DEFAULT_m, DEFAULT_s, seed);
-}
+void Norm::seed(uint32_t seed) { Norm::seed(DEFAULT_m, DEFAULT_s, seed); }
 
-void Norm::seed() {
-   Norm::seed(DEFAULT_m, DEFAULT_s, DEFAULT_seed);
-}
+void Norm::seed() { Norm::seed(DEFAULT_m, DEFAULT_s, DEFAULT_seed); }

--- a/Simulator/Utils/RNG/Norm.cpp
+++ b/Simulator/Utils/RNG/Norm.cpp
@@ -54,7 +54,7 @@
 
 #include "Norm.h"
 
-using namespace std;
+ 
 
 /*!
    This method makes instances functors; it returns normally

--- a/Simulator/Utils/RNG/Norm.h
+++ b/Simulator/Utils/RNG/Norm.h
@@ -21,8 +21,8 @@
 #ifndef _NORM_H_
 #define _NORM_H_
 
-#include "MTRand.h"
 #include <cmath>
+#include "MTRand.h"
 
 /*!
    @class Norm
@@ -54,61 +54,61 @@
    Modified from norm.c, from xneuron3
 */
 class Norm : public MTRand {
-public:
-   virtual ~Norm();
+	public:
+		~Norm() override;
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static MTRand *Create() { return new Norm(); }
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static MTRand* Create() { return new Norm(); }
 
-   /*!
-      The constructor allows specification of the mean,
-      variance (default zero and one, respectively), and initial seed
-      for the random number generator. Once created, a Norm object
-      cannot have its mean or variance changed.
-      @param m mean
-      @param s variance
-      @param seed seed for random number generator
-   */
-   Norm(BGFLOAT m = DEFAULT_m, BGFLOAT s = DEFAULT_s, uint32_t seed = DEFAULT_seed);
+		/*!
+		   The constructor allows specification of the mean,
+		   variance (default zero and one, respectively), and initial seed
+		   for the random number generator. Once created, a Norm object
+		   cannot have its mean or variance changed.
+		   @param m mean
+		   @param s variance
+		   @param seed seed for random number generator
+		*/
+		Norm(BGFLOAT m = DEFAULT_m, BGFLOAT s = DEFAULT_s, uint32_t seed = DEFAULT_seed);
 
-   /*!
-      This method makes instances functors; it returns normally
-      distributed random numbers. Just a cute way of doing things.
-      @return pseudorandom number drawn from a normal distribution.
-   */
-   virtual BGFLOAT operator() (void) override;
+		/*!
+		   This method makes instances functors; it returns normally
+		   distributed random numbers. Just a cute way of doing things.
+		   @return pseudorandom number drawn from a normal distribution.
+		*/
+		BGFLOAT operator()(void) override;
 
-   /// Allow Norm re-seeding (with same behavior as initializers)
-   void seed(BGFLOAT m, BGFLOAT s, uint32_t seed);
-   virtual void seed(uint32_t seed) override;
-   virtual void seed() override;
+		/// Allow Norm re-seeding (with same behavior as initializers)
+		void seed(BGFLOAT m, BGFLOAT s, uint32_t seed);
+		void seed(uint32_t seed) override;
+		void seed() override;
 
-private:
-   // Additional state information
+	private:
+		// Additional state information
 
-   /*! Which of the pair of pseudorandom numbers was last
-      returned. Says whether we should calculate this time  */
-   bool odd_;
+		/*! Which of the pair of pseudorandom numbers was last
+		   returned. Says whether we should calculate this time  */
+		bool odd_;
 
-   /*! The second of the pair of pseudorandom numbers generated (last call) */
-   BGFLOAT X2_;
+		/*! The second of the pair of pseudorandom numbers generated (last call) */
+		BGFLOAT X2_;
 
-   /*! Distribution mean */
-   BGFLOAT mu_;
+		/*! Distribution mean */
+		BGFLOAT mu_;
 
-   /*! Distribution variance */
-   BGFLOAT sigma_;
+		/*! Distribution variance */
+		BGFLOAT sigma_;
 
-   /// Default seeding parameter: mean
-   static constexpr BGFLOAT DEFAULT_m = 0.0;
+		/// Default seeding parameter: mean
+		static constexpr BGFLOAT DEFAULT_m = 0.0;
 
-   /// Default seeding parameter: variance
-   static constexpr BGFLOAT DEFAULT_s = 1.0;
+		/// Default seeding parameter: variance
+		static constexpr BGFLOAT DEFAULT_s = 1.0;
 
-   /// Default seeding parameter: seed
-   static constexpr uint32_t DEFAULT_seed = 0;
+		/// Default seeding parameter: seed
+		static constexpr uint32_t DEFAULT_seed = 0;
 };
 
 #endif

--- a/Simulator/Utils/RNG/RNGFactory.cpp
+++ b/Simulator/Utils/RNG/RNGFactory.cpp
@@ -25,13 +25,13 @@ RNGFactory::~RNGFactory() {
 ///
 ///  @param  className  rng class name.
 ///  @param  Pointer to the class creation function.
-void RNGFactory::registerClass(const string &className, CreateFunction function) {
+void RNGFactory::registerClass(const std::string &className, CreateFunction function) {
    createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired rng class.
-MTRand* RNGFactory::createRNG(const string &className) {
+MTRand* RNGFactory::createRNG(const std::string &className) {
    return invokeCreateFunction(className);
 }
 
@@ -39,7 +39,7 @@ MTRand* RNGFactory::createRNG(const string &className) {
 ///
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
-MTRand *RNGFactory::invokeCreateFunction(const string &className) {
+MTRand *RNGFactory::invokeCreateFunction(const std::string &className) {
    for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
       if (className == i->first)
          return i->second();

--- a/Simulator/Utils/RNG/RNGFactory.cpp
+++ b/Simulator/Utils/RNG/RNGFactory.cpp
@@ -12,37 +12,32 @@
 
 /// Constructor is private to keep a singleton instance of this class.
 RNGFactory::RNGFactory() {
-   // register rng classes
-   registerClass("MTRand", &MTRand::Create);
-   registerClass("Norm", &Norm::Create);
+	// register rng classes
+	registerClass("MTRand", &MTRand::Create);
+	registerClass("Norm", &Norm::Create);
 }
 
-RNGFactory::~RNGFactory() {
-   createFunctions.clear();
-}
+RNGFactory::~RNGFactory() { createFunctions.clear(); }
 
 ///  Register rng class and its creation function to the factory.
 ///
 ///  @param  className  rng class name.
 ///  @param  Pointer to the class creation function.
-void RNGFactory::registerClass(const std::string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void RNGFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired rng class.
-MTRand* RNGFactory::createRNG(const std::string &className) {
-   return invokeCreateFunction(className);
-}
+MTRand* RNGFactory::createRNG(const std::string& className) { return invokeCreateFunction(className); }
 
 /// Create an instance of the rng class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
-MTRand *RNGFactory::invokeCreateFunction(const std::string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+MTRand* RNGFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Utils/RNG/RNGFactory.cpp
+++ b/Simulator/Utils/RNG/RNGFactory.cpp
@@ -36,8 +36,7 @@ MTRand* RNGFactory::createRNG(const std::string& className) { return invokeCreat
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
 MTRand* RNGFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Utils/RNG/RNGFactory.h
+++ b/Simulator/Utils/RNG/RNGFactory.h
@@ -15,45 +15,44 @@
 #include "Global.h"
 #include "MTRand.h"
 
- 
 
 class RNGFactory {
 
-public:
-   ~RNGFactory();
+	public:
+		~RNGFactory();
 
-   static RNGFactory *getInstance() {
-      static RNGFactory instance;
-      return &instance;
-   }
+		static RNGFactory* getInstance() {
+			static RNGFactory instance;
+			return &instance;
+		}
 
-   // Invokes constructor for desired concrete class
-   MTRand* createRNG(const std::string &className);
+		// Invokes constructor for desired concrete class
+		MTRand* createRNG(const std::string& className);
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   RNGFactory(RNGFactory const &) = delete;
-   void operator=(RNGFactory const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		RNGFactory(const RNGFactory&) = delete;
+		void operator=(const RNGFactory&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   RNGFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		RNGFactory();
 
-   /// Pointer to rng instance
-   std::shared_ptr<MTRand> rngInstance;
+		/// Pointer to rng instance
+		std::shared_ptr<MTRand> rngInstance;
 
-   /* Type definitions */
-   /// Defines function type for usage in internal map
-   using CreateFunction =  MTRand *(*)(void);
+		/* Type definitions */
+		/// Defines function type for usage in internal map
+		using CreateFunction = MTRand *(*)(void);
 
-   /// Defines map between class name and corresponding ::Create() function.
-   using RNGFunctionMap = std::map<std::string, CreateFunction>;
+		/// Defines map between class name and corresponding ::Create() function.
+		using RNGFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   RNGFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		RNGFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   MTRand *invokeCreateFunction(const std::string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		MTRand* invokeCreateFunction(const std::string& className);
 
-   /// Register rng class and it's create function to the factory.
-   void registerClass(const std::string &className, CreateFunction function);
+		/// Register rng class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Simulator/Utils/RNG/RNGFactory.h
+++ b/Simulator/Utils/RNG/RNGFactory.h
@@ -15,7 +15,7 @@
 #include "Global.h"
 #include "MTRand.h"
 
-using namespace std;
+ 
 
 class RNGFactory {
 
@@ -28,7 +28,7 @@ public:
    }
 
    // Invokes constructor for desired concrete class
-   MTRand* createRNG(const string &className);
+   MTRand* createRNG(const std::string &className);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    RNGFactory(RNGFactory const &) = delete;
@@ -39,21 +39,21 @@ private:
    RNGFactory();
 
    /// Pointer to rng instance
-   shared_ptr<MTRand> rngInstance;
+   std::shared_ptr<MTRand> rngInstance;
 
    /* Type definitions */
    /// Defines function type for usage in internal map
-   typedef MTRand *(*CreateFunction)(void);
+   using CreateFunction =  MTRand *(*)(void);
 
    /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> RNGFunctionMap;
+   using RNGFunctionMap = std::map<std::string, CreateFunction>;
 
    /// Makes class-to-function map an internal factory member.
    RNGFunctionMap createFunctions;
 
    /// Retrieves and invokes correct ::Create() function.
-   MTRand *invokeCreateFunction(const string &className);
+   MTRand *invokeCreateFunction(const std::string &className);
 
    /// Register rng class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+   void registerClass(const std::string &className, CreateFunction function);
 };

--- a/Simulator/Utils/Timer.cpp
+++ b/Simulator/Utils/Timer.cpp
@@ -9,42 +9,36 @@
 #include "Timer.h"
 
 // Constructor ----------------------------------------------------------------
-Timer::Timer( ) {
-  startTime.tv_sec = 0;
-  startTime.tv_usec = 0;
-  endTime.tv_sec = 0;
-  endTime.tv_usec = 0;
+Timer::Timer() {
+	startTime.tv_sec = 0;
+	startTime.tv_usec = 0;
+	endTime.tv_sec = 0;
+	endTime.tv_usec = 0;
 }
 
 // Memorize the current time in startTime -------------------------------------
-void Timer::start( ) {
-  gettimeofday( &startTime, nullptr );
-}
+void Timer::start() { gettimeofday(&startTime, nullptr); }
 
 // Get the diff between the start and the current time (in microseconds)
-long Timer::lap( ) {
-  gettimeofday( &endTime, nullptr );
-  long interval =
-    ( endTime.tv_sec - startTime.tv_sec ) * 1000000 +
-    ( endTime.tv_usec - startTime.tv_usec );
-  return interval;
+long Timer::lap() {
+	gettimeofday(&endTime, nullptr);
+	long interval =
+		(endTime.tv_sec - startTime.tv_sec) * 1000000 +
+		(endTime.tv_usec - startTime.tv_usec);
+	return interval;
 }
 
 // Get the diff between the old and the specified time (in microseconds)
-long Timer::lap( long oldTv_sec, long oldTv_usec ) {
-  gettimeofday( &endTime, nullptr );
-  long interval =
-    ( endTime.tv_sec - oldTv_sec ) * 1000000 +
-    ( endTime.tv_usec - oldTv_usec );
-  return interval;
+long Timer::lap(long oldTv_sec, long oldTv_usec) {
+	gettimeofday(&endTime, nullptr);
+	long interval =
+		(endTime.tv_sec - oldTv_sec) * 1000000 +
+		(endTime.tv_usec - oldTv_usec);
+	return interval;
 }
 
 // Get sec --------------------------------------------------------------------
-long Timer::getSec( ) {
-  return startTime.tv_sec;
-}
+long Timer::getSec() { return startTime.tv_sec; }
 
 // Get usec -------------------------------------------------------------------
-long Timer::getUsec( ) {
-  return startTime.tv_usec;
-}
+long Timer::getUsec() { return startTime.tv_usec; }

--- a/Simulator/Utils/Timer.h
+++ b/Simulator/Utils/Timer.h
@@ -11,10 +11,8 @@
 
 #include <iostream>
 
- 
 
-extern "C"
-{
+extern "C" {
 #ifdef _WIN32	//windows portability 
 #include <windows.h>	//includes timeval struct
 /// gettimeofday sets the first parameter struct timeval with the
@@ -54,16 +52,16 @@ static int gettimeofday(struct timeval *tval, struct timeval *alwaysnullptr){
 /// Class that encapsulates timing capability, for performance
 /// measurement. Includes lap timing capability.
 class Timer {
- public:
-  Timer( );                  // Constructor
-  void start( );             // Memorize the current time in startTime
-  long lap( );               // endTime - startTime (in microseconds)
-  long lap(long oldTv_sec, long oldTv_usec); // endTime - oldTime (in microseconds)
-  long getSec( );            // get startTime.tv_sec
-  long getUsec( );           // get startTime.tv_usec
- private:
-  struct timeval startTime;  // Memorize the time to have started an evaluation
-  struct timeval endTime;    // Memorize the time to have stopped an evaluation
+	public:
+		Timer(); // Constructor
+		void start(); // Memorize the current time in startTime
+		long lap(); // endTime - startTime (in microseconds)
+		long lap(long oldTv_sec, long oldTv_usec); // endTime - oldTime (in microseconds)
+		long getSec(); // get startTime.tv_sec
+		long getUsec(); // get startTime.tv_usec
+	private:
+		struct timeval startTime; // Memorize the time to have started an evaluation
+		struct timeval endTime; // Memorize the time to have stopped an evaluation
 };
 
 #endif

--- a/Simulator/Utils/Timer.h
+++ b/Simulator/Utils/Timer.h
@@ -11,7 +11,7 @@
 
 #include <iostream>
 
-using namespace std;
+ 
 
 extern "C"
 {

--- a/Simulator/Utils/Util.cpp
+++ b/Simulator/Utils/Util.cpp
@@ -11,7 +11,7 @@
 #include <sstream>
 
 /// Helper function that helps with parsing integers in a fixed layout
-void getValueList(const char *val_string, vector<int> *value_list) {
+void getValueList(const char *val_string, std::vector<int> *value_list) {
     std::istringstream val_stream(val_string);
     int i;
 

--- a/Simulator/Utils/Util.cpp
+++ b/Simulator/Utils/Util.cpp
@@ -11,13 +11,13 @@
 #include <sstream>
 
 /// Helper function that helps with parsing integers in a fixed layout
-void getValueList(const char *val_string, std::vector<int> *value_list) {
-    std::istringstream val_stream(val_string);
-    int i;
+void getValueList(const char* val_string, std::vector<int>* value_list) {
+	std::istringstream val_stream(val_string);
+	int i;
 
-    // Parse integers out of the string and add them to a list
-    while (val_stream.good()) {
-        val_stream >> i;
-        value_list->push_back(i);
-    }
+	// Parse integers out of the string and add them to a list
+	while (val_stream.good()) {
+		val_stream >> i;
+		value_list->push_back(i);
+	}
 }

--- a/Simulator/Utils/Util.h
+++ b/Simulator/Utils/Util.h
@@ -13,8 +13,8 @@
 
 #include <vector>
 
-using namespace std;
+ 
 
-void getValueList(const char *val_string, vector<int> *value_list);
+void getValueList(const char *val_string, std::vector<int> *value_list);
 
 #endif

--- a/Simulator/Utils/Util.h
+++ b/Simulator/Utils/Util.h
@@ -13,8 +13,7 @@
 
 #include <vector>
 
- 
 
-void getValueList(const char *val_string, std::vector<int> *value_list);
+void getValueList(const char* val_string, std::vector<int>* value_list);
 
 #endif

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -11,45 +11,41 @@
 
 // Default constructor
 AllVertices::AllVertices() : size_(0) {
-   summationMap_ = nullptr;
+	summationMap_ = nullptr;
 
-   // Register loadParameters function as a loadParameters operation in the Operation Manager
-   std::function<void()> loadParametersFunc = std::bind(&AllVertices::loadParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
+	// Register loadParameters function as a loadParameters operation in the Operation Manager
+	std::function<void()> loadParametersFunc = std::bind(&AllVertices::loadParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
-   // Register printParameters function as a printParameters operation in the OperationManager
-   std::function<void()> printParametersFunc = std::bind(&AllVertices::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
+	// Register printParameters function as a printParameters operation in the OperationManager
+	std::function<void()> printParametersFunc = std::bind(&AllVertices::printParameters, this);
+	OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
-   // Get a copy of the file and vertex logger to use log4cplus macros to print to debug files
-   fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
-   vertexLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("vertex"));
+	// Get a copy of the file and vertex logger to use log4cplus macros to print to debug files
+	fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
+	vertexLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("vertex"));
 }
 
 AllVertices::~AllVertices() {
-   if (size_ != 0) {
-      delete[] summationMap_;
-   }
+	if (size_ != 0) delete[] summationMap_;
 
-   summationMap_ = nullptr;
+	summationMap_ = nullptr;
 
-   size_ = 0;
+	size_ = 0;
 }
 
 ///  Setup the internal structure of the class (allocate memories).
 void AllVertices::setupVertices() {
-   size_ = Simulator::getInstance().getTotalVertices();
-   summationMap_ = new BGFLOAT[size_];
+	size_ = Simulator::getInstance().getTotalVertices();
+	summationMap_ = new BGFLOAT[size_];
 
-   for (int i = 0; i < size_; ++i) {
-      summationMap_[i] = 0;
-   }
+	for (int i = 0; i < size_; ++i) summationMap_[i] = 0;
 
-   Simulator::getInstance().setPSummationMap(summationMap_);
+	Simulator::getInstance().setPSummationMap(summationMap_);
 }
 
 ///  Prints out all parameters of the vertices to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllVertices::printParameters() const {
-   LOG4CPLUS_DEBUG(fileLogger_, "\nVERTICES PARAMETERS");
+	LOG4CPLUS_DEBUG(fileLogger_, "\nVERTICES PARAMETERS");
 }

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -14,12 +14,12 @@ AllVertices::AllVertices() : size_(0) {
    summationMap_ = nullptr;
 
    // Register loadParameters function as a loadParameters operation in the Operation Manager
-   function<void()> loadParametersFunc = std::bind(&AllVertices::loadParameters, this);
+   std::function<void()> loadParametersFunc = std::bind(&AllVertices::loadParameters, this);
    OperationManager::getInstance().registerOperation(Operations::op::loadParameters, loadParametersFunc);
 
    // Register printParameters function as a printParameters operation in the OperationManager
-   function<void()> printParametersFunc = bind(&AllVertices::printParameters, this);
-   OperationManager::getInstance().registerOperation(Operations::printParameters, printParametersFunc);
+   std::function<void()> printParametersFunc = std::bind(&AllVertices::printParameters, this);
+   OperationManager::getInstance().registerOperation(Operations::op::printParameters, printParametersFunc);
 
    // Get a copy of the file and vertex logger to use log4cplus macros to print to debug files
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -10,8 +10,8 @@
 #include "OperationManager.h"
 
 // Default constructor
-AllVertices::AllVertices() : size_(0) {
-	summationMap_ = nullptr;
+AllVertices::AllVertices() : summationMap_(nullptr), size_(0) {
+
 
 	// Register loadParameters function as a loadParameters operation in the Operation Manager
 	std::function<void()> loadParametersFunc = std::bind(&AllVertices::loadParameters, this);

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -61,7 +61,7 @@ class AllVertices {
 		///
 		///  @param  i   index of the vertex (in vertices) to output info from.
 		///  @return the complete state of the vertex.
-		virtual std::string toString(const int i) const = 0;
+		virtual std::string toString(int i) const = 0;
 
 		///  The summation point for each vertex.
 		///  Summation points are places where the synapses connected to the vertex

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-using namespace std;
+ 
 
 #include <iostream>
 #include <log4cplus/loggingmacros.h>
@@ -62,7 +62,7 @@ public:
    ///
    ///  @param  i   index of the vertex (in vertices) to output info from.
    ///  @return the complete state of the vertex.
-   virtual string toString(const int i) const = 0;
+   virtual std::string toString(const int i) const = 0;
 
    ///  The summation point for each vertex.
    ///  Summation points are places where the synapses connected to the vertex
@@ -79,7 +79,7 @@ protected:
    log4cplus::Logger fileLogger_; // Logs to Output/Debug/logging.txt
    log4cplus::Logger vertexLogger_; // Logs to Output/Debug/neurons.txt
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Allocate GPU memories to store all vertices' states,
        ///  and copy them from host to GPU memory.
@@ -116,7 +116,7 @@ protected:
        ///
        ///  @param  edges               Reference to the allEdges struct on host memory.
        virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
-#else // !defined(USE_GPU)
+#else
 public:
    ///  Update internal state of the indexed Neuron (called by every simulation step).
    ///  Notify outgoing synapses if vertex has fired.
@@ -125,10 +125,10 @@ public:
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
    virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) = 0;
 
-#endif // defined(USE_GPU)
+#endif
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllVerticesDeviceProperties
 {
         ///  The summation point for each vertex.
@@ -138,4 +138,4 @@ struct AllVerticesDeviceProperties
         ///  summation points to their Vm and resets the summation points to zero
         BGFLOAT *summationMap_;
 };
-#endif // defined(USE_GPU)
+#endif

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -21,63 +21,62 @@
 
 #pragma once
 
- 
 
 #include <iostream>
 #include <log4cplus/loggingmacros.h>
 
+#include "AllEdges.h"
 #include "BGTypes.h"
+#include "Layout.h"
 #include "Simulator.h"
 #include "Core/EdgeIndexMap.h"
-#include "AllEdges.h"
-#include "Layout.h"
 
 class Layout;
 class AllEdges;
 
 class AllVertices {
-public:
-   AllVertices();
+	public:
+		AllVertices();
 
-   virtual ~AllVertices();
+		virtual ~AllVertices();
 
-   ///  Setup the internal structure of the class.
-   ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices();
+		///  Setup the internal structure of the class.
+		///  Allocate memories to store all neurons' state.
+		virtual void setupVertices();
 
-   ///  Prints out all parameters of the neurons to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const;
+		///  Prints out all parameters of the neurons to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		virtual void printParameters() const;
 
-   ///  Load member variables from configuration file.
-   ///  Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters() = 0;
+		///  Load member variables from configuration file.
+		///  Registered to OperationManager as Operation::loadParameters
+		virtual void loadParameters() = 0;
 
-   ///  Creates all the Vertices and assigns initial data for them.
-   ///
-   ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout) = 0;
+		///  Creates all the Vertices and assigns initial data for them.
+		///
+		///  @param  layout      Layout information of the neural network.
+		virtual void createAllVertices(Layout* layout) = 0;
 
-   ///  Outputs state of the vertex chosen as a string.
-   ///
-   ///  @param  i   index of the vertex (in vertices) to output info from.
-   ///  @return the complete state of the vertex.
-   virtual std::string toString(const int i) const = 0;
+		///  Outputs state of the vertex chosen as a string.
+		///
+		///  @param  i   index of the vertex (in vertices) to output info from.
+		///  @return the complete state of the vertex.
+		virtual std::string toString(const int i) const = 0;
 
-   ///  The summation point for each vertex.
-   ///  Summation points are places where the synapses connected to the vertex
-   ///  apply (summed up) their PSRs (Post-Synaptic-Response).
-   ///  On the next advance cycle, vertices add the values stored in their corresponding
-   ///  summation points to their Vm and resets the summation points to zero
-   BGFLOAT *summationMap_;
+		///  The summation point for each vertex.
+		///  Summation points are places where the synapses connected to the vertex
+		///  apply (summed up) their PSRs (Post-Synaptic-Response).
+		///  On the next advance cycle, vertices add the values stored in their corresponding
+		///  summation points to their Vm and resets the summation points to zero
+		BGFLOAT* summationMap_;
 
-protected:
-   ///  Total number of vertices.
-   int size_;
+	protected:
+		///  Total number of vertices.
+		int size_;
 
-   // Loggers used to print to using log4cplus logging macros
-   log4cplus::Logger fileLogger_; // Logs to Output/Debug/logging.txt
-   log4cplus::Logger vertexLogger_; // Logs to Output/Debug/neurons.txt
+		// Loggers used to print to using log4cplus logging macros
+		log4cplus::Logger fileLogger_; // Logs to Output/Debug/logging.txt
+		log4cplus::Logger vertexLogger_; // Logs to Output/Debug/neurons.txt
 
 #ifdef __CUDACC__
    public:
@@ -117,13 +116,13 @@ protected:
        ///  @param  edges               Reference to the allEdges struct on host memory.
        virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
 #else
-public:
-   ///  Update internal state of the indexed Neuron (called by every simulation step).
-   ///  Notify outgoing synapses if vertex has fired.
-   ///
-   ///  @param  edges         The Synapse list to search from.
-   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) = 0;
+	public:
+		///  Update internal state of the indexed Neuron (called by every simulation step).
+		///  Notify outgoing synapses if vertex has fired.
+		///
+		///  @param  edges         The Synapse list to search from.
+		///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+		virtual void advanceVertices(AllEdges& edges, const EdgeIndexMap* edgeIndexMap) = 0;
 
 #endif
 };

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -11,11 +11,7 @@
 #include "Layout911.h"
 #include "ParameterManager.h"
 
-All911Vertices::All911Vertices() {
-	callNum_ = nullptr;
-	dispNum_ = nullptr;
-	respNum_ = nullptr;
-}
+All911Vertices::All911Vertices(): respNum_(nullptr), dispNum_(nullptr), callNum_(nullptr) { }
 
 All911Vertices::~All911Vertices() {
 	if (size_ != 0) {

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -8,105 +8,101 @@
 
 #include "All911Vertices.h"
 #include "All911Edges.h"
-#include "ParameterManager.h"
 #include "Layout911.h"
+#include "ParameterManager.h"
 
 All911Vertices::All911Vertices() {
-    callNum_ = nullptr; 
-    dispNum_ = nullptr; 
-    respNum_ = nullptr;
+	callNum_ = nullptr;
+	dispNum_ = nullptr;
+	respNum_ = nullptr;
 }
 
 All911Vertices::~All911Vertices() {
-    if (size_ != 0) {
-        delete[] callNum_;
-        delete[] dispNum_;
-        delete[] respNum_;
-    }
+	if (size_ != 0) {
+		delete[] callNum_;
+		delete[] dispNum_;
+		delete[] respNum_;
+	}
 
-    callNum_ = nullptr;
-    dispNum_ = nullptr;
-    respNum_ = nullptr;
+	callNum_ = nullptr;
+	dispNum_ = nullptr;
+	respNum_ = nullptr;
 }
 
 // Allocate memory for all class properties
 void All911Vertices::setupVertices() {
-    AllVertices::setupVertices();
+	AllVertices::setupVertices();
 
-    callNum_ = new int[size_];
-    dispNum_ = new int[size_];
-    respNum_ = new int[size_];
+	callNum_ = new int[size_];
+	dispNum_ = new int[size_];
+	respNum_ = new int[size_];
 
-    // Populate arrays with 0
-    std::fill_n(callNum_, size_, 0);
-    std::fill_n(dispNum_, size_, 0);
-    std::fill_n(respNum_, size_, 0);
+	// Populate arrays with 0
+	std::fill_n(callNum_, size_, 0);
+	std::fill_n(dispNum_, size_, 0);
+	std::fill_n(respNum_, size_, 0);
 }
 
 // Generate callNum_ and dispNum_ for all caller and psap nodes
-void All911Vertices::createAllVertices(Layout *layout) {
-    std::vector<int> psapList;
-    std::vector<int> respList;
-    psapList.clear();
-    respList.clear();
+void All911Vertices::createAllVertices(Layout* layout) {
+	std::vector<int> psapList;
+	std::vector<int> respList;
+	psapList.clear();
+	respList.clear();
 
-    int callersPerZone[] = {0, 0, 0, 0};
-    int respPerZone[] = {0, 0, 0, 0};
-    
-    Layout911 *layout911 = dynamic_cast<Layout911 *>(layout); 
+	int callersPerZone[] = {0, 0, 0, 0};
+	int respPerZone[] = {0, 0, 0, 0};
 
-    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {  
-        // Create all callers
-        if (layout->vertexTypeMap_[i] == CALR) {
-            callNum_[i] = initRNG.inRange(callNumRange_[0], callNumRange_[1]);
-            callersPerZone[layout911->zone(i)] += callNum_[i];
-        }
+	auto layout911 = dynamic_cast<Layout911*>(layout);
 
-        // Find all PSAPs
-        if(layout->vertexTypeMap_[i] == PSAP) {
-            psapList.push_back(i);
-        }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		// Create all callers
+		if (layout->vertexTypeMap_[i] == CALR) {
+			callNum_[i] = initRNG.inRange(callNumRange_[0], callNumRange_[1]);
+			callersPerZone[layout911->zone(i)] += callNum_[i];
+		}
 
-        // Find all resps
-        if(layout->vertexTypeMap_[i] == RESP) {
-            respList.push_back(i);
-            respPerZone[layout911->zone(i)] += 1;
-        }
-    }
+		// Find all PSAPs
+		if (layout->vertexTypeMap_[i] == PSAP) psapList.push_back(i);
 
-    // Create all psaps
-    // Dispatchers in a psap = [callers in the zone * k] + some randomness
-    for (int i = 0; i < psapList.size(); i++) {
-        int psapQ = layout911->zone(i);
-        int dispCount = (callersPerZone[psapQ] * dispNumScale_) + initRNG.inRange(-5, 5);
-        if (dispCount < 1) { dispCount = 1; }
-        dispNum_[psapList[i]] = dispCount;
-    }
+		// Find all resps
+		if (layout->vertexTypeMap_[i] == RESP) {
+			respList.push_back(i);
+			respPerZone[layout911->zone(i)] += 1;
+		}
+	}
 
-    // Create all responders
-    // Responders in a node = [callers in the zone * k]/[number of responder nodes] + some randomness
-    for (int i = 0; i < respList.size(); i++) {
-        int respQ = layout911->zone(respList[i]);
-        int respCount = (callersPerZone[respQ] * respNumScale_)/respPerZone[respQ] + initRNG.inRange(-5, 5);
-        if (respCount < 1) { respCount = 1; }
-        respNum_[respList[i]] = respCount;
-    }
+	// Create all psaps
+	// Dispatchers in a psap = [callers in the zone * k] + some randomness
+	for (int i = 0; i < psapList.size(); i++) {
+		int psapQ = layout911->zone(i);
+		int dispCount = (callersPerZone[psapQ] * dispNumScale_) + initRNG.inRange(-5, 5);
+		if (dispCount < 1) dispCount = 1;
+		dispNum_[psapList[i]] = dispCount;
+	}
+
+	// Create all responders
+	// Responders in a node = [callers in the zone * k]/[number of responder nodes] + some randomness
+	for (int i = 0; i < respList.size(); i++) {
+		int respQ = layout911->zone(respList[i]);
+		int respCount = (callersPerZone[respQ] * respNumScale_) / respPerZone[respQ] + initRNG.inRange(-5, 5);
+		if (respCount < 1) respCount = 1;
+		respNum_[respList[i]] = respCount;
+	}
 }
 
 void All911Vertices::loadParameters() {
-    ParameterManager::getInstance().getIntByXpath("//CallNum/min/text()", callNumRange_[0]);
-    ParameterManager::getInstance().getIntByXpath("//CallNum/max/text()", callNumRange_[1]);
-    ParameterManager::getInstance().getBGFloatByXpath("//DispNumScale/text()", dispNumScale_);
-    ParameterManager::getInstance().getBGFloatByXpath("//RespNumScale/text()", respNumScale_);
+	ParameterManager::getInstance().getIntByXpath("//CallNum/min/text()", callNumRange_[0]);
+	ParameterManager::getInstance().getIntByXpath("//CallNum/max/text()", callNumRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//DispNumScale/text()", dispNumScale_);
+	ParameterManager::getInstance().getBGFloatByXpath("//RespNumScale/text()", respNumScale_);
 }
 
 
-void All911Vertices::printParameters() const {
-
-}
+void All911Vertices::printParameters() const {}
 
 std::string All911Vertices::toString(const int index) const {
-    return nullptr; // Change this
+	return nullptr; // Change this
 }
 
 #ifndef __CUDACC__
@@ -116,73 +112,73 @@ std::string All911Vertices::toString(const int index) const {
 ///
 ///  @param  edges         The edge list to search from.
 ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) {
-//    // casting all911Edges for this method to use & modify
-//    All911Edges &allEdges = dynamic_cast<All911Edges &>(edges);
-//    // For each vertex in the network
-//    for (int idx = Simulator::getInstance().getTotalVertices() - 1; idx >= 0; --idx) {
-//       // advance vertices
-//       advanceVertex(idx);
+void All911Vertices::advanceVertices(AllEdges& edges, const EdgeIndexMap* edgeIndexMap) {
+	//    // casting all911Edges for this method to use & modify
+	//    All911Edges &allEdges = dynamic_cast<All911Edges &>(edges);
+	//    // For each vertex in the network
+	//    for (int idx = Simulator::getInstance().getTotalVertices() - 1; idx >= 0; --idx) {
+	//       // advance vertices
+	//       advanceVertex(idx);
 
-//       // notify the source and destination edges if anything has happened to the vertex
-//       if (hasFired_[idx]) {
-//          LOG4CPLUS_DEBUG(vertexLogger_, "Vertex: " << idx << " has fired at time: "
-//                         << g_simulationStep * Simulator::getInstance().getDeltaT());
+	//       // notify the source and destination edges if anything has happened to the vertex
+	//       if (hasFired_[idx]) {
+	//          LOG4CPLUS_DEBUG(vertexLogger_, "Vertex: " << idx << " has fired at time: "
+	//                         << g_simulationStep * Simulator::getInstance().getDeltaT());
 
 
-//          // notify outgoing edges
-//          BGSIZE edgeCounts;
+	//          // notify outgoing edges
+	//          BGSIZE edgeCounts;
 
-//          if (edgeIndexMap != nullptr) {
-//             edgeCounts = edgeIndexMap->outgoingEdgeCount_[idx];
-//             if (edgeCounts != 0) {
-//                int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
-//                BGSIZE iEdg;
-//                for (BGSIZE i = 0; i < edgeCounts; i++) {
-//                   iEdg = edgeIndexMap->outgoingEdgeBegin_[beginIndex + i];
-//                   allEdges.preSpikeHit(iEdg);
-//                }
-//             }
-//          }
+	//          if (edgeIndexMap != nullptr) {
+	//             edgeCounts = edgeIndexMap->outgoingEdgeCount_[idx];
+	//             if (edgeCounts != 0) {
+	//                int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
+	//                BGSIZE iEdg;
+	//                for (BGSIZE i = 0; i < edgeCounts; i++) {
+	//                   iEdg = edgeIndexMap->outgoingEdgeBegin_[beginIndex + i];
+	//                   allEdges.preSpikeHit(iEdg);
+	//                }
+	//             }
+	//          }
 
-//          // notify incoming edges
-//          edgeCounts = allEdges.edgeCounts_[idx];
-//          BGSIZE synapse_notified = 0;
+	//          // notify incoming edges
+	//          edgeCounts = allEdges.edgeCounts_[idx];
+	//          BGSIZE synapse_notified = 0;
 
-//          hasFired_[idx] = false;
-//       }
-//    }
+	//          hasFired_[idx] = false;
+	//       }
+	//    }
 }
 
 ///  Update internal state of the indexed Neuron (called by every simulation step).
 ///
 ///  @param  index       Index of the Neuron to update.
 void All911Vertices::advanceVertex(const int index) {
-    // BGFLOAT &Vm = this->Vm_[index];
-    // BGFLOAT &Vthresh = this->Vthresh_[index];
-    // BGFLOAT &summationPoint = this->summationMap_[index];
-    // BGFLOAT &I0 = this->I0_[index];
-    // BGFLOAT &Inoise = this->Inoise_[index];
-    // BGFLOAT &C1 = this->C1_[index];
-    // BGFLOAT &C2 = this->C2_[index];
-    // int &nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
+	// BGFLOAT &Vm = this->Vm_[index];
+	// BGFLOAT &Vthresh = this->Vthresh_[index];
+	// BGFLOAT &summationPoint = this->summationMap_[index];
+	// BGFLOAT &I0 = this->I0_[index];
+	// BGFLOAT &Inoise = this->Inoise_[index];
+	// BGFLOAT &C1 = this->C1_[index];
+	// BGFLOAT &C2 = this->C2_[index];
+	// int &nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
 
-    // if (nStepsInRefr > 0) {
-    //     // is neuron refractory?
-    //     --nStepsInRefr;
-    // } else if (Vm >= Vthresh) {
-    //     // should it fire?
-    //     fire(index);
-    // } else {
-    //     summationPoint += I0; // add IO
-    //     // add noise
-    //     BGFLOAT noise = (*rgNormrnd)();
-    //     //LOG4CPLUS_DEBUG(vertexLogger_, "ADVANCE NEURON[" << index << "] :: Noise = " << noise);
-    //     summationPoint += noise * Inoise; // add noise
-    //     Vm = C1 * Vm + C2 * summationPoint; // decay Vm and add inputs
-    // }
-    // // clear synaptic input for next time step
-    // summationPoint = 0;
+	// if (nStepsInRefr > 0) {
+	//     // is neuron refractory?
+	//     --nStepsInRefr;
+	// } else if (Vm >= Vthresh) {
+	//     // should it fire?
+	//     fire(index);
+	// } else {
+	//     summationPoint += I0; // add IO
+	//     // add noise
+	//     BGFLOAT noise = (*rgNormrnd)();
+	//     //LOG4CPLUS_DEBUG(vertexLogger_, "ADVANCE NEURON[" << index << "] :: Noise = " << noise);
+	//     summationPoint += noise * Inoise; // add noise
+	//     Vm = C1 * Vm + C2 * summationPoint; // decay Vm and add inputs
+	// }
+	// // clear synaptic input for next time step
+	// summationPoint = 0;
 
 }
 

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -38,15 +38,15 @@ void All911Vertices::setupVertices() {
     respNum_ = new int[size_];
 
     // Populate arrays with 0
-    fill_n(callNum_, size_, 0);
-    fill_n(dispNum_, size_, 0);
-    fill_n(respNum_, size_, 0);
+    std::fill_n(callNum_, size_, 0);
+    std::fill_n(dispNum_, size_, 0);
+    std::fill_n(respNum_, size_, 0);
 }
 
 // Generate callNum_ and dispNum_ for all caller and psap nodes
 void All911Vertices::createAllVertices(Layout *layout) {
-    vector<int> psapList;
-    vector<int> respList;
+    std::vector<int> psapList;
+    std::vector<int> respList;
     psapList.clear();
     respList.clear();
 
@@ -105,11 +105,11 @@ void All911Vertices::printParameters() const {
 
 }
 
-string All911Vertices::toString(const int index) const {
+std::string All911Vertices::toString(const int index) const {
     return nullptr; // Change this
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Update internal state of the indexed vertex (called by every simulation step).
 ///  Notify outgoing edges if vertex has fired.

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -57,16 +57,16 @@ void All911Vertices::createAllVertices(Layout* layout) {
 
 	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
 		// Create all callers
-		if (layout->vertexTypeMap_[i] == CALR) {
+		if (layout->vertexTypeMap_[i] == vertexType::CALR) {
 			callNum_[i] = initRNG.inRange(callNumRange_[0], callNumRange_[1]);
 			callersPerZone[layout911->zone(i)] += callNum_[i];
 		}
 
 		// Find all PSAPs
-		if (layout->vertexTypeMap_[i] == PSAP) psapList.push_back(i);
+		if (layout->vertexTypeMap_[i] == vertexType::PSAP) psapList.push_back(i);
 
 		// Find all resps
-		if (layout->vertexTypeMap_[i] == RESP) {
+		if (layout->vertexTypeMap_[i] == vertexType::RESP) {
 			respList.push_back(i);
 			respPerZone[layout911->zone(i)] += 1;
 		}

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -53,7 +53,7 @@ class All911Vertices : public AllVertices {
 		///
 		///  @param  index   index of the vertex (in vertices) to output info from.
 		///  @return the complete state of the vertex.
-		std::string toString(const int index) const override;
+		std::string toString(int index) const override;
 
 	private:
 		/// number of callers
@@ -94,7 +94,7 @@ class All911Vertices : public AllVertices {
 		void advanceVertices(AllEdges& edges, const EdgeIndexMap* edgeIndexMap) override;
 
 	protected:
-		void advanceVertex(const int index);
+		void advanceVertex(int index);
 
 
 #endif // defined(__CUDACC__)

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -54,7 +54,7 @@ public:
    ///
    ///  @param  index   index of the vertex (in vertices) to output info from.
    ///  @return the complete state of the vertex.
-   virtual string toString(const int index) const;
+   virtual std::string toString(const int index) const;
 
 private: 
 
@@ -76,7 +76,7 @@ private:
    /// Scaling factor for number of responders in a Responder node
    BGFLOAT respNumScale_;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    // GPU functionality for 911 simulation is unimplemented.
    // These signatures are required to make the class non-abstract
    public:

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -17,64 +17,62 @@
  */
 #pragma once
 
-#include "Global.h"
 #include "AllVertices.h"
+#include "Global.h"
 
 // Class to hold all data necessary for all the Vertices.
 class All911Vertices : public AllVertices {
-public:
+	public:
+		All911Vertices();
 
-   All911Vertices();
+		~All911Vertices() override;
 
-   virtual ~All911Vertices();
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static AllVertices* Create() { return new All911Vertices(); }
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static AllVertices *Create() { return new All911Vertices(); }
+		///  Setup the internal structure of the class.
+		///  Allocate memories to store all vertices' states.
+		void setupVertices() override;
 
-   ///  Setup the internal structure of the class.
-   ///  Allocate memories to store all vertices' states.
-   virtual void setupVertices();
+		///  Creates all the Vertices and assigns initial data for them.
+		///
+		///  @param  layout      Layout information of the network.
+		void createAllVertices(Layout* layout) override;
 
-   ///  Creates all the Vertices and assigns initial data for them.
-   ///
-   ///  @param  layout      Layout information of the network.
-   virtual void createAllVertices(Layout *layout);
+		///  Load member variables from configuration file.
+		///  Registered to OperationManager as Operation::loadParameters
+		void loadParameters() override;
 
-   ///  Load member variables from configuration file.
-   ///  Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters();
+		///  Prints out all parameters of the vertices to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Prints out all parameters of the vertices to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Outputs state of the vertex chosen as a string.
+		///
+		///  @param  index   index of the vertex (in vertices) to output info from.
+		///  @return the complete state of the vertex.
+		std::string toString(const int index) const override;
 
-   ///  Outputs state of the vertex chosen as a string.
-   ///
-   ///  @param  index   index of the vertex (in vertices) to output info from.
-   ///  @return the complete state of the vertex.
-   virtual std::string toString(const int index) const;
+	private:
+		/// number of callers
+		int* callNum_;
 
-private: 
+		/// Min/max values of CallNum.
+		int callNumRange_[2];
 
-   /// number of callers
-   int *callNum_; 
+		/// Number of dispatchers per PSAP calculated (with randomness) based on population
+		int* dispNum_;
 
-   /// Min/max values of CallNum.
-   int callNumRange_[2];
+		/// Scaling factor for number of dispatchers in a PSAP
+		BGFLOAT dispNumScale_;
 
-   /// Number of dispatchers per PSAP calculated (with randomness) based on population
-   int *dispNum_;
+		/// Number of responders per Responder node calculated (with randomness) based on population
+		int* respNum_;
 
-   /// Scaling factor for number of dispatchers in a PSAP
-   BGFLOAT dispNumScale_;
-
-   /// Number of responders per Responder node calculated (with randomness) based on population
-   int *respNum_;
-
-   /// Scaling factor for number of responders in a Responder node
-   BGFLOAT respNumScale_;
+		/// Scaling factor for number of responders in a Responder node
+		BGFLOAT respNumScale_;
 
 #ifdef __CUDACC__
    // GPU functionality for 911 simulation is unimplemented.
@@ -86,20 +84,18 @@ private:
        virtual void copyNeuronDeviceToHost(void* allVerticesDevice) {};
        virtual void advanceVertices(AllEdges &edges, void* allVerticesDevice, void* allEdgesDevice, float* randNoise, EdgeIndexMap* edgeIndexMapDevice) {};
        virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) {};
-#else  // !defined(USE_GPU)
-public:
- 
-   ///  Update internal state of the indexed Vertex (called by every simulation step).
-   ///  Notify outgoing edges if vertex has fired.
-   ///
-   ///  @param  edges         The Edge list to search from.
-   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) override;
+#else  // !defined(__CUDACC__)
+	public:
+		///  Update internal state of the indexed Vertex (called by every simulation step).
+		///  Notify outgoing edges if vertex has fired.
+		///
+		///  @param  edges         The Edge list to search from.
+		///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+		void advanceVertices(AllEdges& edges, const EdgeIndexMap* edgeIndexMap) override;
 
-protected:
-   void advanceVertex(const int index);
+	protected:
+		void advanceVertex(const int index);
 
 
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)
 };
-

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -15,23 +15,7 @@
 #include "ParseParamError.h"
 
 // Default constructor
-AllIFNeurons::AllIFNeurons() {
-	C1_ = nullptr;
-	C2_ = nullptr;
-	Cm_ = nullptr;
-	I0_ = nullptr;
-	Iinject_ = nullptr;
-	Inoise_ = nullptr;
-	Isyn_ = nullptr;
-	Rm_ = nullptr;
-	Tau_ = nullptr;
-	Trefract_ = nullptr;
-	Vinit_ = nullptr;
-	Vm_ = nullptr;
-	Vreset_ = nullptr;
-	Vrest_ = nullptr;
-	Vthresh_ = nullptr;
-	numStepsInRefractoryPeriod_ = nullptr;
+AllIFNeurons::AllIFNeurons(): numStepsInRefractoryPeriod_(nullptr), Vthresh_(nullptr), Vrest_(nullptr), Vreset_(nullptr), Vm_(nullptr), Vinit_(nullptr), Trefract_(nullptr), Tau_(nullptr), Rm_(nullptr), Isyn_(nullptr), Inoise_(nullptr), Iinject_(nullptr), I0_(nullptr), Cm_(nullptr), C2_(nullptr), C1_(nullptr) {
 }
 
 AllIFNeurons::~AllIFNeurons() {

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -135,28 +135,28 @@ void AllIFNeurons::printParameters() const {
    LOG4CPLUS_DEBUG(fileLogger_,
                    "\n\tInterval of constant injected current: ["
                          << IinjectRange_[0] << ", " << IinjectRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tInterval of STD of (gaussian) noise current: ["
                          << InoiseRange_[0] << ", " << InoiseRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tInterval of firing threshold: ["
                          << VthreshRange_[0] << ", " << VthreshRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tInterval of asymptotic voltage (Vresting): [" << VrestingRange_[0]
                          << ", " << VrestingRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tInterval of reset voltage: [" << VresetRange_[0]
                          << ", " << VresetRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tInterval of initial membrance voltage: [" << VinitRange_[0]
                          << ", " << VinitRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tStarter firing threshold: [" << starterVthreshRange_[0]
                          << ", " << starterVthreshRange_[1] << "]"
-                         << endl
+                         << std::endl
                          << "\tStarter reset threshold: [" << starterVresetRange_[0]
                          << ", " << starterVresetRange_[1] << "]"
-                         << endl << endl);
+                         << std::endl << std::endl);
 }
 
 ///  Creates all the Neurons and generates data for them.
@@ -221,16 +221,16 @@ void AllIFNeurons::createNeuron(int i, Layout *layout) {
       Trefract_[i] = DEFAULT_ExcitTrefract; // TODO(derek): move defaults inside model.
    }
 
-   LOG4CPLUS_DEBUG(vertexLogger_, "\nCREATE NEURON[" << i << "] {" << endl
-                 << "\tVm = " << Vm_[i] << endl
-                 << "\tVthresh = " << Vthresh_[i] << endl
-                 << "\tI0 = " << I0_[i] << endl
+   LOG4CPLUS_DEBUG(vertexLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
+                 << "\tVm = " << Vm_[i] << std::endl
+                 << "\tVthresh = " << Vthresh_[i] << std::endl
+                 << "\tI0 = " << I0_[i] << std::endl
                  << "\tInoise = " << Inoise_[i] << " from : (" << InoiseRange_[0] << "," << InoiseRange_[1]
                  << ")"
-                 << endl
-                 << "\tC1 = " << C1_[i] << endl
-                 << "\tC2 = " << C2_[i] << endl
-                 << "}" << endl);
+                 << std::endl
+                 << "\tC1 = " << C1_[i] << std::endl
+                 << "\tC2 = " << C2_[i] << std::endl
+                 << "}" << std::endl);
 }
 
 ///  Set the Neuron at the indexed location to default values.
@@ -282,19 +282,19 @@ void AllIFNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT) 
 ///
 ///  @param  index  index of the neuron (in neurons) to output info from.
 ///  @return the complete state of the neuron.
-string AllIFNeurons::toString(const int index) const {
-   stringstream ss;
+std::string AllIFNeurons::toString(const int index) const {
+   std::stringstream ss;
    ss << "Cm: " << Cm_[index] << " "; // membrane capacitance
    ss << "Rm: " << Rm_[index] << " "; // membrane resistance
    ss << "Vthresh: " << Vthresh_[index] << " "; // if Vm exceeds, Vthresh, a spike is emitted
    ss << "Vrest: " << Vrest_[index] << " "; // the resting membrane voltage
    ss << "Vreset: " << Vreset_[index] << " "; // The voltage to reset Vm to after a spike
-   ss << "Vinit: " << Vinit_[index] << endl; // The initial condition for V_m at t=0
+   ss << "Vinit: " << Vinit_[index] << std::endl; // The initial condition for V_m at t=0
    ss << "Trefract: " << Trefract_[index] << " "; // the number of steps in the refractory period
    ss << "Inoise: " << Inoise_[index] << " "; // the stdev of the noise to be added each delta_t
    ss << "Iinject: " << Iinject_[index] << " "; // A constant current to be injected into the LIF neuron
    ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
-      << endl; // the number of steps left in the refractory period
+      << std::endl; // the number of steps left in the refractory period
    ss << "Vm: " << Vm_[index] << " "; // the membrane voltage
    ss << "hasFired: " << hasFired_[index] << " "; // it done fired?
    ss << "C1: " << C1_[index] << " ";
@@ -306,7 +306,7 @@ string AllIFNeurons::toString(const int index) const {
 ///  Sets the data for Neurons to input's data.
 ///
 ///  @param  input       istream to read from.
-void AllIFNeurons::deserialize(istream &input) {
+void AllIFNeurons::deserialize(std::istream &input) {
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       readNeuron(input, i);
    }
@@ -316,7 +316,7 @@ void AllIFNeurons::deserialize(istream &input) {
 ///
 ///  @param  input       istream to read from.
 ///  @param  i           index of the neuron (in neurons).
-void AllIFNeurons::readNeuron(istream &input, int i) {
+void AllIFNeurons::readNeuron(std::istream &input, int i) {
    // input.ignore() so input skips over end-of-line characters.
    input >> Cm_[i];
    input.ignore();
@@ -357,7 +357,7 @@ void AllIFNeurons::readNeuron(istream &input, int i) {
 ///  Writes out the data in Neurons.
 ///
 ///  @param  output      stream to write out to.
-void AllIFNeurons::serialize(ostream &output) const {
+void AllIFNeurons::serialize(std::ostream &output) const {
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       writeNeuron(output, i);
    }
@@ -367,24 +367,24 @@ void AllIFNeurons::serialize(ostream &output) const {
 ///
 ///  @param  output      stream to write out to.
 ///  @param  i           index of the neuron (in neurons).
-void AllIFNeurons::writeNeuron(ostream &output, int i) const {
-   output << Cm_[i] << ends;
-   output << Rm_[i] << ends;
-   output << Vthresh_[i] << ends;
-   output << Vrest_[i] << ends;
-   output << Vreset_[i] << ends;
-   output << Vinit_[i] << ends;
-   output << Trefract_[i] << ends;
-   output << Inoise_[i] << ends;
-   output << Iinject_[i] << ends;
-   output << Isyn_[i] << ends;
-   output << numStepsInRefractoryPeriod_[i] << ends;
-   output << C1_[i] << ends;
-   output << C2_[i] << ends;
-   output << I0_[i] << ends;
-   output << Vm_[i] << ends;
-   output << hasFired_[i] << ends;
-   output << Tau_[i] << ends;
+void AllIFNeurons::writeNeuron(std::ostream &output, int i) const {
+   output << Cm_[i] << std::ends;
+   output << Rm_[i] << std::ends;
+   output << Vthresh_[i] << std::ends;
+   output << Vrest_[i] << std::ends;
+   output << Vreset_[i] << std::ends;
+   output << Vinit_[i] << std::ends;
+   output << Trefract_[i] << std::ends;
+   output << Inoise_[i] << std::ends;
+   output << Iinject_[i] << std::ends;
+   output << Isyn_[i] << std::ends;
+   output << numStepsInRefractoryPeriod_[i] << std::ends;
+   output << C1_[i] << std::ends;
+   output << C2_[i] << std::ends;
+   output << I0_[i] << std::ends;
+   output << Vm_[i] << std::ends;
+   output << hasFired_[i] << std::ends;
+   output << Tau_[i] << std::ends;
 }
 
 

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -7,246 +7,242 @@
  */
 
 #include "AllIFNeurons.h"
-#include "ParseParamError.h"
 #include "Layout.h"
 #include "MTRand.h"
 #include "Norm.h"
-#include "ParameterManager.h"
 #include "OperationManager.h"
+#include "ParameterManager.h"
+#include "ParseParamError.h"
 
 // Default constructor
 AllIFNeurons::AllIFNeurons() {
-   C1_ = nullptr;
-   C2_ = nullptr;
-   Cm_ = nullptr;
-   I0_ = nullptr;
-   Iinject_ = nullptr;
-   Inoise_ = nullptr;
-   Isyn_ = nullptr;
-   Rm_ = nullptr;
-   Tau_ = nullptr;
-   Trefract_ = nullptr;
-   Vinit_ = nullptr;
-   Vm_ = nullptr;
-   Vreset_ = nullptr;
-   Vrest_ = nullptr;
-   Vthresh_ = nullptr;
-   numStepsInRefractoryPeriod_ = nullptr;
+	C1_ = nullptr;
+	C2_ = nullptr;
+	Cm_ = nullptr;
+	I0_ = nullptr;
+	Iinject_ = nullptr;
+	Inoise_ = nullptr;
+	Isyn_ = nullptr;
+	Rm_ = nullptr;
+	Tau_ = nullptr;
+	Trefract_ = nullptr;
+	Vinit_ = nullptr;
+	Vm_ = nullptr;
+	Vreset_ = nullptr;
+	Vrest_ = nullptr;
+	Vthresh_ = nullptr;
+	numStepsInRefractoryPeriod_ = nullptr;
 }
 
 AllIFNeurons::~AllIFNeurons() {
-   if (size_ != 0) {
-      delete[] C1_;
-      delete[] C2_;
-      delete[] Cm_;
-      delete[] I0_;
-      delete[] Iinject_;
-      delete[] Inoise_;
-      delete[] Isyn_;
-      delete[] Rm_;
-      delete[] Tau_;
-      delete[] Trefract_;
-      delete[] Vinit_;
-      delete[] Vm_;
-      delete[] Vreset_;
-      delete[] Vrest_;
-      delete[] Vthresh_;
-      delete[] numStepsInRefractoryPeriod_;
-   }
+	if (size_ != 0) {
+		delete[] C1_;
+		delete[] C2_;
+		delete[] Cm_;
+		delete[] I0_;
+		delete[] Iinject_;
+		delete[] Inoise_;
+		delete[] Isyn_;
+		delete[] Rm_;
+		delete[] Tau_;
+		delete[] Trefract_;
+		delete[] Vinit_;
+		delete[] Vm_;
+		delete[] Vreset_;
+		delete[] Vrest_;
+		delete[] Vthresh_;
+		delete[] numStepsInRefractoryPeriod_;
+	}
 
-   C1_ = nullptr;
-   C2_ = nullptr;
-   Cm_ = nullptr;
-   I0_ = nullptr;
-   Iinject_ = nullptr;
-   Inoise_ = nullptr;
-   Isyn_ = nullptr;
-   Rm_ = nullptr;
-   Tau_ = nullptr;
-   Trefract_ = nullptr;
-   Vinit_ = nullptr;
-   Vm_ = nullptr;
-   Vreset_ = nullptr;
-   Vrest_ = nullptr;
-   Vthresh_ = nullptr;
-   numStepsInRefractoryPeriod_ = nullptr;
+	C1_ = nullptr;
+	C2_ = nullptr;
+	Cm_ = nullptr;
+	I0_ = nullptr;
+	Iinject_ = nullptr;
+	Inoise_ = nullptr;
+	Isyn_ = nullptr;
+	Rm_ = nullptr;
+	Tau_ = nullptr;
+	Trefract_ = nullptr;
+	Vinit_ = nullptr;
+	Vm_ = nullptr;
+	Vreset_ = nullptr;
+	Vrest_ = nullptr;
+	Vthresh_ = nullptr;
+	numStepsInRefractoryPeriod_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories).
 void AllIFNeurons::setupVertices() {
-   AllSpikingNeurons::setupVertices();
+	AllSpikingNeurons::setupVertices();
 
-   // TODO: Rename variables for easier identification
-   C1_ = new BGFLOAT[size_];
-   C2_ = new BGFLOAT[size_];
-   Cm_ = new BGFLOAT[size_];
-   I0_ = new BGFLOAT[size_];
-   Iinject_ = new BGFLOAT[size_];
-   Inoise_ = new BGFLOAT[size_];
-   Isyn_ = new BGFLOAT[size_];
-   Rm_ = new BGFLOAT[size_];
-   Tau_ = new BGFLOAT[size_];
-   Trefract_ = new BGFLOAT[size_];
-   Vinit_ = new BGFLOAT[size_];
-   Vm_ = new BGFLOAT[size_];
-   Vreset_ = new BGFLOAT[size_];
-   Vrest_ = new BGFLOAT[size_];
-   Vthresh_ = new BGFLOAT[size_];
-   numStepsInRefractoryPeriod_ = new int[size_];
+	// TODO: Rename variables for easier identification
+	C1_ = new BGFLOAT[size_];
+	C2_ = new BGFLOAT[size_];
+	Cm_ = new BGFLOAT[size_];
+	I0_ = new BGFLOAT[size_];
+	Iinject_ = new BGFLOAT[size_];
+	Inoise_ = new BGFLOAT[size_];
+	Isyn_ = new BGFLOAT[size_];
+	Rm_ = new BGFLOAT[size_];
+	Tau_ = new BGFLOAT[size_];
+	Trefract_ = new BGFLOAT[size_];
+	Vinit_ = new BGFLOAT[size_];
+	Vm_ = new BGFLOAT[size_];
+	Vreset_ = new BGFLOAT[size_];
+	Vrest_ = new BGFLOAT[size_];
+	Vthresh_ = new BGFLOAT[size_];
+	numStepsInRefractoryPeriod_ = new int[size_];
 
-   for (int i = 0; i < size_; ++i) {
-      numStepsInRefractoryPeriod_[i] = 0;
-   }
+	for (int i = 0; i < size_; ++i) numStepsInRefractoryPeriod_[i] = 0;
 }
 
 ///  Load member variables from configuration file.
 ///  Registered to OperationManager as Operation::op::loadParameters
 void AllIFNeurons::loadParameters() {
-   ParameterManager::getInstance().getBGFloatByXpath("//Iinject/min/text()", IinjectRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Iinject/max/text()", IinjectRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Iinject/min/text()", IinjectRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Iinject/max/text()", IinjectRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//Inoise/min/text()", InoiseRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Inoise/max/text()", InoiseRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Inoise/min/text()", InoiseRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Inoise/max/text()", InoiseRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//Vthresh/min/text()", VthreshRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Vthresh/max/text()", VthreshRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vthresh/min/text()", VthreshRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vthresh/max/text()", VthreshRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//Vresting/min/text()", VrestingRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Vresting/max/text()", VrestingRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vresting/min/text()", VrestingRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vresting/max/text()", VrestingRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//Vreset/min/text()", VresetRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Vreset/max/text()", VresetRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vreset/min/text()", VresetRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vreset/max/text()", VresetRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//Vinit/min/text()", VinitRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//Vinit/max/text()", VinitRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vinit/min/text()", VinitRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//Vinit/max/text()", VinitRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//starter_vthresh/min/text()", starterVthreshRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//starter_vthresh/max/text()", starterVthreshRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//starter_vthresh/min/text()", starterVthreshRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//starter_vthresh/max/text()", starterVthreshRange_[1]);
 
-   ParameterManager::getInstance().getBGFloatByXpath("//starter_vreset/min/text()", starterVresetRange_[0]);
-   ParameterManager::getInstance().getBGFloatByXpath("//starter_vreset/max/text()", starterVresetRange_[1]);
+	ParameterManager::getInstance().getBGFloatByXpath("//starter_vreset/min/text()", starterVresetRange_[0]);
+	ParameterManager::getInstance().getBGFloatByXpath("//starter_vreset/max/text()", starterVresetRange_[1]);
 }
 
 ///  Prints out all parameters of the neurons to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllIFNeurons::printParameters() const {
-   AllVertices::printParameters();
+	AllVertices::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_,
-                   "\n\tInterval of constant injected current: ["
-                         << IinjectRange_[0] << ", " << IinjectRange_[1] << "]"
-                         << std::endl
-                         << "\tInterval of STD of (gaussian) noise current: ["
-                         << InoiseRange_[0] << ", " << InoiseRange_[1] << "]"
-                         << std::endl
-                         << "\tInterval of firing threshold: ["
-                         << VthreshRange_[0] << ", " << VthreshRange_[1] << "]"
-                         << std::endl
-                         << "\tInterval of asymptotic voltage (Vresting): [" << VrestingRange_[0]
-                         << ", " << VrestingRange_[1] << "]"
-                         << std::endl
-                         << "\tInterval of reset voltage: [" << VresetRange_[0]
-                         << ", " << VresetRange_[1] << "]"
-                         << std::endl
-                         << "\tInterval of initial membrance voltage: [" << VinitRange_[0]
-                         << ", " << VinitRange_[1] << "]"
-                         << std::endl
-                         << "\tStarter firing threshold: [" << starterVthreshRange_[0]
-                         << ", " << starterVthreshRange_[1] << "]"
-                         << std::endl
-                         << "\tStarter reset threshold: [" << starterVresetRange_[0]
-                         << ", " << starterVresetRange_[1] << "]"
-                         << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_,
+	                "\n\tInterval of constant injected current: ["
+	                << IinjectRange_[0] << ", " << IinjectRange_[1] << "]"
+	                << std::endl
+	                << "\tInterval of STD of (gaussian) noise current: ["
+	                << InoiseRange_[0] << ", " << InoiseRange_[1] << "]"
+	                << std::endl
+	                << "\tInterval of firing threshold: ["
+	                << VthreshRange_[0] << ", " << VthreshRange_[1] << "]"
+	                << std::endl
+	                << "\tInterval of asymptotic voltage (Vresting): [" << VrestingRange_[0]
+	                << ", " << VrestingRange_[1] << "]"
+	                << std::endl
+	                << "\tInterval of reset voltage: [" << VresetRange_[0]
+	                << ", " << VresetRange_[1] << "]"
+	                << std::endl
+	                << "\tInterval of initial membrance voltage: [" << VinitRange_[0]
+	                << ", " << VinitRange_[1] << "]"
+	                << std::endl
+	                << "\tStarter firing threshold: [" << starterVthreshRange_[0]
+	                << ", " << starterVthreshRange_[1] << "]"
+	                << std::endl
+	                << "\tStarter reset threshold: [" << starterVresetRange_[0]
+	                << ", " << starterVresetRange_[1] << "]"
+	                << std::endl << std::endl);
 }
 
 ///  Creates all the Neurons and generates data for them.
 ///
 ///  @param  layout      Layout information of the neural network.
-void AllIFNeurons::createAllVertices(Layout *layout) {
-   /* set their specific types */
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      setNeuronDefaults(i);
+void AllIFNeurons::createAllVertices(Layout* layout) {
+	/* set their specific types */
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		setNeuronDefaults(i);
 
-      // set the neuron info for neurons
-      createNeuron(i, layout);
-   }
+		// set the neuron info for neurons
+		createNeuron(i, layout);
+	}
 }
 
 ///  Creates a single Neuron and generates data for it.
 ///
 ///  @param  i Index of the neuron to create.
 ///  @param  layout       Layout information of the neural network.
-void AllIFNeurons::createNeuron(int i, Layout *layout) {
-   // set the neuron info for neurons
-   Iinject_[i] = initRNG.inRange(IinjectRange_[0], IinjectRange_[1]);
-   Inoise_[i] = initRNG.inRange(InoiseRange_[0], InoiseRange_[1]);
-   Vthresh_[i] = initRNG.inRange(VthreshRange_[0], VthreshRange_[1]);
-   Vrest_[i] = initRNG.inRange(VrestingRange_[0], VrestingRange_[1]);
-   Vreset_[i] = initRNG.inRange(VresetRange_[0], VresetRange_[1]);
-   Vinit_[i] = initRNG.inRange(VinitRange_[0], VinitRange_[1]);
-   Vm_[i] = Vinit_[i];
+void AllIFNeurons::createNeuron(int i, Layout* layout) {
+	// set the neuron info for neurons
+	Iinject_[i] = initRNG.inRange(IinjectRange_[0], IinjectRange_[1]);
+	Inoise_[i] = initRNG.inRange(InoiseRange_[0], InoiseRange_[1]);
+	Vthresh_[i] = initRNG.inRange(VthreshRange_[0], VthreshRange_[1]);
+	Vrest_[i] = initRNG.inRange(VrestingRange_[0], VrestingRange_[1]);
+	Vreset_[i] = initRNG.inRange(VresetRange_[0], VresetRange_[1]);
+	Vinit_[i] = initRNG.inRange(VinitRange_[0], VinitRange_[1]);
+	Vm_[i] = Vinit_[i];
 
-   initNeuronConstsFromParamValues(i, Simulator::getInstance().getDeltaT());
+	initNeuronConstsFromParamValues(i, Simulator::getInstance().getDeltaT());
 
-   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
-   spikeHistory_[i] = new uint64_t[maxSpikes];
-   for (int j = 0; j < maxSpikes; ++j) {
-      spikeHistory_[i][j] = ULONG_MAX;
-   }
+	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	spikeHistory_[i] = new uint64_t[maxSpikes];
+	for (int j = 0; j < maxSpikes; ++j) spikeHistory_[i][j] = ULONG_MAX;
 
-   switch (layout->vertexTypeMap_[i]) {
-      case INH:
-         LOG4CPLUS_DEBUG(vertexLogger_, "Setting inhibitory neuron: " << i);
-         // set inhibitory absolute refractory period
-         Trefract_[i] = DEFAULT_InhibTrefract;// TODO(derek): move defaults inside model.
-         break;
+	switch (layout->vertexTypeMap_[i]) {
+		case INH:
+			LOG4CPLUS_DEBUG(vertexLogger_, "Setting inhibitory neuron: " << i);
+		// set inhibitory absolute refractory period
+			Trefract_[i] = DEFAULT_InhibTrefract; // TODO(derek): move defaults inside model.
+			break;
 
-      case EXC:
-         LOG4CPLUS_DEBUG(vertexLogger_, "Setting excitatory neuron: " << i);
-         // set excitatory absolute refractory period
-         Trefract_[i] = DEFAULT_ExcitTrefract;
-         break;
+		case EXC:
+			LOG4CPLUS_DEBUG(vertexLogger_, "Setting excitatory neuron: " << i);
+		// set excitatory absolute refractory period
+			Trefract_[i] = DEFAULT_ExcitTrefract;
+			break;
 
-      default:
-         LOG4CPLUS_DEBUG(vertexLogger_, "ERROR: unknown neuron type: "
-               << layout->vertexTypeMap_[i] << "@" << i);
-         assert(false);
-         break;
-   }
-   // endogenously_active_neuron_map -> Model State
-   if (layout->starterMap_[i]) {
-      // set endogenously active threshold voltage, reset voltage, and refractory period
-      Vthresh_[i] = initRNG.inRange(starterVthreshRange_[0], starterVthreshRange_[1]);
-      Vreset_[i] = initRNG.inRange(starterVresetRange_[0], starterVresetRange_[1]);
-      Trefract_[i] = DEFAULT_ExcitTrefract; // TODO(derek): move defaults inside model.
-   }
+		default:
+			LOG4CPLUS_DEBUG(vertexLogger_, "ERROR: unknown neuron type: "
+			                << layout->vertexTypeMap_[i] << "@" << i);
+			assert(false);
+			break;
+	}
+	// endogenously_active_neuron_map -> Model State
+	if (layout->starterMap_[i]) {
+		// set endogenously active threshold voltage, reset voltage, and refractory period
+		Vthresh_[i] = initRNG.inRange(starterVthreshRange_[0], starterVthreshRange_[1]);
+		Vreset_[i] = initRNG.inRange(starterVresetRange_[0], starterVresetRange_[1]);
+		Trefract_[i] = DEFAULT_ExcitTrefract; // TODO(derek): move defaults inside model.
+	}
 
-   LOG4CPLUS_DEBUG(vertexLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
-                 << "\tVm = " << Vm_[i] << std::endl
-                 << "\tVthresh = " << Vthresh_[i] << std::endl
-                 << "\tI0 = " << I0_[i] << std::endl
-                 << "\tInoise = " << Inoise_[i] << " from : (" << InoiseRange_[0] << "," << InoiseRange_[1]
-                 << ")"
-                 << std::endl
-                 << "\tC1 = " << C1_[i] << std::endl
-                 << "\tC2 = " << C2_[i] << std::endl
-                 << "}" << std::endl);
+	LOG4CPLUS_DEBUG(vertexLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
+	                << "\tVm = " << Vm_[i] << std::endl
+	                << "\tVthresh = " << Vthresh_[i] << std::endl
+	                << "\tI0 = " << I0_[i] << std::endl
+	                << "\tInoise = " << Inoise_[i] << " from : (" << InoiseRange_[0] << "," << InoiseRange_[1]
+	                << ")"
+	                << std::endl
+	                << "\tC1 = " << C1_[i] << std::endl
+	                << "\tC2 = " << C2_[i] << std::endl
+	                << "}" << std::endl);
 }
 
 ///  Set the Neuron at the indexed location to default values.
 ///
 ///  @param  index    Index of the Neuron that the synapse belongs to.
 void AllIFNeurons::setNeuronDefaults(const int index) {
-   Cm_[index] = DEFAULT_Cm;
-   Rm_[index] = DEFAULT_Rm;
-   Vthresh_[index] = DEFAULT_Vthresh;
-   Vrest_[index] = DEFAULT_Vrest;
-   Vreset_[index] = DEFAULT_Vreset;
-   Vinit_[index] = DEFAULT_Vreset;
-   Trefract_[index] = DEFAULT_Trefract;
-   Inoise_[index] = DEFAULT_Inoise;
-   Iinject_[index] = DEFAULT_Iinject;
-   Tau_[index] = DEFAULT_Cm * DEFAULT_Rm;
+	Cm_[index] = DEFAULT_Cm;
+	Rm_[index] = DEFAULT_Rm;
+	Vthresh_[index] = DEFAULT_Vthresh;
+	Vrest_[index] = DEFAULT_Vrest;
+	Vreset_[index] = DEFAULT_Vreset;
+	Vinit_[index] = DEFAULT_Vreset;
+	Trefract_[index] = DEFAULT_Trefract;
+	Inoise_[index] = DEFAULT_Inoise;
+	Iinject_[index] = DEFAULT_Iinject;
+	Tau_[index] = DEFAULT_Cm * DEFAULT_Rm;
 }
 
 ///  Initializes the Neuron constants at the indexed location.
@@ -254,28 +250,27 @@ void AllIFNeurons::setNeuronDefaults(const int index) {
 ///  @param  i    Index of the Neuron.
 ///  @param  deltaT          Inner simulation step duration
 void AllIFNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT) {
-   BGFLOAT &Tau = this->Tau_[i];
-   BGFLOAT &C1 = this->C1_[i];
-   BGFLOAT &C2 = this->C2_[i];
-   BGFLOAT &Rm = this->Rm_[i];
-   BGFLOAT &I0 = this->I0_[i];
-   BGFLOAT &Iinject = this->Iinject_[i];
-   BGFLOAT &Vrest = this->Vrest_[i];
+	BGFLOAT& Tau = this->Tau_[i];
+	BGFLOAT& C1 = this->C1_[i];
+	BGFLOAT& C2 = this->C2_[i];
+	BGFLOAT& Rm = this->Rm_[i];
+	BGFLOAT& I0 = this->I0_[i];
+	BGFLOAT& Iinject = this->Iinject_[i];
+	BGFLOAT& Vrest = this->Vrest_[i];
 
-   /* init consts C1,C2 for exponential Euler integration */
-   if (Tau > 0) {
-      C1 = exp(-deltaT / Tau);
-      C2 = Rm * (1 - C1);
-   } else {
-      C1 = 0.0;
-      C2 = Rm;
-   }
-   /* calculate const IO */
-   if (Rm > 0) {
-      I0 = Iinject + Vrest / Rm;
-   } else {
-      assert(false);
-   }
+	/* init consts C1,C2 for exponential Euler integration */
+	if (Tau > 0) {
+		C1 = exp(-deltaT / Tau);
+		C2 = Rm * (1 - C1);
+	}
+	else {
+		C1 = 0.0;
+		C2 = Rm;
+	}
+	/* calculate const IO */
+	if (Rm > 0) I0 = Iinject + Vrest / Rm;
+	else
+		assert(false);
 }
 
 ///  Outputs state of the neuron chosen as a string.
@@ -283,108 +278,102 @@ void AllIFNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT) 
 ///  @param  index  index of the neuron (in neurons) to output info from.
 ///  @return the complete state of the neuron.
 std::string AllIFNeurons::toString(const int index) const {
-   std::stringstream ss;
-   ss << "Cm: " << Cm_[index] << " "; // membrane capacitance
-   ss << "Rm: " << Rm_[index] << " "; // membrane resistance
-   ss << "Vthresh: " << Vthresh_[index] << " "; // if Vm exceeds, Vthresh, a spike is emitted
-   ss << "Vrest: " << Vrest_[index] << " "; // the resting membrane voltage
-   ss << "Vreset: " << Vreset_[index] << " "; // The voltage to reset Vm to after a spike
-   ss << "Vinit: " << Vinit_[index] << std::endl; // The initial condition for V_m at t=0
-   ss << "Trefract: " << Trefract_[index] << " "; // the number of steps in the refractory period
-   ss << "Inoise: " << Inoise_[index] << " "; // the stdev of the noise to be added each delta_t
-   ss << "Iinject: " << Iinject_[index] << " "; // A constant current to be injected into the LIF neuron
-   ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
-      << std::endl; // the number of steps left in the refractory period
-   ss << "Vm: " << Vm_[index] << " "; // the membrane voltage
-   ss << "hasFired: " << hasFired_[index] << " "; // it done fired?
-   ss << "C1: " << C1_[index] << " ";
-   ss << "C2: " << C2_[index] << " ";
-   ss << "I0: " << I0_[index] << " ";
-   return ss.str();
+	std::stringstream ss;
+	ss << "Cm: " << Cm_[index] << " "; // membrane capacitance
+	ss << "Rm: " << Rm_[index] << " "; // membrane resistance
+	ss << "Vthresh: " << Vthresh_[index] << " "; // if Vm exceeds, Vthresh, a spike is emitted
+	ss << "Vrest: " << Vrest_[index] << " "; // the resting membrane voltage
+	ss << "Vreset: " << Vreset_[index] << " "; // The voltage to reset Vm to after a spike
+	ss << "Vinit: " << Vinit_[index] << std::endl; // The initial condition for V_m at t=0
+	ss << "Trefract: " << Trefract_[index] << " "; // the number of steps in the refractory period
+	ss << "Inoise: " << Inoise_[index] << " "; // the stdev of the noise to be added each delta_t
+	ss << "Iinject: " << Iinject_[index] << " "; // A constant current to be injected into the LIF neuron
+	ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
+		<< std::endl; // the number of steps left in the refractory period
+	ss << "Vm: " << Vm_[index] << " "; // the membrane voltage
+	ss << "hasFired: " << hasFired_[index] << " "; // it done fired?
+	ss << "C1: " << C1_[index] << " ";
+	ss << "C2: " << C2_[index] << " ";
+	ss << "I0: " << I0_[index] << " ";
+	return ss.str();
 }
 
 ///  Sets the data for Neurons to input's data.
 ///
 ///  @param  input       istream to read from.
-void AllIFNeurons::deserialize(std::istream &input) {
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      readNeuron(input, i);
-   }
+void AllIFNeurons::deserialize(std::istream& input) {
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) readNeuron(input, i);
 }
 
 ///  Sets the data for Neuron #index to input's data.
 ///
 ///  @param  input       istream to read from.
 ///  @param  i           index of the neuron (in neurons).
-void AllIFNeurons::readNeuron(std::istream &input, int i) {
-   // input.ignore() so input skips over end-of-line characters.
-   input >> Cm_[i];
-   input.ignore();
-   input >> Rm_[i];
-   input.ignore();
-   input >> Vthresh_[i];
-   input.ignore();
-   input >> Vrest_[i];
-   input.ignore();
-   input >> Vreset_[i];
-   input.ignore();
-   input >> Vinit_[i];
-   input.ignore();
-   input >> Trefract_[i];
-   input.ignore();
-   input >> Inoise_[i];
-   input.ignore();
-   input >> Iinject_[i];
-   input.ignore();
-   input >> Isyn_[i];
-   input.ignore();
-   input >> numStepsInRefractoryPeriod_[i];
-   input.ignore();
-   input >> C1_[i];
-   input.ignore();
-   input >> C2_[i];
-   input.ignore();
-   input >> I0_[i];
-   input.ignore();
-   input >> Vm_[i];
-   input.ignore();
-   input >> hasFired_[i];
-   input.ignore();
-   input >> Tau_[i];
-   input.ignore();
+void AllIFNeurons::readNeuron(std::istream& input, int i) {
+	// input.ignore() so input skips over end-of-line characters.
+	input >> Cm_[i];
+	input.ignore();
+	input >> Rm_[i];
+	input.ignore();
+	input >> Vthresh_[i];
+	input.ignore();
+	input >> Vrest_[i];
+	input.ignore();
+	input >> Vreset_[i];
+	input.ignore();
+	input >> Vinit_[i];
+	input.ignore();
+	input >> Trefract_[i];
+	input.ignore();
+	input >> Inoise_[i];
+	input.ignore();
+	input >> Iinject_[i];
+	input.ignore();
+	input >> Isyn_[i];
+	input.ignore();
+	input >> numStepsInRefractoryPeriod_[i];
+	input.ignore();
+	input >> C1_[i];
+	input.ignore();
+	input >> C2_[i];
+	input.ignore();
+	input >> I0_[i];
+	input.ignore();
+	input >> Vm_[i];
+	input.ignore();
+	input >> hasFired_[i];
+	input.ignore();
+	input >> Tau_[i];
+	input.ignore();
 }
 
 ///  Writes out the data in Neurons.
 ///
 ///  @param  output      stream to write out to.
-void AllIFNeurons::serialize(std::ostream &output) const {
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      writeNeuron(output, i);
-   }
+void AllIFNeurons::serialize(std::ostream& output) const {
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) writeNeuron(output, i);
 }
 
 ///  Writes out the data in the selected Neuron.
 ///
 ///  @param  output      stream to write out to.
 ///  @param  i           index of the neuron (in neurons).
-void AllIFNeurons::writeNeuron(std::ostream &output, int i) const {
-   output << Cm_[i] << std::ends;
-   output << Rm_[i] << std::ends;
-   output << Vthresh_[i] << std::ends;
-   output << Vrest_[i] << std::ends;
-   output << Vreset_[i] << std::ends;
-   output << Vinit_[i] << std::ends;
-   output << Trefract_[i] << std::ends;
-   output << Inoise_[i] << std::ends;
-   output << Iinject_[i] << std::ends;
-   output << Isyn_[i] << std::ends;
-   output << numStepsInRefractoryPeriod_[i] << std::ends;
-   output << C1_[i] << std::ends;
-   output << C2_[i] << std::ends;
-   output << I0_[i] << std::ends;
-   output << Vm_[i] << std::ends;
-   output << hasFired_[i] << std::ends;
-   output << Tau_[i] << std::ends;
+void AllIFNeurons::writeNeuron(std::ostream& output, int i) const {
+	output << Cm_[i] << std::ends;
+	output << Rm_[i] << std::ends;
+	output << Vthresh_[i] << std::ends;
+	output << Vrest_[i] << std::ends;
+	output << Vreset_[i] << std::ends;
+	output << Vinit_[i] << std::ends;
+	output << Trefract_[i] << std::ends;
+	output << Inoise_[i] << std::ends;
+	output << Iinject_[i] << std::ends;
+	output << Isyn_[i] << std::ends;
+	output << numStepsInRefractoryPeriod_[i] << std::ends;
+	output << C1_[i] << std::ends;
+	output << C2_[i] << std::ends;
+	output << I0_[i] << std::ends;
+	output << Vm_[i] << std::ends;
+	output << hasFired_[i] << std::ends;
+	output << Tau_[i] << std::ends;
 }
-
-

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -186,18 +186,19 @@ void AllIFNeurons::createNeuron(int i, Layout* layout) {
 
 	initNeuronConstsFromParamValues(i, Simulator::getInstance().getDeltaT());
 
-	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = static_cast<int>((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().
+		getMaxFiringRate()));
 	spikeHistory_[i] = new uint64_t[maxSpikes];
 	for (int j = 0; j < maxSpikes; ++j) spikeHistory_[i][j] = ULONG_MAX;
 
 	switch (layout->vertexTypeMap_[i]) {
-		case INH:
+		case vertexType::INH:
 			LOG4CPLUS_DEBUG(vertexLogger_, "Setting inhibitory neuron: " << i);
 		// set inhibitory absolute refractory period
 			Trefract_[i] = DEFAULT_InhibTrefract; // TODO(derek): move defaults inside model.
 			break;
 
-		case EXC:
+		case vertexType::EXC:
 			LOG4CPLUS_DEBUG(vertexLogger_, "Setting excitatory neuron: " << i);
 		// set excitatory absolute refractory period
 			Trefract_[i] = DEFAULT_ExcitTrefract;
@@ -205,7 +206,7 @@ void AllIFNeurons::createNeuron(int i, Layout* layout) {
 
 		default:
 			LOG4CPLUS_DEBUG(vertexLogger_, "ERROR: unknown neuron type: "
-			                << layout->vertexTypeMap_[i] << "@" << i);
+			                << static_cast<int>(layout->vertexTypeMap_[i]) << "@" << i);
 			assert(false);
 			break;
 	}

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -23,49 +23,49 @@
  */
 #pragma once
 
-#include "Global.h"
 #include "AllSpikingNeurons.h"
+#include "Global.h"
 
 struct AllIFNeuronsDeviceProperties;
 
 class AllIFNeurons : public AllSpikingNeurons {
-public:
-   AllIFNeurons();
+	public:
+		AllIFNeurons();
 
-   virtual ~AllIFNeurons();
+		~AllIFNeurons() override;
 
-   ///  Setup the internal structure of the class.
-   ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices() override;
+		///  Setup the internal structure of the class.
+		///  Allocate memories to store all neurons' state.
+		void setupVertices() override;
 
-   ///  Load member variables from configuration file.
-   ///  Registered to OperationManager as Operation::loadParameters
-   virtual void loadParameters();
+		///  Load member variables from configuration file.
+		///  Registered to OperationManager as Operation::loadParameters
+		void loadParameters() override;
 
-   ///  Prints out all parameters of the neurons to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const;
+		///  Prints out all parameters of the neurons to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Creates all the Neurons and assigns initial data for them.
-   ///
-   ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout);
+		///  Creates all the Neurons and assigns initial data for them.
+		///
+		///  @param  layout      Layout information of the neural network.
+		void createAllVertices(Layout* layout) override;
 
-   ///  Outputs state of the neuron chosen as a string.
-   ///
-   ///  @param  index   index of the neuron (in neurons) to output info from.
-   ///  @return the complete state of the neuron.
-   virtual std::string toString(const int index) const;
+		///  Outputs state of the neuron chosen as a string.
+		///
+		///  @param  index   index of the neuron (in neurons) to output info from.
+		///  @return the complete state of the neuron.
+		std::string toString(const int index) const override;
 
-   /// Reads and sets the data for all neurons from input stream.
-   ///
-   /// @param  input       istream to read from.
-   virtual void deserialize(std::istream &input);
+		/// Reads and sets the data for all neurons from input stream.
+		///
+		/// @param  input       istream to read from.
+		virtual void deserialize(std::istream& input);
 
-   ///  Writes out the data in all neurons to output stream.
-   ///
-   ///  @param  output      stream to write out to.ss.
-   virtual void serialize(std::ostream &output) const;
+		///  Writes out the data in all neurons to output stream.
+		///
+		///  @param  output      stream to write out to.ss.
+		virtual void serialize(std::ostream& output) const;
 
 #ifdef __CUDACC__
    public:
@@ -140,115 +140,115 @@ public:
        ///  @param  allVerticesDevice         Reference to the AllIFNeuronsDeviceProperties struct.
   void copyDeviceToHost( AllIFNeuronsDeviceProperties& allVerticesDevice );
 
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)
 
-protected:
-   ///  Creates a single Neuron and generates data for it.
-   ///
-   ///  @param  neuronIndex Index of the neuron to create.
-   ///  @param  layout       Layout information of the neural network.
-   void createNeuron(int neuronIndex, Layout *layout);
+	protected:
+		///  Creates a single Neuron and generates data for it.
+		///
+		///  @param  neuronIndex Index of the neuron to create.
+		///  @param  layout       Layout information of the neural network.
+		void createNeuron(int neuronIndex, Layout* layout);
 
-   ///  Set the Neuron at the indexed location to default values.
-   ///
-   ///  @param  index    Index of the Neuron that the synapse belongs to.
-   void setNeuronDefaults(const int index);
+		///  Set the Neuron at the indexed location to default values.
+		///
+		///  @param  index    Index of the Neuron that the synapse belongs to.
+		void setNeuronDefaults(const int index);
 
-   ///  Initializes the Neuron constants at the indexed location.
-   ///
-   ///  @param  neuronIndex    Index of the Neuron.
-   ///  @param  deltaT          Inner simulation step duration
-   virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT);
+		///  Initializes the Neuron constants at the indexed location.
+		///
+		///  @param  neuronIndex    Index of the Neuron.
+		///  @param  deltaT          Inner simulation step duration
+		virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT);
 
-   ///  Sets the data for Neuron #index to input's data.
-   ///
-   ///  @param  input       istream to read from.
-   ///  @param  i           index of the neuron (in neurons).
-   void readNeuron(std::istream &input, int i);
+		///  Sets the data for Neuron #index to input's data.
+		///
+		///  @param  input       istream to read from.
+		///  @param  i           index of the neuron (in neurons).
+		void readNeuron(std::istream& input, int i);
 
-   ///  Writes out the data in the selected Neuron.
-   ///
-   ///  @param  output      stream to write out to.
-   ///  @param  i           index of the neuron (in neurons).
-   void writeNeuron(std::ostream &output, int i) const;
+		///  Writes out the data in the selected Neuron.
+		///
+		///  @param  output      stream to write out to.
+		///  @param  i           index of the neuron (in neurons).
+		void writeNeuron(std::ostream& output, int i) const;
 
-public:
-   ///  The length of the absolute refractory period. [units=sec; range=(0,1);]
-   BGFLOAT *Trefract_;
+	public:
+		///  The length of the absolute refractory period. [units=sec; range=(0,1);]
+		BGFLOAT* Trefract_;
 
-   ///  If \f$V_m\f$ exceeds \f$V_{thresh}\f$ a spike is emmited. [units=V; range=(-10,100);]
-   BGFLOAT *Vthresh_;
+		///  If \f$V_m\f$ exceeds \f$V_{thresh}\f$ a spike is emmited. [units=V; range=(-10,100);]
+		BGFLOAT* Vthresh_;
 
-   ///  The resting membrane voltage. [units=V; range=(-1,1);]
-   BGFLOAT *Vrest_;
+		///  The resting membrane voltage. [units=V; range=(-1,1);]
+		BGFLOAT* Vrest_;
 
-   ///  The voltage to reset \f$V_m\f$ to after a spike. [units=V; range=(-1,1);]
-   BGFLOAT *Vreset_;
+		///  The voltage to reset \f$V_m\f$ to after a spike. [units=V; range=(-1,1);]
+		BGFLOAT* Vreset_;
 
-   ///  The initial condition for \f$V_m\f$ at time \f$t=0\f$. [units=V; range=(-1,1);]
-   BGFLOAT *Vinit_;
+		///  The initial condition for \f$V_m\f$ at time \f$t=0\f$. [units=V; range=(-1,1);]
+		BGFLOAT* Vinit_;
 
-   ///  The membrane capacitance \f$C_m\f$ [range=(0,1); units=F;]
-   ///  Used to initialize Tau (no use after that)
-   BGFLOAT *Cm_;
+		///  The membrane capacitance \f$C_m\f$ [range=(0,1); units=F;]
+		///  Used to initialize Tau (no use after that)
+		BGFLOAT* Cm_;
 
-   ///  The membrane resistance \f$R_m\f$ [units=Ohm; range=(0,1e30)]
-   BGFLOAT *Rm_;
+		///  The membrane resistance \f$R_m\f$ [units=Ohm; range=(0,1e30)]
+		BGFLOAT* Rm_;
 
-   /// The standard deviation of the noise to be added each integration time constant. [range=(0,1); units=A;]
-   BGFLOAT *Inoise_;
+		/// The standard deviation of the noise to be added each integration time constant. [range=(0,1); units=A;]
+		BGFLOAT* Inoise_;
 
-   ///  A constant current to be injected into the LIF neuron. [units=A; range=(-1,1);]
-   BGFLOAT *Iinject_;
+		///  A constant current to be injected into the LIF neuron. [units=A; range=(-1,1);]
+		BGFLOAT* Iinject_;
 
-   /// What the hell is this used for???
-   ///  It does not seem to be used; seems to be a candidate for deletion.
-   ///  Possibly from the old code before using a separate summation point
-   ///  The synaptic input current.
-   BGFLOAT *Isyn_;
+		/// What the hell is this used for???
+		///  It does not seem to be used; seems to be a candidate for deletion.
+		///  Possibly from the old code before using a separate summation point
+		///  The synaptic input current.
+		BGFLOAT* Isyn_;
 
-   /// The remaining number of time steps for the absolute refractory period.
-   int *numStepsInRefractoryPeriod_;
+		/// The remaining number of time steps for the absolute refractory period.
+		int* numStepsInRefractoryPeriod_;
 
-   /// Internal constant for the exponential Euler integration of f$V_m\f$.
-   BGFLOAT *C1_;
+		/// Internal constant for the exponential Euler integration of f$V_m\f$.
+		BGFLOAT* C1_;
 
-   /// Internal constant for the exponential Euler integration of \f$V_m\f$.
-   BGFLOAT *C2_;
+		/// Internal constant for the exponential Euler integration of \f$V_m\f$.
+		BGFLOAT* C2_;
 
-   /// Internal constant for the exponential Euler integration of \f$V_m\f$.
-   BGFLOAT *I0_;
+		/// Internal constant for the exponential Euler integration of \f$V_m\f$.
+		BGFLOAT* I0_;
 
-   /// The membrane voltage \f$V_m\f$ [readonly; units=V;]
-   BGFLOAT *Vm_;
+		/// The membrane voltage \f$V_m\f$ [readonly; units=V;]
+		BGFLOAT* Vm_;
 
-   /// The membrane time constant \f$(R_m \cdot C_m)\f$
-   BGFLOAT *Tau_;
+		/// The membrane time constant \f$(R_m \cdot C_m)\f$
+		BGFLOAT* Tau_;
 
-private:
-   /// Min/max values of Iinject.
-   BGFLOAT IinjectRange_[2];
+	private:
+		/// Min/max values of Iinject.
+		BGFLOAT IinjectRange_[2];
 
-   /// Min/max values of Inoise.
-   BGFLOAT InoiseRange_[2];
+		/// Min/max values of Inoise.
+		BGFLOAT InoiseRange_[2];
 
-   /// Min/max values of Vthresh.
-   BGFLOAT VthreshRange_[2];
+		/// Min/max values of Vthresh.
+		BGFLOAT VthreshRange_[2];
 
-   /// Min/max values of Vresting.
-   BGFLOAT VrestingRange_[2];
+		/// Min/max values of Vresting.
+		BGFLOAT VrestingRange_[2];
 
-   /// Min/max values of Vreset.
-   BGFLOAT VresetRange_[2];
+		/// Min/max values of Vreset.
+		BGFLOAT VresetRange_[2];
 
-   /// Min/max values of Vinit.
-   BGFLOAT VinitRange_[2];
+		/// Min/max values of Vinit.
+		BGFLOAT VinitRange_[2];
 
-   /// Min/max values of Vthresh.
-   BGFLOAT starterVthreshRange_[2];
+		/// Min/max values of Vthresh.
+		BGFLOAT starterVthreshRange_[2];
 
-   /// Min/max values of Vreset.
-   BGFLOAT starterVresetRange_[2];
+		/// Min/max values of Vreset.
+		BGFLOAT starterVresetRange_[2];
 };
 
 #ifdef __CUDACC__
@@ -306,4 +306,4 @@ struct AllIFNeuronsDeviceProperties : public AllSpikingNeuronsDeviceProperties
         /// The membrane time constant \f$(R_m \cdot C_m)\f$
         BGFLOAT *Tau_;
 };
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -55,7 +55,7 @@ class AllIFNeurons : public AllSpikingNeurons {
 		///
 		///  @param  index   index of the neuron (in neurons) to output info from.
 		///  @return the complete state of the neuron.
-		std::string toString(const int index) const override;
+		std::string toString(int index) const override;
 
 		/// Reads and sets the data for all neurons from input stream.
 		///
@@ -152,13 +152,13 @@ class AllIFNeurons : public AllSpikingNeurons {
 		///  Set the Neuron at the indexed location to default values.
 		///
 		///  @param  index    Index of the Neuron that the synapse belongs to.
-		void setNeuronDefaults(const int index);
+		void setNeuronDefaults(int index);
 
 		///  Initializes the Neuron constants at the indexed location.
 		///
 		///  @param  neuronIndex    Index of the Neuron.
 		///  @param  deltaT          Inner simulation step duration
-		virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT);
+		virtual void initNeuronConstsFromParamValues(int neuronIndex, BGFLOAT deltaT);
 
 		///  Sets the data for Neuron #index to input's data.
 		///

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -55,19 +55,19 @@ public:
    ///
    ///  @param  index   index of the neuron (in neurons) to output info from.
    ///  @return the complete state of the neuron.
-   virtual string toString(const int index) const;
+   virtual std::string toString(const int index) const;
 
    /// Reads and sets the data for all neurons from input stream.
    ///
    /// @param  input       istream to read from.
-   virtual void deserialize(istream &input);
+   virtual void deserialize(std::istream &input);
 
    ///  Writes out the data in all neurons to output stream.
    ///
    ///  @param  output      stream to write out to.ss.
-   virtual void serialize(ostream &output) const;
+   virtual void serialize(std::ostream &output) const;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Update the state of all neurons for a time step
        ///  Notify outgoing synapses if neuron has fired.
@@ -164,13 +164,13 @@ protected:
    ///
    ///  @param  input       istream to read from.
    ///  @param  i           index of the neuron (in neurons).
-   void readNeuron(istream &input, int i);
+   void readNeuron(std::istream &input, int i);
 
    ///  Writes out the data in the selected Neuron.
    ///
    ///  @param  output      stream to write out to.
    ///  @param  i           index of the neuron (in neurons).
-   void writeNeuron(ostream &output, int i) const;
+   void writeNeuron(std::ostream &output, int i) const;
 
 public:
    ///  The length of the absolute refractory period. [units=sec; range=(0,1);]
@@ -251,7 +251,7 @@ private:
    BGFLOAT starterVresetRange_[2];
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllIFNeuronsDeviceProperties : public AllSpikingNeuronsDeviceProperties
 {
         ///  The length of the absolute refractory period. [units=sec; range=(0,1);]

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -10,13 +10,7 @@
 #include "ParseParamError.h"
 
 // Default constructor
-AllIZHNeurons::AllIZHNeurons() : AllIFNeurons() {
-	Aconst_ = nullptr;
-	Bconst_ = nullptr;
-	Cconst_ = nullptr;
-	Dconst_ = nullptr;
-	u_ = nullptr;
-	C3_ = nullptr;
+AllIZHNeurons::AllIZHNeurons() : AllIFNeurons(), C3_(nullptr), u_(nullptr), Dconst_(nullptr), Cconst_(nullptr), Bconst_(nullptr), Aconst_(nullptr) {
 }
 
 AllIZHNeurons::~AllIZHNeurons() {

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -11,122 +11,123 @@
 
 // Default constructor
 AllIZHNeurons::AllIZHNeurons() : AllIFNeurons() {
-   Aconst_ = nullptr;
-   Bconst_ = nullptr;
-   Cconst_ = nullptr;
-   Dconst_ = nullptr;
-   u_ = nullptr;
-   C3_ = nullptr;
+	Aconst_ = nullptr;
+	Bconst_ = nullptr;
+	Cconst_ = nullptr;
+	Dconst_ = nullptr;
+	u_ = nullptr;
+	C3_ = nullptr;
 }
 
 AllIZHNeurons::~AllIZHNeurons() {
-   if (size_ != 0) {
-      delete[] Aconst_;
-      delete[] Bconst_;
-      delete[] Cconst_;
-      delete[] Dconst_;
-      delete[] u_;
-      delete[] C3_;
-   }
+	if (size_ != 0) {
+		delete[] Aconst_;
+		delete[] Bconst_;
+		delete[] Cconst_;
+		delete[] Dconst_;
+		delete[] u_;
+		delete[] C3_;
+	}
 
-   Aconst_ = nullptr;
-   Bconst_ = nullptr;
-   Cconst_ = nullptr;
-   Dconst_ = nullptr;
-   u_ = nullptr;
-   C3_ = nullptr;
+	Aconst_ = nullptr;
+	Bconst_ = nullptr;
+	Cconst_ = nullptr;
+	Dconst_ = nullptr;
+	u_ = nullptr;
+	C3_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories).
 void AllIZHNeurons::setupVertices() {
-   AllIFNeurons::setupVertices();
+	AllIFNeurons::setupVertices();
 
-   Aconst_ = new BGFLOAT[size_];
-   Bconst_ = new BGFLOAT[size_];
-   Cconst_ = new BGFLOAT[size_];
-   Dconst_ = new BGFLOAT[size_];
-   u_ = new BGFLOAT[size_];
-   C3_ = new BGFLOAT[size_];
+	Aconst_ = new BGFLOAT[size_];
+	Bconst_ = new BGFLOAT[size_];
+	Cconst_ = new BGFLOAT[size_];
+	Dconst_ = new BGFLOAT[size_];
+	u_ = new BGFLOAT[size_];
+	C3_ = new BGFLOAT[size_];
 }
 
 ///  Prints out all parameters of the neurons to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllIZHNeurons::printParameters() const {
-   AllIFNeurons::printParameters();
+	AllIFNeurons::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices type: AllIZHNeurons" << std::endl
-             << "\tInterval of A constant for excitatory neurons: ["
-             << excAconst_[0] << ", " << excAconst_[1] << "]"
-             << std::endl
-             << "\tInterval of A constant for inhibitory neurons: ["
-             << inhAconst_[0] << ", " << inhAconst_[1] << "]"
-             << std::endl
-             << "\tInterval of B constant for excitatory neurons: ["
-             << excBconst_[0] << ", " << excBconst_[1] << "]"
-             << std::endl
-             << "\tInterval of B constant for inhibitory neurons: ["
-             << inhBconst_[0] << ", " << inhBconst_[1] << "]"
-             << std::endl
-             << "\tInterval of C constant for excitatory neurons: ["
-             << excCconst_[0] << ", " << excCconst_[1] << "]"
-             << std::endl
-             << "\tInterval of C constant for inhibitory neurons: ["
-             << inhCconst_[0] << ", " << inhCconst_[1] << "]"
-             << std::endl
-             << "\tInterval of D constant for excitatory neurons: ["
-             << excDconst_[0] << ", " << excDconst_[1] << "]"
-             << std::endl
-             << "\tInterval of D constant for inhibitory neurons: ["
-             << inhDconst_[0] << ", " << inhDconst_[1] << "]"
-             << std::endl << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices type: AllIZHNeurons" << std::endl
+	                << "\tInterval of A constant for excitatory neurons: ["
+	                << excAconst_[0] << ", " << excAconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of A constant for inhibitory neurons: ["
+	                << inhAconst_[0] << ", " << inhAconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of B constant for excitatory neurons: ["
+	                << excBconst_[0] << ", " << excBconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of B constant for inhibitory neurons: ["
+	                << inhBconst_[0] << ", " << inhBconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of C constant for excitatory neurons: ["
+	                << excCconst_[0] << ", " << excCconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of C constant for inhibitory neurons: ["
+	                << inhCconst_[0] << ", " << inhCconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of D constant for excitatory neurons: ["
+	                << excDconst_[0] << ", " << excDconst_[1] << "]"
+	                << std::endl
+	                << "\tInterval of D constant for inhibitory neurons: ["
+	                << inhDconst_[0] << ", " << inhDconst_[1] << "]"
+	                << std::endl << std::endl);
 
 }
 
 ///  Creates all the Neurons and generates data for them.
 ///
 ///  @param  layout      Layout information of the neural network.
-void AllIZHNeurons::createAllVertices(Layout *layout) {
-   /* set their specific types */
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      setNeuronDefaults(i);
+void AllIZHNeurons::createAllVertices(Layout* layout) {
+	/* set their specific types */
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		setNeuronDefaults(i);
 
-      // set the neuron info for neurons
-      createNeuron(i, layout);
-   }
+		// set the neuron info for neurons
+		createNeuron(i, layout);
+	}
 }
 
 ///  Creates a single Neuron and generates data for it.
 ///
 ///  @param  i Index of the neuron to create.
 ///  @param  layout       Layout information of the neural network.
-void AllIZHNeurons::createNeuron(int i, Layout *layout) {
-   // set the neuron info for neurons
-   AllIFNeurons::createNeuron(i, layout);
+void AllIZHNeurons::createNeuron(int i, Layout* layout) {
+	// set the neuron info for neurons
+	AllIFNeurons::createNeuron(i, layout);
 
-   // TODO: we may need another distribution mode besides flat distribution
-   if (layout->vertexTypeMap_[i] == EXC) {
-      // excitatory neuron
-      Aconst_[i] = initRNG.inRange(excAconst_[0], excAconst_[1]);
-      Bconst_[i] = initRNG.inRange(excBconst_[0], excBconst_[1]);
-      Cconst_[i] = initRNG.inRange(excCconst_[0], excCconst_[1]);
-      Dconst_[i] = initRNG.inRange(excDconst_[0], excDconst_[1]);
-   } else {
-      // inhibitory neuron
-      Aconst_[i] = initRNG.inRange(inhAconst_[0], inhAconst_[1]);
-      Bconst_[i] = initRNG.inRange(inhBconst_[0], inhBconst_[1]);
-      Cconst_[i] = initRNG.inRange(inhCconst_[0], inhCconst_[1]);
-      Dconst_[i] = initRNG.inRange(inhDconst_[0], inhDconst_[1]);
-   }
+	// TODO: we may need another distribution mode besides flat distribution
+	if (layout->vertexTypeMap_[i] == EXC) {
+		// excitatory neuron
+		Aconst_[i] = initRNG.inRange(excAconst_[0], excAconst_[1]);
+		Bconst_[i] = initRNG.inRange(excBconst_[0], excBconst_[1]);
+		Cconst_[i] = initRNG.inRange(excCconst_[0], excCconst_[1]);
+		Dconst_[i] = initRNG.inRange(excDconst_[0], excDconst_[1]);
+	}
+	else {
+		// inhibitory neuron
+		Aconst_[i] = initRNG.inRange(inhAconst_[0], inhAconst_[1]);
+		Bconst_[i] = initRNG.inRange(inhBconst_[0], inhBconst_[1]);
+		Cconst_[i] = initRNG.inRange(inhCconst_[0], inhCconst_[1]);
+		Dconst_[i] = initRNG.inRange(inhDconst_[0], inhDconst_[1]);
+	}
 
-   u_[i] = 0;
+	u_[i] = 0;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
-                 << "\tAconst = " << Aconst_[i] << std::endl
-                 << "\tBconst = " << Bconst_[i] << std::endl
-                 << "\tCconst = " << Cconst_[i] << std::endl
-                 << "\tDconst = " << Dconst_[i] << std::endl
-                 << "\tC3 = " << C3_[i] << std::endl
-                 << "}" << std::endl);
+	LOG4CPLUS_DEBUG(fileLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
+	                << "\tAconst = " << Aconst_[i] << std::endl
+	                << "\tBconst = " << Bconst_[i] << std::endl
+	                << "\tCconst = " << Cconst_[i] << std::endl
+	                << "\tDconst = " << Dconst_[i] << std::endl
+	                << "\tC3 = " << C3_[i] << std::endl
+	                << "}" << std::endl);
 
 }
 
@@ -134,15 +135,15 @@ void AllIZHNeurons::createNeuron(int i, Layout *layout) {
 ///
 ///  @param  i    Index of the Neuron to refer.
 void AllIZHNeurons::setNeuronDefaults(const int index) {
-   AllIFNeurons::setNeuronDefaults(index);
+	AllIFNeurons::setNeuronDefaults(index);
 
-   // no refractory period
-   Trefract_[index] = 0;
+	// no refractory period
+	Trefract_[index] = 0;
 
-   Aconst_[index] = DEFAULT_a;
-   Bconst_[index] = DEFAULT_b;
-   Cconst_[index] = DEFAULT_c;
-   Dconst_[index] = DEFAULT_d;
+	Aconst_[index] = DEFAULT_a;
+	Bconst_[index] = DEFAULT_b;
+	Cconst_[index] = DEFAULT_c;
+	Dconst_[index] = DEFAULT_d;
 }
 
 ///  Initializes the Neuron constants at the indexed location.
@@ -150,10 +151,10 @@ void AllIZHNeurons::setNeuronDefaults(const int index) {
 ///  @param  i    Index of the Neuron.
 ///  @param  deltaT          Inner simulation step duration
 void AllIZHNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT) {
-   AllIFNeurons::initNeuronConstsFromParamValues(i, deltaT);
+	AllIFNeurons::initNeuronConstsFromParamValues(i, deltaT);
 
-   BGFLOAT &C3 = this->C3_[i];
-   C3 = deltaT * 1000;
+	BGFLOAT& C3 = this->C3_[i];
+	C3 = deltaT * 1000;
 }
 
 ///  Outputs state of the neuron chosen as a string.
@@ -161,71 +162,67 @@ void AllIZHNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT)
 ///  @param  index index of the neuron (in neurons) to output info from.
 ///  @return the complete state of the neuron.
 std::string AllIZHNeurons::toString(const int index) const {
-   std::stringstream ss;
+	std::stringstream ss;
 
-   ss << AllIFNeurons::toString(index);
+	ss << AllIFNeurons::toString(index);
 
-   ss << "Aconst: " << Aconst_[index] << " ";
-   ss << "Bconst: " << Bconst_[index] << " ";
-   ss << "Cconst: " << Cconst_[index] << " ";
-   ss << "Dconst: " << Dconst_[index] << " ";
-   ss << "u: " << u_[index] << " ";
-   ss << "C3: " << C3_[index] << " ";
-   return ss.str();
+	ss << "Aconst: " << Aconst_[index] << " ";
+	ss << "Bconst: " << Bconst_[index] << " ";
+	ss << "Cconst: " << Cconst_[index] << " ";
+	ss << "Dconst: " << Dconst_[index] << " ";
+	ss << "u: " << u_[index] << " ";
+	ss << "C3: " << C3_[index] << " ";
+	return ss.str();
 }
 
 ///  Sets the data for Neurons to input's data.
 ///
 ///  @param  input       istream to read from.
-void AllIZHNeurons::deserialize(std::istream &input) {
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      readNeuron(input, i);
-   }
+void AllIZHNeurons::deserialize(std::istream& input) {
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) readNeuron(input, i);
 }
 
 ///  Sets the data for Neuron #index to input's data.
 ///
 ///  @param  input       istream to read from.
 ///  @param  index           index of the neuron (in neurons).
-void AllIZHNeurons::readNeuron(std::istream &input, int index) {
-   AllIFNeurons::readNeuron(input, index);
+void AllIZHNeurons::readNeuron(std::istream& input, int index) {
+	AllIFNeurons::readNeuron(input, index);
 
-   input >> Aconst_[index];
-   input.ignore();
-   input >> Bconst_[index];
-   input.ignore();
-   input >> Cconst_[index];
-   input.ignore();
-   input >> Dconst_[index];
-   input.ignore();
-   input >> u_[index];
-   input.ignore();
-   input >> C3_[index];
-   input.ignore();
+	input >> Aconst_[index];
+	input.ignore();
+	input >> Bconst_[index];
+	input.ignore();
+	input >> Cconst_[index];
+	input.ignore();
+	input >> Dconst_[index];
+	input.ignore();
+	input >> u_[index];
+	input.ignore();
+	input >> C3_[index];
+	input.ignore();
 }
 
 ///  Writes out the data in Neurons.
 ///
 ///  @param  output      stream to write out to.
-void AllIZHNeurons::serialize(std::ostream &output) const {
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      writeNeuron(output, i);
-   }
+void AllIZHNeurons::serialize(std::ostream& output) const {
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) writeNeuron(output, i);
 }
 
 ///  Writes out the data in the selected Neuron.
 ///
 ///  @param  output      stream to write out to.
 ///  @param  index       index of the neuron (in neurons).
-void AllIZHNeurons::writeNeuron(std::ostream &output, int index) const {
-   AllIFNeurons::writeNeuron(output, index);
+void AllIZHNeurons::writeNeuron(std::ostream& output, int index) const {
+	AllIFNeurons::writeNeuron(output, index);
 
-   output << Aconst_[index] << std::ends;
-   output << Bconst_[index] << std::ends;
-   output << Cconst_[index] << std::ends;
-   output << Dconst_[index] << std::ends;
-   output << u_[index] << std::ends;
-   output << C3_[index] << std::ends;
+	output << Aconst_[index] << std::ends;
+	output << Bconst_[index] << std::ends;
+	output << Cconst_[index] << std::ends;
+	output << Dconst_[index] << std::ends;
+	output << u_[index] << std::ends;
+	output << C3_[index] << std::ends;
 }
 
 #ifndef __CUDACC__
@@ -234,86 +231,88 @@ void AllIZHNeurons::writeNeuron(std::ostream &output, int index) const {
 ///
 ///  @param  index       Index of the Neuron to update.
 void AllIZHNeurons::advanceNeuron(const int index) {
-   BGFLOAT &Vm = this->Vm_[index];
-   BGFLOAT &Vthresh = this->Vthresh_[index];
-   BGFLOAT &summationPoint = this->summationMap_[index];
-   BGFLOAT &I0 = this->I0_[index];
-   BGFLOAT &Inoise = this->Inoise_[index];
-   BGFLOAT &C1 = this->C1_[index];
-   BGFLOAT &C2 = this->C2_[index];
-   BGFLOAT &C3 = this->C3_[index];
-   int &nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
+	BGFLOAT& Vm = this->Vm_[index];
+	BGFLOAT& Vthresh = this->Vthresh_[index];
+	BGFLOAT& summationPoint = this->summationMap_[index];
+	BGFLOAT& I0 = this->I0_[index];
+	BGFLOAT& Inoise = this->Inoise_[index];
+	BGFLOAT& C1 = this->C1_[index];
+	BGFLOAT& C2 = this->C2_[index];
+	BGFLOAT& C3 = this->C3_[index];
+	int& nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
 
-   BGFLOAT &a = Aconst_[index];
-   BGFLOAT &b = Bconst_[index];
-   BGFLOAT &u = this->u_[index];
+	BGFLOAT& a = Aconst_[index];
+	BGFLOAT& b = Bconst_[index];
+	BGFLOAT& u = this->u_[index];
 
-   if (nStepsInRefr > 0) {
-      // is neuron refractory?
-      --nStepsInRefr;
-   } else if (Vm >= Vthresh) {
-      // should it fire?
-      fire(index);
-   } else {
-      summationPoint += I0; // add IO
-      // add noise
-      BGFLOAT noise = (*noiseRNG)();
-      // Happens really often, causes drastic slow down
-      // DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << std::endl;)
-      summationPoint += noise * Inoise; // add noise
+	if (nStepsInRefr > 0) {
+		// is neuron refractory?
+		--nStepsInRefr;
+	}
+	else if (Vm >= Vthresh) {
+		// should it fire?
+		fire(index);
+	}
+	else {
+		summationPoint += I0; // add IO
+		// add noise
+		BGFLOAT noise = (*noiseRNG)();
+		// Happens really often, causes drastic slow down
+		// DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << std::endl;)
+		summationPoint += noise * Inoise; // add noise
 
-      BGFLOAT Vint = Vm * 1000;
+		BGFLOAT Vint = Vm * 1000;
 
-      // Izhikevich model integration step
-      BGFLOAT Vb = Vint + C3 * (0.04 * Vint * Vint + 5 * Vint + 140 - u);
-      u = u + C3 * a * (b * Vint - u);
+		// Izhikevich model integration step
+		BGFLOAT Vb = Vint + C3 * (0.04 * Vint * Vint + 5 * Vint + 140 - u);
+		u = u + C3 * a * (b * Vint - u);
 
-      Vm = Vb * 0.001 + C2 * summationPoint;  // add inputs
-   }
+		Vm = Vb * 0.001 + C2 * summationPoint; // add inputs
+	}
 
-   // Happens really often, causes drastic slow down
-//   DEBUG_MID(cout << index << " " << Vm << std::endl;)
-//   DEBUG_MID(cout << "NEURON[" << index << "] {" << std::endl
-//                  << "\tVm = " << Vm << std::endl
-//                  << "\ta = " << a << std::endl
-//                  << "\tb = " << b << std::endl
-//                  << "\tc = " << Cconst_[index] << std::endl
-//                  << "\td = " << Dconst_[index] << std::endl
-//                  << "\tu = " << u << std::endl
-//                  << "\tVthresh = " << Vthresh << std::endl
-//                  << "\tsummationPoint = " << summationPoint << std::endl
-//                  << "\tI0 = " << I0 << std::endl
-//                  << "\tInoise = " << Inoise << std::endl
-//                  << "\tC1 = " << C1 << std::endl
-//                  << "\tC2 = " << C2 << std::endl
-//                  << "\tC3 = " << C3 << std::endl
-//                  << "}" << std::endl;)
+	// Happens really often, causes drastic slow down
+	//   DEBUG_MID(cout << index << " " << Vm << std::endl;)
+	//   DEBUG_MID(cout << "NEURON[" << index << "] {" << std::endl
+	//                  << "\tVm = " << Vm << std::endl
+	//                  << "\ta = " << a << std::endl
+	//                  << "\tb = " << b << std::endl
+	//                  << "\tc = " << Cconst_[index] << std::endl
+	//                  << "\td = " << Dconst_[index] << std::endl
+	//                  << "\tu = " << u << std::endl
+	//                  << "\tVthresh = " << Vthresh << std::endl
+	//                  << "\tsummationPoint = " << summationPoint << std::endl
+	//                  << "\tI0 = " << I0 << std::endl
+	//                  << "\tInoise = " << Inoise << std::endl
+	//                  << "\tC1 = " << C1 << std::endl
+	//                  << "\tC2 = " << C2 << std::endl
+	//                  << "\tC3 = " << C3 << std::endl
+	//                  << "}" << std::endl;)
 
-   // clear synaptic input for next time step
-   summationPoint = 0;
+	// clear synaptic input for next time step
+	summationPoint = 0;
 }
 
 ///  Fire the selected Neuron and calculate the result.
 ///
 ///  @param  index       Index of the Neuron to update.
 void AllIZHNeurons::fire(const int index) const {
-   const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
-   AllSpikingNeurons::fire(index);
+	const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
+	AllSpikingNeurons::fire(index);
 
-   // calculate the number of steps in the absolute refractory period
-   BGFLOAT &Vm = this->Vm_[index];
-   int &nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
-   BGFLOAT &Trefract = this->Trefract_[index];
+	// calculate the number of steps in the absolute refractory period
+	BGFLOAT& Vm = this->Vm_[index];
+	int& nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
+	BGFLOAT& Trefract = this->Trefract_[index];
 
-   BGFLOAT &c = Cconst_[index];
-   BGFLOAT &d = Dconst_[index];
-   BGFLOAT &u = this->u_[index];
+	BGFLOAT& c = Cconst_[index];
+	BGFLOAT& d = Dconst_[index];
+	BGFLOAT& u = this->u_[index];
 
-   nStepsInRefr = static_cast<int> ( Trefract / deltaT + 0.5 );
+	nStepsInRefr = static_cast<int>(Trefract / deltaT + 0.5);
 
-   // reset to 'Vreset'
-   Vm = c * 0.001;
-   u = u + d;
+	// reset to 'Vreset'
+	Vm = c * 0.001;
+	u = u + d;
 }
 
 #endif

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -104,7 +104,7 @@ void AllIZHNeurons::createNeuron(int i, Layout* layout) {
 	AllIFNeurons::createNeuron(i, layout);
 
 	// TODO: we may need another distribution mode besides flat distribution
-	if (layout->vertexTypeMap_[i] == EXC) {
+	if (layout->vertexTypeMap_[i] == vertexType::EXC) {
 		// excitatory neuron
 		Aconst_[i] = initRNG.inRange(excAconst_[0], excAconst_[1]);
 		Bconst_[i] = initRNG.inRange(excBconst_[0], excBconst_[1]);

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -54,31 +54,31 @@ void AllIZHNeurons::setupVertices() {
 void AllIZHNeurons::printParameters() const {
    AllIFNeurons::printParameters();
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices type: AllIZHNeurons" << endl
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices type: AllIZHNeurons" << std::endl
              << "\tInterval of A constant for excitatory neurons: ["
              << excAconst_[0] << ", " << excAconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of A constant for inhibitory neurons: ["
              << inhAconst_[0] << ", " << inhAconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of B constant for excitatory neurons: ["
              << excBconst_[0] << ", " << excBconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of B constant for inhibitory neurons: ["
              << inhBconst_[0] << ", " << inhBconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of C constant for excitatory neurons: ["
              << excCconst_[0] << ", " << excCconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of C constant for inhibitory neurons: ["
              << inhCconst_[0] << ", " << inhCconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of D constant for excitatory neurons: ["
              << excDconst_[0] << ", " << excDconst_[1] << "]"
-             << endl
+             << std::endl
              << "\tInterval of D constant for inhibitory neurons: ["
              << inhDconst_[0] << ", " << inhDconst_[1] << "]"
-             << endl << endl);
+             << std::endl << std::endl);
 
 }
 
@@ -120,13 +120,13 @@ void AllIZHNeurons::createNeuron(int i, Layout *layout) {
 
    u_[i] = 0;
 
-   LOG4CPLUS_DEBUG(fileLogger_, "\nCREATE NEURON[" << i << "] {" << endl
-                 << "\tAconst = " << Aconst_[i] << endl
-                 << "\tBconst = " << Bconst_[i] << endl
-                 << "\tCconst = " << Cconst_[i] << endl
-                 << "\tDconst = " << Dconst_[i] << endl
-                 << "\tC3 = " << C3_[i] << endl
-                 << "}" << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\nCREATE NEURON[" << i << "] {" << std::endl
+                 << "\tAconst = " << Aconst_[i] << std::endl
+                 << "\tBconst = " << Bconst_[i] << std::endl
+                 << "\tCconst = " << Cconst_[i] << std::endl
+                 << "\tDconst = " << Dconst_[i] << std::endl
+                 << "\tC3 = " << C3_[i] << std::endl
+                 << "}" << std::endl);
 
 }
 
@@ -160,8 +160,8 @@ void AllIZHNeurons::initNeuronConstsFromParamValues(int i, const BGFLOAT deltaT)
 ///
 ///  @param  index index of the neuron (in neurons) to output info from.
 ///  @return the complete state of the neuron.
-string AllIZHNeurons::toString(const int index) const {
-   stringstream ss;
+std::string AllIZHNeurons::toString(const int index) const {
+   std::stringstream ss;
 
    ss << AllIFNeurons::toString(index);
 
@@ -177,7 +177,7 @@ string AllIZHNeurons::toString(const int index) const {
 ///  Sets the data for Neurons to input's data.
 ///
 ///  @param  input       istream to read from.
-void AllIZHNeurons::deserialize(istream &input) {
+void AllIZHNeurons::deserialize(std::istream &input) {
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       readNeuron(input, i);
    }
@@ -187,7 +187,7 @@ void AllIZHNeurons::deserialize(istream &input) {
 ///
 ///  @param  input       istream to read from.
 ///  @param  index           index of the neuron (in neurons).
-void AllIZHNeurons::readNeuron(istream &input, int index) {
+void AllIZHNeurons::readNeuron(std::istream &input, int index) {
    AllIFNeurons::readNeuron(input, index);
 
    input >> Aconst_[index];
@@ -207,7 +207,7 @@ void AllIZHNeurons::readNeuron(istream &input, int index) {
 ///  Writes out the data in Neurons.
 ///
 ///  @param  output      stream to write out to.
-void AllIZHNeurons::serialize(ostream &output) const {
+void AllIZHNeurons::serialize(std::ostream &output) const {
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       writeNeuron(output, i);
    }
@@ -217,18 +217,18 @@ void AllIZHNeurons::serialize(ostream &output) const {
 ///
 ///  @param  output      stream to write out to.
 ///  @param  index       index of the neuron (in neurons).
-void AllIZHNeurons::writeNeuron(ostream &output, int index) const {
+void AllIZHNeurons::writeNeuron(std::ostream &output, int index) const {
    AllIFNeurons::writeNeuron(output, index);
 
-   output << Aconst_[index] << ends;
-   output << Bconst_[index] << ends;
-   output << Cconst_[index] << ends;
-   output << Dconst_[index] << ends;
-   output << u_[index] << ends;
-   output << C3_[index] << ends;
+   output << Aconst_[index] << std::ends;
+   output << Bconst_[index] << std::ends;
+   output << Cconst_[index] << std::ends;
+   output << Dconst_[index] << std::ends;
+   output << u_[index] << std::ends;
+   output << C3_[index] << std::ends;
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Update internal state of the indexed Neuron (called by every simulation step).
 ///
@@ -259,7 +259,7 @@ void AllIZHNeurons::advanceNeuron(const int index) {
       // add noise
       BGFLOAT noise = (*noiseRNG)();
       // Happens really often, causes drastic slow down
-      // DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << endl;)
+      // DEBUG_MID(cout << "ADVANCE NEURON[" << index << "] :: noise = " << noise << std::endl;)
       summationPoint += noise * Inoise; // add noise
 
       BGFLOAT Vint = Vm * 1000;
@@ -272,22 +272,22 @@ void AllIZHNeurons::advanceNeuron(const int index) {
    }
 
    // Happens really often, causes drastic slow down
-//   DEBUG_MID(cout << index << " " << Vm << endl;)
-//   DEBUG_MID(cout << "NEURON[" << index << "] {" << endl
-//                  << "\tVm = " << Vm << endl
-//                  << "\ta = " << a << endl
-//                  << "\tb = " << b << endl
-//                  << "\tc = " << Cconst_[index] << endl
-//                  << "\td = " << Dconst_[index] << endl
-//                  << "\tu = " << u << endl
-//                  << "\tVthresh = " << Vthresh << endl
-//                  << "\tsummationPoint = " << summationPoint << endl
-//                  << "\tI0 = " << I0 << endl
-//                  << "\tInoise = " << Inoise << endl
-//                  << "\tC1 = " << C1 << endl
-//                  << "\tC2 = " << C2 << endl
-//                  << "\tC3 = " << C3 << endl
-//                  << "}" << endl;)
+//   DEBUG_MID(cout << index << " " << Vm << std::endl;)
+//   DEBUG_MID(cout << "NEURON[" << index << "] {" << std::endl
+//                  << "\tVm = " << Vm << std::endl
+//                  << "\ta = " << a << std::endl
+//                  << "\tb = " << b << std::endl
+//                  << "\tc = " << Cconst_[index] << std::endl
+//                  << "\td = " << Dconst_[index] << std::endl
+//                  << "\tu = " << u << std::endl
+//                  << "\tVthresh = " << Vthresh << std::endl
+//                  << "\tsummationPoint = " << summationPoint << std::endl
+//                  << "\tI0 = " << I0 << std::endl
+//                  << "\tInoise = " << Inoise << std::endl
+//                  << "\tC1 = " << C1 << std::endl
+//                  << "\tC2 = " << C2 << std::endl
+//                  << "\tC3 = " << C3 << std::endl
+//                  << "}" << std::endl;)
 
    // clear synaptic input for next time step
    summationPoint = 0;

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -71,48 +71,48 @@
  */
 #pragma once
 
-#include "Global.h"
 #include "AllIFNeurons.h"
+#include "Global.h"
 
 struct AllIZHNeuronsDeviceProperties;
 
 // Class to hold all data necessary for all the Neurons.
 class AllIZHNeurons : public AllIFNeurons {
-public:
-   AllIZHNeurons();
+	public:
+		AllIZHNeurons();
 
-   virtual ~AllIZHNeurons();
+		~AllIZHNeurons() override;
 
-   static AllVertices *Create() { return new AllIZHNeurons(); }
+		static AllVertices* Create() { return new AllIZHNeurons(); }
 
-   ///  Setup the internal structure of the class.
-   ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices() override;
+		///  Setup the internal structure of the class.
+		///  Allocate memories to store all neurons' state.
+		void setupVertices() override;
 
-   ///  Prints out all parameters of the neurons to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters of the neurons to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
-   ///  Creates all the Neurons and assigns initial data for them.
-   ///
-   ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout) override;
+		///  Creates all the Neurons and assigns initial data for them.
+		///
+		///  @param  layout      Layout information of the neural network.
+		void createAllVertices(Layout* layout) override;
 
-   ///  Outputs state of the neuron chosen as a string.
-   ///
-   ///  @param  index   index of the neuron (in neurons) to output info from.
-   ///  @return the complete state of the neuron.
-   virtual std::string toString(const int index) const override;
+		///  Outputs state of the neuron chosen as a string.
+		///
+		///  @param  index   index of the neuron (in neurons) to output info from.
+		///  @return the complete state of the neuron.
+		std::string toString(const int index) const override;
 
-   ///  Reads and sets the data for all neurons from input stream.
-   ///
-   ///  @param  input       istream to read from.
-   virtual void deserialize(std::istream &input) override;
+		///  Reads and sets the data for all neurons from input stream.
+		///
+		///  @param  input       istream to read from.
+		void deserialize(std::istream& input) override;
 
-   ///  Writes out the data in all neurons to output stream.
-   ///
-   ///  @param  output      stream to write out to.
-   virtual void serialize(std::ostream &output) const override;
+		///  Writes out the data in all neurons to output stream.
+		///
+		///  @param  output      stream to write out to.
+		void serialize(std::ostream& output) const override;
 
 #ifdef __CUDACC__
    public:
@@ -188,106 +188,106 @@ public:
        ///  @param  allVerticesDevice         Reference to the AllIZHNeuronsDeviceProperties struct.
        void copyDeviceToHost( AllIZHNeuronsDeviceProperties& allVerticesDevice);
 
-#else  // !defined(USE_GPU)
+#else  // !defined(__CUDACC__)
 
-protected:
-   ///  Helper for #advanceNeuron. Updates state of a single neuron.
-   ///
-   ///  @param  index            Index of the neuron to update.
-   virtual void advanceNeuron(const int index);
+	protected:
+		///  Helper for #advanceNeuron. Updates state of a single neuron.
+		///
+		///  @param  index            Index of the neuron to update.
+		void advanceNeuron(const int index) override;
 
-   ///  Initiates a firing of a neuron to connected neurons.
-   ///
-   ///  @param  index            Index of the neuron to fire.
-   virtual void fire(const int index) const;
+		///  Initiates a firing of a neuron to connected neurons.
+		///
+		///  @param  index            Index of the neuron to fire.
+		void fire(const int index) const override;
 
-#endif  // defined(USE_GPU)
+#endif  // defined(__CUDACC__)
 
-protected:
-   ///  Creates a single Neuron and generates data for it.
-   ///
-   ///  @param  neuronIndex Index of the neuron to create.
-   ///  @param  layout       Layout information of the neural network.
-   void createNeuron(int neuronIndex, Layout *layout);
+	protected:
+		///  Creates a single Neuron and generates data for it.
+		///
+		///  @param  neuronIndex Index of the neuron to create.
+		///  @param  layout       Layout information of the neural network.
+		void createNeuron(int neuronIndex, Layout* layout);
 
-   ///  Set the Neuron at the indexed location to default values.
-   ///
-   ///  @param  index    Index of the Neuron that the synapse belongs to.
-   void setNeuronDefaults(const int index);
+		///  Set the Neuron at the indexed location to default values.
+		///
+		///  @param  index    Index of the Neuron that the synapse belongs to.
+		void setNeuronDefaults(const int index);
 
-   ///  Initializes the Neuron constants at the indexed location.
-   ///
-   ///  @param  neuronIndex    Index of the Neuron.
-   ///  @param  deltaT          Inner simulation step duration
-   virtual void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT) override;
+		///  Initializes the Neuron constants at the indexed location.
+		///
+		///  @param  neuronIndex    Index of the Neuron.
+		///  @param  deltaT          Inner simulation step duration
+		void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT) override;
 
-   ///  Sets the data for Neuron #index to input's data.
-   ///
-   ///  @param  input       istream to read from.
-   ///  @param  index           index of the neuron (in neurons).
-   void readNeuron(std::istream &input, int index);
+		///  Sets the data for Neuron #index to input's data.
+		///
+		///  @param  input       istream to read from.
+		///  @param  index           index of the neuron (in neurons).
+		void readNeuron(std::istream& input, int index);
 
-   ///  Writes out the data in the selected Neuron.
-   ///
-   ///  @param  output      stream to write out to.
-   ///  @param  index           index of the neuron (in neurons).
-   void writeNeuron(std::ostream &output, int index) const;
+		///  Writes out the data in the selected Neuron.
+		///
+		///  @param  output      stream to write out to.
+		///  @param  index           index of the neuron (in neurons).
+		void writeNeuron(std::ostream& output, int index) const;
 
-public:
-   ///  A constant (0.02, 01) describing the coupling of variable u to Vm.
-   BGFLOAT *Aconst_;
+	public:
+		///  A constant (0.02, 01) describing the coupling of variable u to Vm.
+		BGFLOAT* Aconst_;
 
-   ///  A constant controlling sensitivity of u.
-   BGFLOAT *Bconst_;
+		///  A constant controlling sensitivity of u.
+		BGFLOAT* Bconst_;
 
-   ///  A constant controlling reset of Vm.
-   BGFLOAT *Cconst_;
+		///  A constant controlling reset of Vm.
+		BGFLOAT* Cconst_;
 
-   ///  A constant controlling reset of u.
-   BGFLOAT *Dconst_;
+		///  A constant controlling reset of u.
+		BGFLOAT* Dconst_;
 
-   ///  internal variable.
-   BGFLOAT *u_;
+		///  internal variable.
+		BGFLOAT* u_;
 
-   ///  Internal constant for the exponential Euler integration.
-   BGFLOAT *C3_;
+		///  Internal constant for the exponential Euler integration.
+		BGFLOAT* C3_;
 
-private:
-   ///  Default value of Aconst.
-   static constexpr BGFLOAT DEFAULT_a = 0.0035;
+	private:
+		///  Default value of Aconst.
+		static constexpr BGFLOAT DEFAULT_a = 0.0035;
 
-   ///  Default value of Bconst.
-   static constexpr BGFLOAT DEFAULT_b = 0.2;
+		///  Default value of Bconst.
+		static constexpr BGFLOAT DEFAULT_b = 0.2;
 
-   ///  Default value of Cconst.
-   static constexpr BGFLOAT DEFAULT_c = -50;
+		///  Default value of Cconst.
+		static constexpr BGFLOAT DEFAULT_c = -50;
 
-   ///  Default value of Dconst.
-   static constexpr BGFLOAT DEFAULT_d = 2;
+		///  Default value of Dconst.
+		static constexpr BGFLOAT DEFAULT_d = 2;
 
-   ///  Min/max values of Aconst for excitatory neurons.
-   BGFLOAT excAconst_[2];
+		///  Min/max values of Aconst for excitatory neurons.
+		BGFLOAT excAconst_[2];
 
-   ///  Min/max values of Aconst for inhibitory neurons.
-   BGFLOAT inhAconst_[2];
+		///  Min/max values of Aconst for inhibitory neurons.
+		BGFLOAT inhAconst_[2];
 
-   ///  Min/max values of Bconst for excitatory neurons.
-   BGFLOAT excBconst_[2];
+		///  Min/max values of Bconst for excitatory neurons.
+		BGFLOAT excBconst_[2];
 
-   ///  Min/max values of Bconst for inhibitory neurons.
-   BGFLOAT inhBconst_[2];
+		///  Min/max values of Bconst for inhibitory neurons.
+		BGFLOAT inhBconst_[2];
 
-   ///  Min/max values of Cconst for excitatory neurons.
-   BGFLOAT excCconst_[2];
+		///  Min/max values of Cconst for excitatory neurons.
+		BGFLOAT excCconst_[2];
 
-   ///  Min/max values of Cconst for inhibitory neurons.
-   BGFLOAT inhCconst_[2];
+		///  Min/max values of Cconst for inhibitory neurons.
+		BGFLOAT inhCconst_[2];
 
-   ///  Min/max values of Dconst for excitatory neurons.
-   BGFLOAT excDconst_[2];
+		///  Min/max values of Dconst for excitatory neurons.
+		BGFLOAT excDconst_[2];
 
-   ///  Min/max values of Dconst for inhibitory neurons.
-   BGFLOAT inhDconst_[2];
+		///  Min/max values of Dconst for inhibitory neurons.
+		BGFLOAT inhDconst_[2];
 };
 
 #ifdef __CUDACC__
@@ -311,4 +311,4 @@ struct AllIZHNeuronsDeviceProperties : public AllIFNeuronsDeviceProperties
         ///  Internal constant for the exponential Euler integration.
         BGFLOAT *C3_;
 };
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -102,7 +102,7 @@ class AllIZHNeurons : public AllIFNeurons {
 		///
 		///  @param  index   index of the neuron (in neurons) to output info from.
 		///  @return the complete state of the neuron.
-		std::string toString(const int index) const override;
+		std::string toString(int index) const override;
 
 		///  Reads and sets the data for all neurons from input stream.
 		///
@@ -194,12 +194,12 @@ class AllIZHNeurons : public AllIFNeurons {
 		///  Helper for #advanceNeuron. Updates state of a single neuron.
 		///
 		///  @param  index            Index of the neuron to update.
-		void advanceNeuron(const int index) override;
+		void advanceNeuron(int index) override;
 
 		///  Initiates a firing of a neuron to connected neurons.
 		///
 		///  @param  index            Index of the neuron to fire.
-		void fire(const int index) const override;
+		void fire(int index) const override;
 
 #endif  // defined(__CUDACC__)
 
@@ -213,13 +213,13 @@ class AllIZHNeurons : public AllIFNeurons {
 		///  Set the Neuron at the indexed location to default values.
 		///
 		///  @param  index    Index of the Neuron that the synapse belongs to.
-		void setNeuronDefaults(const int index);
+		void setNeuronDefaults(int index);
 
 		///  Initializes the Neuron constants at the indexed location.
 		///
 		///  @param  neuronIndex    Index of the Neuron.
 		///  @param  deltaT          Inner simulation step duration
-		void initNeuronConstsFromParamValues(int neuronIndex, const BGFLOAT deltaT) override;
+		void initNeuronConstsFromParamValues(int neuronIndex, BGFLOAT deltaT) override;
 
 		///  Sets the data for Neuron #index to input's data.
 		///

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -102,19 +102,19 @@ public:
    ///
    ///  @param  index   index of the neuron (in neurons) to output info from.
    ///  @return the complete state of the neuron.
-   virtual string toString(const int index) const override;
+   virtual std::string toString(const int index) const override;
 
    ///  Reads and sets the data for all neurons from input stream.
    ///
    ///  @param  input       istream to read from.
-   virtual void deserialize(istream &input) override;
+   virtual void deserialize(std::istream &input) override;
 
    ///  Writes out the data in all neurons to output stream.
    ///
    ///  @param  output      stream to write out to.
-   virtual void serialize(ostream &output) const override;
+   virtual void serialize(std::ostream &output) const override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Update the state of all neurons for a time step
        ///  Notify outgoing synapses if neuron has fired.
@@ -225,13 +225,13 @@ protected:
    ///
    ///  @param  input       istream to read from.
    ///  @param  index           index of the neuron (in neurons).
-   void readNeuron(istream &input, int index);
+   void readNeuron(std::istream &input, int index);
 
    ///  Writes out the data in the selected Neuron.
    ///
    ///  @param  output      stream to write out to.
    ///  @param  index           index of the neuron (in neurons).
-   void writeNeuron(ostream &output, int index) const;
+   void writeNeuron(std::ostream &output, int index) const;
 
 public:
    ///  A constant (0.02, 01) describing the coupling of variable u to Vm.
@@ -290,7 +290,7 @@ private:
    BGFLOAT inhDconst_[2];
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllIZHNeuronsDeviceProperties : public AllIFNeuronsDeviceProperties
 {
         ///  A constant (0.02, 01) describing the coupling of variable u to Vm.

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.cpp
@@ -9,17 +9,15 @@
 #include "ParseParamError.h"
 
 // Default constructor
-AllLIFNeurons::AllLIFNeurons() : AllIFNeurons() {
-}
+AllLIFNeurons::AllLIFNeurons() : AllIFNeurons() {}
 
-AllLIFNeurons::~AllLIFNeurons() {
-}
+AllLIFNeurons::~AllLIFNeurons() {}
 
 ///  Prints out all parameters of the neurons to logging file.
 ///  Registered to OperationManager as Operation::printParameters
 void AllLIFNeurons::printParameters() const {
-   AllIFNeurons::printParameters();
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices Type: AllLIFNeurons" << std::endl);
+	AllIFNeurons::printParameters();
+	LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices Type: AllLIFNeurons" << std::endl);
 }
 
 #ifndef __CUDACC__
@@ -28,57 +26,59 @@ void AllLIFNeurons::printParameters() const {
 ///
 ///  @param  index       Index of the Neuron to update.
 void AllLIFNeurons::advanceNeuron(const int index) {
-    BGFLOAT &Vm = this->Vm_[index];
-    BGFLOAT &Vthresh = this->Vthresh_[index];
-    BGFLOAT &summationPoint = this->summationMap_[index];
-    BGFLOAT &I0 = this->I0_[index];
-    BGFLOAT &Inoise = this->Inoise_[index];
-    BGFLOAT &C1 = this->C1_[index];
-    BGFLOAT &C2 = this->C2_[index];
-    int &nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
+	BGFLOAT& Vm = this->Vm_[index];
+	BGFLOAT& Vthresh = this->Vthresh_[index];
+	BGFLOAT& summationPoint = this->summationMap_[index];
+	BGFLOAT& I0 = this->I0_[index];
+	BGFLOAT& Inoise = this->Inoise_[index];
+	BGFLOAT& C1 = this->C1_[index];
+	BGFLOAT& C2 = this->C2_[index];
+	int& nStepsInRefr = this->numStepsInRefractoryPeriod_[index];
 
-    if (nStepsInRefr > 0) {
-        // is neuron refractory?
-        --nStepsInRefr;
-    } else if (Vm >= Vthresh) {
-        // should it fire?
-        fire(index);
-    } else {
-        summationPoint += I0; // add IO
-        // add noise
-        BGFLOAT noise = (*noiseRNG)();
-        //LOG4CPLUS_DEBUG(vertexLogger_, "ADVANCE NEURON[" << index << "] :: Noise = " << noise);
-        summationPoint += noise * Inoise; // add noise
-        Vm = C1 * Vm + C2 * summationPoint; // decay Vm and add inputs
-    }
-    // clear synaptic input for next time step
-    summationPoint = 0;
+	if (nStepsInRefr > 0) {
+		// is neuron refractory?
+		--nStepsInRefr;
+	}
+	else if (Vm >= Vthresh) {
+		// should it fire?
+		fire(index);
+	}
+	else {
+		summationPoint += I0; // add IO
+		// add noise
+		BGFLOAT noise = (*noiseRNG)();
+		//LOG4CPLUS_DEBUG(vertexLogger_, "ADVANCE NEURON[" << index << "] :: Noise = " << noise);
+		summationPoint += noise * Inoise; // add noise
+		Vm = C1 * Vm + C2 * summationPoint; // decay Vm and add inputs
+	}
+	// clear synaptic input for next time step
+	summationPoint = 0;
 
-    // Causes a huge slowdown since it's printed so frequently
-//    LOG4CPLUS_DEBUG(vertexLogger_, "Index: " << index << " Vm: " << Vm);
-//    LOG4CPLUS_DEBUG(vertexLogger_, "NEURON[" << index << "] {" << endl
-//                   << "\tVm = " << Vm << endl
-//                   << "\tVthresh = " << Vthresh << endl
-//                   << "\tsummationPoint = " << summationPoint << endl
-//                   << "\tI0 = " << I0 << endl
-//                   << "\tInoise = " << Inoise << endl
-//                   << "\tC1 = " << C1 << endl
-//                   << "\tC2 = " << C2 << endl
-//                   << "}" << endl);
+	// Causes a huge slowdown since it's printed so frequently
+	//    LOG4CPLUS_DEBUG(vertexLogger_, "Index: " << index << " Vm: " << Vm);
+	//    LOG4CPLUS_DEBUG(vertexLogger_, "NEURON[" << index << "] {" << endl
+	//                   << "\tVm = " << Vm << endl
+	//                   << "\tVthresh = " << Vthresh << endl
+	//                   << "\tsummationPoint = " << summationPoint << endl
+	//                   << "\tI0 = " << I0 << endl
+	//                   << "\tInoise = " << Inoise << endl
+	//                   << "\tC1 = " << C1 << endl
+	//                   << "\tC2 = " << C2 << endl
+	//                   << "}" << endl);
 }
 
 ///  Fire the selected Neuron and calculate the result.
 ///
 ///  @param  index       Index of the Neuron to update.
 void AllLIFNeurons::fire(const int index) const {
-    const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
-    AllSpikingNeurons::fire(index);
+	const BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
+	AllSpikingNeurons::fire(index);
 
-    // calculate the number of steps in the absolute refractory period
-    numStepsInRefractoryPeriod_[index] = static_cast<int> ( Trefract_[index] / deltaT + 0.5 );
+	// calculate the number of steps in the absolute refractory period
+	numStepsInRefractoryPeriod_[index] = static_cast<int>(Trefract_[index] / deltaT + 0.5);
 
-    // reset to 'Vreset'
-    Vm_[index] = Vreset_[index];
+	// reset to 'Vreset'
+	Vm_[index] = Vreset_[index];
 }
 
 #endif

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.cpp
@@ -19,10 +19,10 @@ AllLIFNeurons::~AllLIFNeurons() {
 ///  Registered to OperationManager as Operation::printParameters
 void AllLIFNeurons::printParameters() const {
    AllIFNeurons::printParameters();
-   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices Type: AllLIFNeurons" << endl);
+   LOG4CPLUS_DEBUG(fileLogger_, "\n\tVertices Type: AllLIFNeurons" << std::endl);
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Update internal state of the indexed Neuron (called by every simulation step).
 ///

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -94,7 +94,7 @@ public:
    ///  Registered to OperationManager as Operation::printParameters
    virtual void printParameters() const override;
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
 
        ///  Update the state of all neurons for a time step

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -111,12 +111,12 @@ class AllLIFNeurons : public AllIFNeurons {
 		///  Helper for #advanceNeuron. Updates state of a single neuron.
 		///
 		///  @param  index Index of the neuron to update.
-		void advanceNeuron(const int index) override;
+		void advanceNeuron(int index) override;
 
 		///  Initiates a firing of a neuron to connected neurons.
 		///
 		///  @param  index Index of the neuron to fire.
-		void fire(const int index) const override;
+		void fire(int index) const override;
 
 #endif // defined(__CUDACC__)
 };

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -73,26 +73,25 @@
  */
 #pragma once
 
-#include "Global.h"
 #include "AllIFNeurons.h"
 #include "AllSpikingSynapses.h"
+#include "Global.h"
 
 // Class to hold all data necessary for all the Neurons.
 class AllLIFNeurons : public AllIFNeurons {
-public:
+	public:
+		AllLIFNeurons();
 
-   AllLIFNeurons();
+		~AllLIFNeurons() override;
 
-   virtual ~AllLIFNeurons();
+		///  Creates an instance of the class.
+		///
+		///  @return Reference to the instance of the class.
+		static AllVertices* Create() { return new AllLIFNeurons(); }
 
-   ///  Creates an instance of the class.
-   ///
-   ///  @return Reference to the instance of the class.
-   static AllVertices *Create() { return new AllLIFNeurons(); }
-
-   ///  Prints out all parameters of the neurons to logging file.
-   ///  Registered to OperationManager as Operation::printParameters
-   virtual void printParameters() const override;
+		///  Prints out all parameters of the neurons to logging file.
+		///  Registered to OperationManager as Operation::printParameters
+		void printParameters() const override;
 
 #ifdef __CUDACC__
    public:
@@ -107,19 +106,17 @@ public:
        ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
        virtual void advanceVertices(AllEdges &synapses, void* allVerticesDevice, void* allEdgesDevice, float* randNoise, EdgeIndexMap* edgeIndexMapDevice) override;
 
-#else  // !defined(USE_GPU)
-protected:
+#else  // !defined(__CUDACC__)
+	protected:
+		///  Helper for #advanceNeuron. Updates state of a single neuron.
+		///
+		///  @param  index Index of the neuron to update.
+		void advanceNeuron(const int index) override;
 
-   ///  Helper for #advanceNeuron. Updates state of a single neuron.
-   ///
-   ///  @param  index Index of the neuron to update.
-   virtual void advanceNeuron(const int index);
+		///  Initiates a firing of a neuron to connected neurons.
+		///
+		///  @param  index Index of the neuron to fire.
+		void fire(const int index) const override;
 
-   ///  Initiates a firing of a neuron to connected neurons.
-   ///
-   ///  @param  index Index of the neuron to fire.
-   virtual void fire(const int index) const;
-
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)
 };
-

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -65,7 +65,7 @@ void AllSpikingNeurons::clearSpikeCounts() {
    }
 }
 
-#if !defined(USE_GPU)
+#ifndef __CUDACC__
 
 ///  Update internal state of the indexed Neuron (called by every simulation step).
 ///  Notify outgoing synapses if neuron has fired.

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -11,58 +11,56 @@
 
 // Default constructor
 AllSpikingNeurons::AllSpikingNeurons() : AllVertices() {
-   hasFired_ = nullptr;
-   spikeCount_ = nullptr;
-   spikeCountOffset_ = nullptr;
-   spikeHistory_ = nullptr;
+	hasFired_ = nullptr;
+	spikeCount_ = nullptr;
+	spikeCountOffset_ = nullptr;
+	spikeHistory_ = nullptr;
 }
 
 AllSpikingNeurons::~AllSpikingNeurons() {
-   if (size_ != 0) {
-      for (int i = 0; i < size_; i++) {
-         delete[] spikeHistory_[i];
-      }
+	if (size_ != 0) {
+		for (int i = 0; i < size_; i++) delete[] spikeHistory_[i];
 
-      delete[] hasFired_;
-      delete[] spikeCount_;
-      delete[] spikeCountOffset_;
-      delete[] spikeHistory_;
-   }
+		delete[] hasFired_;
+		delete[] spikeCount_;
+		delete[] spikeCountOffset_;
+		delete[] spikeHistory_;
+	}
 
-   hasFired_ = nullptr;
-   spikeCount_ = nullptr;
-   spikeCountOffset_ = nullptr;
-   spikeHistory_ = nullptr;
+	hasFired_ = nullptr;
+	spikeCount_ = nullptr;
+	spikeCountOffset_ = nullptr;
+	spikeHistory_ = nullptr;
 }
 
 ///  Setup the internal structure of the class (allocate memories).
 void AllSpikingNeurons::setupVertices() {
-   AllVertices::setupVertices();
+	AllVertices::setupVertices();
 
-   // TODO: Rename variables for easier identification
-   hasFired_ = new bool[size_];
-   spikeCount_ = new int[size_];
-   spikeCountOffset_ = new int[size_];
-   spikeHistory_ = new uint64_t *[size_];
+	// TODO: Rename variables for easier identification
+	hasFired_ = new bool[size_];
+	spikeCount_ = new int[size_];
+	spikeCountOffset_ = new int[size_];
+	spikeHistory_ = new uint64_t*[size_];
 
-   for (int i = 0; i < size_; ++i) {
-      spikeHistory_[i] = nullptr;
-      hasFired_[i] = false;
-      spikeCount_[i] = 0;
-      spikeCountOffset_[i] = 0;
-   }
+	for (int i = 0; i < size_; ++i) {
+		spikeHistory_[i] = nullptr;
+		hasFired_[i] = false;
+		spikeCount_[i] = 0;
+		spikeCountOffset_[i] = 0;
+	}
 
-   Simulator::getInstance().setPSummationMap(summationMap_);
+	Simulator::getInstance().setPSummationMap(summationMap_);
 }
 
 ///  Clear the spike counts out of all Neurons.
 void AllSpikingNeurons::clearSpikeCounts() {
-   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
 
-   for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      spikeCountOffset_[i] = (spikeCount_[i] + spikeCountOffset_[i]) % maxSpikes;
-      spikeCount_[i] = 0;
-   }
+	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
+		spikeCountOffset_[i] = (spikeCount_[i] + spikeCountOffset_[i]) % maxSpikes;
+		spikeCount_[i] = 0;
+	}
 }
 
 #ifndef __CUDACC__
@@ -72,70 +70,70 @@ void AllSpikingNeurons::clearSpikeCounts() {
 ///
 ///  @param  synapses         The Synapse list to search from.
 ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap *edgeIndexMap) {
-   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+void AllSpikingNeurons::advanceVertices(AllEdges& synapses, const EdgeIndexMap* edgeIndexMap) {
+	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
 
-   AllSpikingSynapses &spSynapses = dynamic_cast<AllSpikingSynapses &>(synapses);
-   // For each neuron in the network
-   for (int idx = Simulator::getInstance().getTotalVertices() - 1; idx >= 0; --idx) {
-      // advance neurons
-      advanceNeuron(idx);
+	auto& spSynapses = dynamic_cast<AllSpikingSynapses&>(synapses);
+	// For each neuron in the network
+	for (int idx = Simulator::getInstance().getTotalVertices() - 1; idx >= 0; --idx) {
+		// advance neurons
+		advanceNeuron(idx);
 
-      // notify outgoing/incoming synapses if neuron has fired
-      if (hasFired_[idx]) {
-         LOG4CPLUS_DEBUG(vertexLogger_, "Neuron: " << idx << " has fired at time: "
-                        << g_simulationStep * Simulator::getInstance().getDeltaT());
+		// notify outgoing/incoming synapses if neuron has fired
+		if (hasFired_[idx]) {
+			LOG4CPLUS_DEBUG(vertexLogger_, "Neuron: " << idx << " has fired at time: "
+			                << g_simulationStep * Simulator::getInstance().getDeltaT());
 
-         assert(spikeCount_[idx] < maxSpikes);
+			assert(spikeCount_[idx] < maxSpikes);
 
-         // notify outgoing synapses
-         BGSIZE synapseCounts;
+			// notify outgoing synapses
+			BGSIZE synapseCounts;
 
-         if (edgeIndexMap != nullptr) {
-            synapseCounts = edgeIndexMap->outgoingEdgeCount_[idx];
-            if (synapseCounts != 0) {
-               int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
-               BGSIZE iEdg;
-               for (BGSIZE i = 0; i < synapseCounts; i++) {
-                  iEdg = edgeIndexMap->outgoingEdgeIndexMap_[beginIndex + i];
-                  spSynapses.preSpikeHit(iEdg);
-               }
-            }
-         }
+			if (edgeIndexMap != nullptr) {
+				synapseCounts = edgeIndexMap->outgoingEdgeCount_[idx];
+				if (synapseCounts != 0) {
+					int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
+					BGSIZE iEdg;
+					for (BGSIZE i = 0; i < synapseCounts; i++) {
+						iEdg = edgeIndexMap->outgoingEdgeIndexMap_[beginIndex + i];
+						spSynapses.preSpikeHit(iEdg);
+					}
+				}
+			}
 
-         // notify incoming synapses
-         synapseCounts = spSynapses.edgeCounts_[idx];
-         BGSIZE synapse_notified = 0;
+			// notify incoming synapses
+			synapseCounts = spSynapses.edgeCounts_[idx];
+			BGSIZE synapse_notified = 0;
 
-         if (spSynapses.allowBackPropagation()) {
-            for (int z = 0; synapse_notified < synapseCounts; z++) {
-               BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * idx + z;
-               if (spSynapses.inUse_[iEdg] == true) {
-                  spSynapses.postSpikeHit(iEdg);
-                  synapse_notified++;
-               }
-            }
-         }
+			if (spSynapses.allowBackPropagation()) {
+				for (int z = 0; synapse_notified < synapseCounts; z++) {
+					BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * idx + z;
+					if (spSynapses.inUse_[iEdg] == true) {
+						spSynapses.postSpikeHit(iEdg);
+						synapse_notified++;
+					}
+				}
+			}
 
-         hasFired_[idx] = false;
-      }
-   }
+			hasFired_[idx] = false;
+		}
+	}
 }
 
 ///  Fire the selected Neuron and calculate the result.
 ///
 ///  @param  index       Index of the Neuron to update.
 void AllSpikingNeurons::fire(const int index) const {
-   // Note that the neuron has fired!
-   hasFired_[index] = true;
+	// Note that the neuron has fired!
+	hasFired_[index] = true;
 
-   // record spike time
-   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
-   int idxSp = (spikeCount_[index] + spikeCountOffset_[index]) % maxSpikes;
-   spikeHistory_[index][idxSp] = g_simulationStep;
+	// record spike time
+	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int idxSp = (spikeCount_[index] + spikeCountOffset_[index]) % maxSpikes;
+	spikeHistory_[index][idxSp] = g_simulationStep;
 
-   // increment spike count and total spike count
-   spikeCount_[index]++;
+	// increment spike count and total spike count
+	spikeCount_[index]++;
 }
 
 ///  Get the spike history of neuron[index] at the location offIndex.
@@ -149,10 +147,10 @@ void AllSpikingNeurons::fire(const int index) const {
 ///  @param  index            Index of the neuron to get spike history.
 ///  @param  offIndex         Offset of the history buffer to get from.
 uint64_t AllSpikingNeurons::getSpikeHistory(int index, int offIndex) {
-   // offIndex is a minus offset
-   int maxSpikes = (int) ((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
-   int idxSp = (spikeCount_[index] + spikeCountOffset_[index] + maxSpikes + offIndex) % maxSpikes;
-   return spikeHistory_[index][idxSp];
+	// offIndex is a minus offset
+	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int idxSp = (spikeCount_[index] + spikeCountOffset_[index] + maxSpikes + offIndex) % maxSpikes;
+	return spikeHistory_[index][idxSp];
 }
 
 #endif

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -10,11 +10,7 @@
 #include "AllSpikingSynapses.h"
 
 // Default constructor
-AllSpikingNeurons::AllSpikingNeurons() : AllVertices() {
-	hasFired_ = nullptr;
-	spikeCount_ = nullptr;
-	spikeCountOffset_ = nullptr;
-	spikeHistory_ = nullptr;
+AllSpikingNeurons::AllSpikingNeurons() : AllVertices(), spikeHistory_(nullptr), spikeCountOffset_(nullptr), spikeCount_(nullptr), hasFired_(nullptr) {
 }
 
 AllSpikingNeurons::~AllSpikingNeurons() {

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -55,7 +55,8 @@ void AllSpikingNeurons::setupVertices() {
 
 ///  Clear the spike counts out of all Neurons.
 void AllSpikingNeurons::clearSpikeCounts() {
-	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = static_cast<int>((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().
+		getMaxFiringRate()));
 
 	for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
 		spikeCountOffset_[i] = (spikeCount_[i] + spikeCountOffset_[i]) % maxSpikes;
@@ -71,7 +72,8 @@ void AllSpikingNeurons::clearSpikeCounts() {
 ///  @param  synapses         The Synapse list to search from.
 ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
 void AllSpikingNeurons::advanceVertices(AllEdges& synapses, const EdgeIndexMap* edgeIndexMap) {
-	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = static_cast<int>((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().
+		getMaxFiringRate()));
 
 	auto& spSynapses = dynamic_cast<AllSpikingSynapses&>(synapses);
 	// For each neuron in the network
@@ -128,7 +130,8 @@ void AllSpikingNeurons::fire(const int index) const {
 	hasFired_[index] = true;
 
 	// record spike time
-	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = static_cast<int>((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().
+		getMaxFiringRate()));
 	int idxSp = (spikeCount_[index] + spikeCountOffset_[index]) % maxSpikes;
 	spikeHistory_[index][idxSp] = g_simulationStep;
 
@@ -148,7 +151,8 @@ void AllSpikingNeurons::fire(const int index) const {
 ///  @param  offIndex         Offset of the history buffer to get from.
 uint64_t AllSpikingNeurons::getSpikeHistory(int index, int offIndex) {
 	// offIndex is a minus offset
-	int maxSpikes = (int)((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().getMaxFiringRate()));
+	int maxSpikes = static_cast<int>((Simulator::getInstance().getEpochDuration() * Simulator::getInstance().
+		getMaxFiringRate()));
 	int idxSp = (spikeCount_[index] + spikeCountOffset_[index] + maxSpikes + offIndex) % maxSpikes;
 	return spikeHistory_[index][idxSp];
 }

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -105,12 +105,12 @@ class AllSpikingNeurons : public AllVertices {
 		///  Helper for #advanceNeuron. Updates state of a single neuron.
 		///
 		///  @param  index            Index of the neuron to update.
-		virtual void advanceNeuron(const int index) = 0;
+		virtual void advanceNeuron(int index) = 0;
 
 		///  Initiates a firing of a neuron to connected neurons
 		///
 		///  @param  index            Index of the neuron to fire.
-		virtual void fire(const int index) const;
+		virtual void fire(int index) const;
 
 #endif // defined(__CUDACC__)
 

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-using namespace std;
+ 
 
 #include "Global.h"
 #include "AllVertices.h"
@@ -44,7 +44,7 @@ public:
    ///  Clear the spike counts out of all Neurons.
    void clearSpikeCounts();
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
    public:
        ///  Set some parameters used for advanceVerticesDevice.
        ///
@@ -139,7 +139,7 @@ protected:
 
 };
 
-#if defined(USE_GPU)
+#ifdef __CUDACC__
 struct AllSpikingNeuronsDeviceProperties : public AllVerticesDeviceProperties
 {
         ///  The booleans which track whether the neuron has fired.

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -23,26 +23,25 @@
 
 #pragma once
 
- 
 
-#include "Global.h"
-#include "AllVertices.h"
 #include "AllSpikingSynapses.h"
+#include "AllVertices.h"
+#include "Global.h"
 
 struct AllSpikingNeuronsDeviceProperties;
 
 class AllSpikingNeurons : public AllVertices {
-public:
-   AllSpikingNeurons();
+	public:
+		AllSpikingNeurons();
 
-   virtual ~AllSpikingNeurons();
+		~AllSpikingNeurons() override;
 
-   ///  Setup the internal structure of the class.
-   ///  Allocate memories to store all neurons' state.
-   virtual void setupVertices() override;
+		///  Setup the internal structure of the class.
+		///  Allocate memories to store all neurons' state.
+		void setupVertices() override;
 
-   ///  Clear the spike counts out of all Neurons.
-   void clearSpikeCounts();
+		///  Clear the spike counts out of all Neurons.
+		void clearSpikeCounts();
 
 #ifdef __CUDACC__
    public:
@@ -84,58 +83,58 @@ public:
        ///
        ///  @param  allVerticesDevice   GPU address of the allVertices struct on device memory.
        void clearDeviceSpikeCounts( AllSpikingNeuronsDeviceProperties& allVerticesDevice);
-#else // !defined(USE_GPU)
+#else // !defined(__CUDACC__)
 
-public:
-   ///  Update internal state of the indexed Neuron (called by every simulation step).
-   ///  Notify outgoing synapses if neuron has fired.
-   ///
-   ///  @param  synapses         The Synapse list to search from.
-   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &synapses, const EdgeIndexMap *edgeIndexMap);
+	public:
+		///  Update internal state of the indexed Neuron (called by every simulation step).
+		///  Notify outgoing synapses if neuron has fired.
+		///
+		///  @param  synapses         The Synapse list to search from.
+		///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+		void advanceVertices(AllEdges& synapses, const EdgeIndexMap* edgeIndexMap) override;
 
-   /// Get the spike history of neuron[index] at the location offIndex.
-   /// More specifically, retrieves the global simulation time step for the spike
-   /// in question from the spike history record.
-   ///
-   /// @param  index            Index of the neuron to get spike history.
-   /// @param  offIndex         Offset of the history buffer to get from.
-   uint64_t getSpikeHistory(int index, int offIndex);
+		/// Get the spike history of neuron[index] at the location offIndex.
+		/// More specifically, retrieves the global simulation time step for the spike
+		/// in question from the spike history record.
+		///
+		/// @param  index            Index of the neuron to get spike history.
+		/// @param  offIndex         Offset of the history buffer to get from.
+		uint64_t getSpikeHistory(int index, int offIndex);
 
-protected:
-   ///  Helper for #advanceNeuron. Updates state of a single neuron.
-   ///
-   ///  @param  index            Index of the neuron to update.
-   virtual void advanceNeuron(const int index) = 0;
+	protected:
+		///  Helper for #advanceNeuron. Updates state of a single neuron.
+		///
+		///  @param  index            Index of the neuron to update.
+		virtual void advanceNeuron(const int index) = 0;
 
-   ///  Initiates a firing of a neuron to connected neurons
-   ///
-   ///  @param  index            Index of the neuron to fire.
-   virtual void fire(const int index) const;
+		///  Initiates a firing of a neuron to connected neurons
+		///
+		///  @param  index            Index of the neuron to fire.
+		virtual void fire(const int index) const;
 
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)
 
-public:
-   ///  The booleans which track whether the neuron has fired.
-   bool *hasFired_;
+	public:
+		///  The booleans which track whether the neuron has fired.
+		bool* hasFired_;
 
-   ///  The number of spikes since the last growth cycle.
-   int *spikeCount_;
+		///  The number of spikes since the last growth cycle.
+		int* spikeCount_;
 
-   ///  Offset of the spike_history buffer.
-   int *spikeCountOffset_;
+		///  Offset of the spike_history buffer.
+		int* spikeCountOffset_;
 
-   ///  Step count (history) for each spike fired by each neuron.
-   ///  The step counts are stored in a buffer for each neuron, and the pointers
-   ///  to the buffer are stored in a list pointed by spike_history.
-   ///  Each buffer is a circular, and offset of top location of the buffer i is
-   ///  specified by spikeCountOffset[i].
-   uint64_t **spikeHistory_;
+		///  Step count (history) for each spike fired by each neuron.
+		///  The step counts are stored in a buffer for each neuron, and the pointers
+		///  to the buffer are stored in a list pointed by spike_history.
+		///  Each buffer is a circular, and offset of top location of the buffer i is
+		///  specified by spikeCountOffset[i].
+		uint64_t** spikeHistory_;
 
-protected:
-   ///  True if back propagaion is allowed.
-   ///  (parameters used for advanceVerticesDevice.)
-   bool fAllowBackPropagation_;
+	protected:
+		///  True if back propagaion is allowed.
+		///  (parameters used for advanceVerticesDevice.)
+		bool fAllowBackPropagation_;
 
 };
 
@@ -158,4 +157,4 @@ struct AllSpikingNeuronsDeviceProperties : public AllVerticesDeviceProperties
         ///  specified by spikeCountOffset[i].
         uint64_t **spikeHistory_;
 };
-#endif // defined(USE_GPU)
+#endif // defined(__CUDACC__)

--- a/Simulator/Vertices/Neuro/AllVerticesDeviceFuncs_d.cu
+++ b/Simulator/Vertices/Neuro/AllVerticesDeviceFuncs_d.cu
@@ -236,10 +236,10 @@ __global__ void advanceIZHNeuronsDevice( int totalVertices, int maxEdges, int ma
                 BGSIZE synapseCounts = edgeIndexMapDevice->outgoingEdgeCount_[idx];
                 if (synapseCounts != 0) {
                     // get the index of where this neuron's list of synapses are
-                    BGSIZE beginIndex = edgeIndexMapDevice->outgoingEdgeBegin_[idx]; 
+                    BGSIZE beginIndex = edgeIndexMapDevice->outgoingEdgeBegin_[idx];
                     // get the memory location of where that list begins
                     BGSIZE* outgoingMapBegin = &(edgeIndexMapDevice->outgoingEdgeIndexMap_[beginIndex]);
-                   
+
                     // for each synapse, let them know we have fired
                     for (BGSIZE i = 0; i < synapseCounts; i++) {
                         preSpikingSynapsesSpikeHitDevice(outgoingMapBegin[i], allEdgesDevice);

--- a/Simulator/Vertices/VerticesFactory.cpp
+++ b/Simulator/Vertices/VerticesFactory.cpp
@@ -28,14 +28,14 @@ VerticesFactory::~VerticesFactory() {
 ///
 ///  @param  className  vertices class name.
 ///  @param  Pointer to the class creation function.
-void VerticesFactory::registerClass(const string &className, CreateFunction function) {
+void VerticesFactory::registerClass(const std::string &className, CreateFunction function) {
    createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired vertices class.
-shared_ptr<AllVertices> VerticesFactory::createVertices(const string &className) {
-   verticesInstance = shared_ptr<AllVertices>(invokeCreateFunction(className));
+std::shared_ptr<AllVertices> VerticesFactory::createVertices(const std::string &className) {
+   verticesInstance = std::shared_ptr<AllVertices>(invokeCreateFunction(className));
    return verticesInstance;
 }
 
@@ -43,7 +43,7 @@ shared_ptr<AllVertices> VerticesFactory::createVertices(const string &className)
 ///
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
-AllVertices *VerticesFactory::invokeCreateFunction(const string &className) {
+AllVertices *VerticesFactory::invokeCreateFunction(const std::string &className) {
    for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
       if (className == i->first)
          return i->second();

--- a/Simulator/Vertices/VerticesFactory.cpp
+++ b/Simulator/Vertices/VerticesFactory.cpp
@@ -42,8 +42,7 @@ std::shared_ptr<AllVertices> VerticesFactory::createVertices(const std::string& 
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
 AllVertices* VerticesFactory::invokeCreateFunction(const std::string& className) {
-	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-		if (className == i->first) return i->second();
-	}
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) if (className == i->first) return i->
+		second();
 	return nullptr;
 }

--- a/Simulator/Vertices/VerticesFactory.cpp
+++ b/Simulator/Vertices/VerticesFactory.cpp
@@ -8,45 +8,42 @@
 
 #include "VerticesFactory.h"
 
-#include "AllLIFNeurons.h"
-#include "AllIZHNeurons.h"
 #include "All911Vertices.h"
+#include "AllIZHNeurons.h"
+#include "AllLIFNeurons.h"
 
 /// Constructor is private to keep a singleton instance of this class.
 VerticesFactory::VerticesFactory() {
-   // register vertices classes
-   registerClass("AllLIFNeurons", &AllLIFNeurons::Create);
-   registerClass("AllIZHNeurons", &AllIZHNeurons::Create);
-   registerClass("All911Vertices", &All911Vertices::Create);
+	// register vertices classes
+	registerClass("AllLIFNeurons", &AllLIFNeurons::Create);
+	registerClass("AllIZHNeurons", &AllIZHNeurons::Create);
+	registerClass("All911Vertices", &All911Vertices::Create);
 }
 
-VerticesFactory::~VerticesFactory() {
-   createFunctions.clear();
-}
+VerticesFactory::~VerticesFactory() { createFunctions.clear(); }
 
 ///  Register vertices class and its creation function to the factory.
 ///
 ///  @param  className  vertices class name.
 ///  @param  Pointer to the class creation function.
-void VerticesFactory::registerClass(const std::string &className, CreateFunction function) {
-   createFunctions[className] = function;
+void VerticesFactory::registerClass(const std::string& className, CreateFunction function) {
+	createFunctions[className] = function;
 }
 
 
 /// Creates concrete instance of the desired vertices class.
-std::shared_ptr<AllVertices> VerticesFactory::createVertices(const std::string &className) {
-   verticesInstance = std::shared_ptr<AllVertices>(invokeCreateFunction(className));
-   return verticesInstance;
+std::shared_ptr<AllVertices> VerticesFactory::createVertices(const std::string& className) {
+	verticesInstance = std::shared_ptr<AllVertices>(invokeCreateFunction(className));
+	return verticesInstance;
 }
 
 /// Create an instance of the vertices class using the static ::Create() method.
 ///
 /// The calling method uses this retrieval mechanism in 
 /// value assignment.
-AllVertices *VerticesFactory::invokeCreateFunction(const std::string &className) {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
-   }
-   return nullptr;
+AllVertices* VerticesFactory::invokeCreateFunction(const std::string& className) {
+	for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
+		if (className == i->first) return i->second();
+	}
+	return nullptr;
 }

--- a/Simulator/Vertices/VerticesFactory.h
+++ b/Simulator/Vertices/VerticesFactory.h
@@ -15,7 +15,7 @@
 #include "Global.h"
 #include "AllVertices.h"
 
-using namespace std;
+ 
 
 class VerticesFactory {
 
@@ -28,7 +28,7 @@ public:
    }
 
    // Invokes constructor for desired concrete class
-   shared_ptr<AllVertices> createVertices(const string &className);
+   std::shared_ptr<AllVertices> createVertices(const std::string &className);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    VerticesFactory(VerticesFactory const &) = delete;
@@ -39,21 +39,21 @@ private:
    VerticesFactory();
 
    /// Pointer to vertices instance
-   shared_ptr<AllVertices> verticesInstance;
+   std::shared_ptr<AllVertices> verticesInstance;
 
    /* Type definitions */
    /// Defines function type for usage in internal map
-   typedef AllVertices *(*CreateFunction)(void);
+   using CreateFunction =  AllVertices *(*)();
 
    /// Defines map between class name and corresponding ::Create() function.
-   typedef map<string, CreateFunction> VerticesFunctionMap;
+   using VerticesFunctionMap =  std::map<std::string, CreateFunction>;
 
    /// Makes class-to-function map an internal factory member.
    VerticesFunctionMap createFunctions;
 
    /// Retrieves and invokes correct ::Create() function.
-   AllVertices *invokeCreateFunction(const string &className);
+   AllVertices *invokeCreateFunction(const std::string &className);
 
    /// Register vertex class and it's create function to the factory.
-   void registerClass(const string &className, CreateFunction function);
+   void registerClass(const std::string &className, CreateFunction function);
 };

--- a/Simulator/Vertices/VerticesFactory.h
+++ b/Simulator/Vertices/VerticesFactory.h
@@ -12,48 +12,47 @@
 #include <memory>
 #include <string>
 
-#include "Global.h"
 #include "AllVertices.h"
+#include "Global.h"
 
- 
 
 class VerticesFactory {
 
-public:
-   ~VerticesFactory();
+	public:
+		~VerticesFactory();
 
-   static VerticesFactory *getInstance() {
-      static VerticesFactory instance;
-      return &instance;
-   }
+		static VerticesFactory* getInstance() {
+			static VerticesFactory instance;
+			return &instance;
+		}
 
-   // Invokes constructor for desired concrete class
-   std::shared_ptr<AllVertices> createVertices(const std::string &className);
+		// Invokes constructor for desired concrete class
+		std::shared_ptr<AllVertices> createVertices(const std::string& className);
 
-   /// Delete these methods because they can cause copy instances of the singleton when using threads.
-   VerticesFactory(VerticesFactory const &) = delete;
-   void operator=(VerticesFactory const &) = delete;
+		/// Delete these methods because they can cause copy instances of the singleton when using threads.
+		VerticesFactory(const VerticesFactory&) = delete;
+		void operator=(const VerticesFactory&) = delete;
 
-private:
-   /// Constructor is private to keep a singleton instance of this class.
-   VerticesFactory();
+	private:
+		/// Constructor is private to keep a singleton instance of this class.
+		VerticesFactory();
 
-   /// Pointer to vertices instance
-   std::shared_ptr<AllVertices> verticesInstance;
+		/// Pointer to vertices instance
+		std::shared_ptr<AllVertices> verticesInstance;
 
-   /* Type definitions */
-   /// Defines function type for usage in internal map
-   using CreateFunction =  AllVertices *(*)();
+		/* Type definitions */
+		/// Defines function type for usage in internal map
+		using CreateFunction = AllVertices *(*)();
 
-   /// Defines map between class name and corresponding ::Create() function.
-   using VerticesFunctionMap =  std::map<std::string, CreateFunction>;
+		/// Defines map between class name and corresponding ::Create() function.
+		using VerticesFunctionMap = std::map<std::string, CreateFunction>;
 
-   /// Makes class-to-function map an internal factory member.
-   VerticesFunctionMap createFunctions;
+		/// Makes class-to-function map an internal factory member.
+		VerticesFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   AllVertices *invokeCreateFunction(const std::string &className);
+		/// Retrieves and invokes correct ::Create() function.
+		AllVertices* invokeCreateFunction(const std::string& className);
 
-   /// Register vertex class and it's create function to the factory.
-   void registerClass(const std::string &className, CreateFunction function);
+		/// Register vertex class and it's create function to the factory.
+		void registerClass(const std::string& className, CreateFunction function);
 };

--- a/Testing/Core/EdgeIndexMapTests.cpp
+++ b/Testing/Core/EdgeIndexMapTests.cpp
@@ -18,9 +18,7 @@ static int SYNAPSE_COUNT = 100;
 
 /// Testing object with initialized EdgeIndexMap. Used to reduce reused code.
 struct SynapseIndexMapTestObject : public testing::Test {
-    SynapseIndexMapTestObject() {
-        edgeIndexMap = new EdgeIndexMap(VERTEX_COUNT, SYNAPSE_COUNT);
-    }
+    SynapseIndexMapTestObject() : edgeIndexMap(new EdgeIndexMap(VERTEX_COUNT, SYNAPSE_COUNT)) { }
     
     ~SynapseIndexMapTestObject() {
        delete edgeIndexMap;

--- a/ThirdParty/log4cplus-2.0.2/msvc14/CLFSAppender.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/CLFSAppender.vcxproj
@@ -44,52 +44,52 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/MSTTSAppender.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/MSTTSAppender.vcxproj
@@ -44,52 +44,52 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/Qt4DebugAppender.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/Qt4DebugAppender.vcxproj
@@ -44,52 +44,52 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/Qt5DebugAppender.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/Qt5DebugAppender.vcxproj
@@ -44,52 +44,52 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/log4cplus.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/log4cplus.vcxproj
@@ -44,52 +44,52 @@
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/log4cplusS.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/log4cplusS.vcxproj
@@ -43,49 +43,49 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ThirdParty/log4cplus-2.0.2/msvc14/loggingserver.vcxproj
+++ b/ThirdParty/log4cplus-2.0.2/msvc14/loggingserver.vcxproj
@@ -43,51 +43,51 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Unicode|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Unicode|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
# PLEASE DO NOT TRY TO ACTUALLY MERGE THIS INTO MASTER YET FOR THE LOVE OF GOD : ) <3

I'm just posting my fork's current work in trying to get Windows supported for Graphitti. 
Some main changes so far, at the time of writing:
- As of #302 , I removed all `using namespace std;` usages as a temporary fix to the old Windows SDK C++17 breaking change - I expect that in a future iteration, we should just attempt to remove using `windows.h`  in `Timer.h` and see if we can move forth with reintroducing `using namespace std;`.
- Moved some constructor assignments into the respective initializer lists instead. 
- changed plain `enum`s to `enum class`es for stronger type checking.
- Changed `USE_GPU` to `__CUDACC__` because _I'm pretty sure_ the latter macro is a way to discern between CUDA/Non-CUDA applications already provided by NVIDIA. 

This build currently doesn't compile on Windows because of the third task point in #302 - for those interested in trying this build out, generate the windows .lib of `log4cplus` with MSVC and link it manually : ). I'm 90% sure none of the changes I introduced so far have affected the Linux build though.

Not implemented in yet is:
- #303 (experimental, will only move forward if there is a general consensus for me to try)
- #304 (same as ^) 