### PR TITLE
Manually publishing gh-pages no longer destroys Doxygen files

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2
+      - name: Generate Doxygen
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: docs/Doxygen/Doxyfile
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docs/Developer/GHActions.md
+++ b/docs/Developer/GHActions.md
@@ -2,17 +2,13 @@
 
 This page is dedicated to documentation of any automation files found within the [.github/workflows](https://github.com/UWB-Biocomputing/Graphitti/tree/master/.github/workflows) folder.
 
-## Doxygen Action gh-pages.yml
+## Doxygen and GitHub Pages Action gh-pages.yml
 
 This action is Triggered on a monthly schedule. At the first of every month the doxygen documentation will be regenerated so that any new changes will be updated to the GitHub pages. First, it checks-out the repository using [actions/checkout](https://github.com/actions/checkout). Next, the doxygen files are regenerated using [mattnotmitt/doxygen-action](https://github.com/mattnotmitt/doxygen-action). Lastly, the gh-pages branch is updated with the new docs folder and published using the [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) action. When this is done, the branch is committed as an orphan to keep the branch as clean as possible.
 
-## GitHub Pages Action gh-pages.yml
-
-The GitHub Pages action happens in within the same script as the doxygen action. The gh-pages branch is updated with the docs folder from the master branch on the first of the month. Then those changes are published together.
-
 ## Manual GitHub Pages Action publish-gh-pages.yml
 
-The manual GitHub Pages action is a feature that came from wanting to quickly publish changes to markdown files in our docs folder. This action activates when the button within the actions tab is toggled. Once toggled, it will take the docs files from the master branch and publish them to the gh-pages branch as a forced orphan just like in the gh-pages.yml workflow.
+The manual GitHub Pages action is a feature that came from wanting to quickly publish changes to documentation files in our docs folder. This action is activated by navigating to the actions tab, selecting the "Publish GitHub Pages Manually" workflow, then toggling the run workflow button on the desired branch. The branch to run this action on will typically be the master branch as that is the one with the most up to date documentation. Once toggled, it will take the docs files from the selected branch and publish them to the gh-pages branch as a forced orphan just like in the gh-pages.yml workflow. This action will also regenerate the Doxygen files in the same way the gh-pages.yml script does. This is done because other branches doesn't hold the Doxygen/html files and would lose this information if not regenerated during this script.
 
 ## PlantUML Action plantUML.yml
 

--- a/docs/Developer/GHPages.md
+++ b/docs/Developer/GHPages.md
@@ -10,7 +10,7 @@ When making edits and changes to the GitHub Pages, you'll create a new feature b
 
 We use markdown files in order to render our documentation in a web browser. These files follow a relatively simple syntax of which a guide can be found [here](https://www.markdownguide.org/basic-syntax/) for.
 
-Once you've completed your edits and changes, commit them to the branch and obtain approval for merger. The changes will not be visible from the gh-pages branch until the first of the month as per our automation script that publishes the updated pages. Once merged though, the changes should be seen in the master branch.
+Once you've completed your edits and changes, commit them to the branch and obtain approval for merger. The changes will not be visible from the gh-pages branch until the first of the month unless you use the publish-gh-pages.yml script which can manually publish the documentation for you. Once merged though, the changes should be seen in the master branch. Find more information on these GitHub Actions [here](GHActions.md#doxygen-and-github-pages-action-gh-pagesyml) and [here](GHActions.md#manual-github-pages-action-publish-gh-pagesyml). 
 
 ## What is the gh-pages Branch?
 


### PR DESCRIPTION
Manually publishing the gh-pages using the manual-gh-pages.yml action no longer destroys the Doxygen files. Now, all Doxygen files are regenerated during this action. This allows for the gh-pages branch to stay clean and organized without a commit history while also making sure to publish and maintain all relevant documentation and Doxygen files.