### PR TITLE
Factory cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,12 @@ add_executable(tests
         Testing/Core/FunctionNodeTests.cpp
         Testing/Core/SimulatorTests.cpp
         Testing/Core/OperationManagerTestingClass.h
+        Testing/Core/VerticesFactoryTests.cpp
+        Testing/Core/ConnectionsFactoryTests.cpp
+        Testing/Core/EdgesFactoryTests.cpp
+        Testing/Core/LayoutFactoryTests.cpp
+        Testing/Core/RecorderFactoryTests.cpp
+        Testing/Core/RNGFactoryTests.cpp
         Testing/Utils/ParameterManagerTests.cpp)
 
 # Links the Googletest framework with the testing executable

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -27,7 +27,7 @@ Connections::Connections()
    // Create Edges/Synapses class using type definition in configuration file
    string type;
    ParameterManager::getInstance().getStringByXpath("//EdgesParams/@class", type);
-   edges_ = EdgesFactory::getInstance()->createEdges(type);
+   edges_ = EdgesFactory::getInstance().createEdges(type);
 
    // Register printParameters function as a printParameters operation in the OperationManager
    function<void()> printParametersFunc = bind(&Connections::printParameters, this);

--- a/Simulator/Connections/ConnectionsFactory.cpp
+++ b/Simulator/Connections/ConnectionsFactory.cpp
@@ -46,10 +46,8 @@ shared_ptr<Connections> ConnectionsFactory::createConnections(const string &clas
 {
    auto createConnectionsIter = createFunctions.find(className);
    if (createConnectionsIter != createFunctions.end()) {
-      connectionsInstance = shared_ptr<Connections>(createConnectionsIter->second());
-   } else {
-      connectionsInstance = nullptr;
+      return shared_ptr<Connections>(createConnectionsIter->second());
    }
 
-   return connectionsInstance;
+   return nullptr;
 }

--- a/Simulator/Connections/ConnectionsFactory.cpp
+++ b/Simulator/Connections/ConnectionsFactory.cpp
@@ -15,7 +15,7 @@
 /// Constructor is private to keep a singleton instance of this class.
 ConnectionsFactory::ConnectionsFactory()
 {
-   // register neurons classes
+   // register connections classes
    registerClass("ConnStatic", &ConnStatic::Create);
    registerClass("ConnGrowth", &ConnGrowth::Create);
    registerClass("Connections911", &Connections911::Create);
@@ -29,8 +29,8 @@ ConnectionsFactory::~ConnectionsFactory()
 
 ///  Register connections class and its creation function to the factory.
 ///
-///  @param  className class name.
-///  @param  Pointer to the class creation function.
+///  @param  className  Class name.
+///  @param  function   Pointer to the class creation function.
 void ConnectionsFactory::registerClass(const string &className, CreateFunction function)
 {
    createFunctions[className] = function;
@@ -38,21 +38,18 @@ void ConnectionsFactory::registerClass(const string &className, CreateFunction f
 
 
 /// Creates concrete instance of the desired connections class.
+///
+/// @param className Connections class name.
+/// @return Shared pointer to connections instance if className is found in
+///         createFunctions map, nullptr otherwise.
 shared_ptr<Connections> ConnectionsFactory::createConnections(const string &className)
 {
-   connectionsInstance = shared_ptr<Connections>(invokeCreateFunction(className));
-   return connectionsInstance;
-}
-
-/// Create an instance of the connections class using the static ::Create() method.
-///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-Connections *ConnectionsFactory::invokeCreateFunction(const string &className)
-{
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createConnectionsIter = createFunctions.find(className);
+   if (createConnectionsIter != createFunctions.end()) {
+      connectionsInstance = shared_ptr<Connections>(createConnectionsIter->second());
+   } else {
+      connectionsInstance = nullptr;
    }
-   return nullptr;
+
+   return connectionsInstance;
 }

--- a/Simulator/Connections/ConnectionsFactory.h
+++ b/Simulator/Connections/ConnectionsFactory.h
@@ -49,9 +49,6 @@ private:
    /// Makes class-to-function map an internal factory member.
    ConnectionsFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   Connections *invokeCreateFunction(const string &className);
-
    /// Register connection class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);
 };

--- a/Simulator/Connections/ConnectionsFactory.h
+++ b/Simulator/Connections/ConnectionsFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    ConnectionsFactory();
 
-   /// Pointer to connections instance.
-   shared_ptr<Connections> connectionsInstance;
-
    /// Defines function type for usage in internal map
    typedef Connections *(*CreateFunction)(void);
 

--- a/Simulator/Connections/ConnectionsFactory.h
+++ b/Simulator/Connections/ConnectionsFactory.h
@@ -20,10 +20,10 @@ class ConnectionsFactory {
 public:
    ~ConnectionsFactory();
 
-   static ConnectionsFactory *getInstance()
+   static ConnectionsFactory &getInstance()
    {
       static ConnectionsFactory instance;
-      return &instance;
+      return instance;
    }
 
    /// Invokes constructor for desired concrete class

--- a/Simulator/Connections/NG911/Connections911.h
+++ b/Simulator/Connections/NG911/Connections911.h
@@ -48,7 +48,7 @@ public:
    virtual void printParameters() const override;
 
    /// Records typeMap history for recorders
-   vertexType *oldTypeMap_;
+   vertexType *oldTypeMap_ = nullptr;
 
 private:
    /// number of maximum connections per vertex

--- a/Simulator/Core/Driver.cpp
+++ b/Simulator/Core/Driver.cpp
@@ -171,8 +171,6 @@ int main(int argc, char *argv[])
       simulator.getModel()->getRecorder()->term();
    }
 
-   delete noiseRNG;
-
    time(&end_time);
    double timeElapsed = difftime(end_time, start_time);
    double ssps = simulator.getEpochDuration() * simulator.getNumEpochs() / timeElapsed;

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -30,15 +30,15 @@ Model::Model()
 
    // Create Layout class using type definition from configuration file.
    ParameterManager::getInstance().getStringByXpath("//LayoutParams/@class", type);
-   layout_ = LayoutFactory::getInstance()->createLayout(type);
+   layout_ = LayoutFactory::getInstance().createLayout(type);
 
    // Create Connections class using type definition from configuration file.
    ParameterManager::getInstance().getStringByXpath("//ConnectionsParams/@class", type);
-   connections_ = ConnectionsFactory::getInstance()->createConnections(type);
+   connections_ = ConnectionsFactory::getInstance().createConnections(type);
 
    // Create Recorder class using type definition from configuration file.
    ParameterManager::getInstance().getStringByXpath("//RecorderParams/@class", type);
-   recorder_ = RecorderFactory::getInstance()->createRecorder(type);
+   recorder_ = RecorderFactory::getInstance().createRecorder(type);
 
    // Get a copy of the file logger to use log4cplus macros
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -97,7 +97,7 @@ void Simulator::loadParameters()
    // Instantiate rng object
    string type;
    ParameterManager::getInstance().getStringByXpath("//RNGConfig/NoiseRNGSeed/@class", type);
-   noiseRNG = RNGFactory::getInstance()->createRNG(type);
+   noiseRNG = RNGFactory::getInstance().createRNG(type);
 
    ParameterManager::getInstance().getLongByXpath("//RNGConfig/InitRNGSeed/text()", initRngSeed_);
    ParameterManager::getInstance().getLongByXpath("//RNGConfig/NoiseRNGSeed/text()", noiseRngSeed_);

--- a/Simulator/Edges/EdgesFactory.cpp
+++ b/Simulator/Edges/EdgesFactory.cpp
@@ -16,7 +16,7 @@
 /// Constructor is private to keep a singleton instance of this class.
 EdgesFactory::EdgesFactory()
 {
-   // register neurons classes
+   // register edges classes
    registerClass("AllSpikingSynapses", &AllSpikingSynapses::Create);
    registerClass("AllSTDPSynapses", &AllSTDPSynapses::Create);
    registerClass("AllDSSynapses", &AllDSSynapses::Create);
@@ -31,30 +31,27 @@ EdgesFactory::~EdgesFactory()
 
 ///  Register edges class and its creation function to the factory.
 ///
-///  @param  className  neurons class name.
-///  @param  Pointer to the class creation function.
+///  @param  className  Edges class name.
+///  @param  function   Pointer to the class creation function.
 void EdgesFactory::registerClass(const string &className, CreateFunction function)
 {
    createFunctions[className] = function;
 }
 
 
-/// Creates concrete instance of the desired neurons class.
+/// Creates concrete instance of the desired edges class.
+///
+/// @param className Edges class name.
+/// @return Shared pointer to edges intance if className is found in
+///         createFunctions map, nullptr otherwise.
 shared_ptr<AllEdges> EdgesFactory::createEdges(const string &className)
 {
-   edgesInstance_ = shared_ptr<AllEdges>(invokeCreateFunction(className));
-   return edgesInstance_;
-}
-
-/// Create an instance of the edges class using the static ::Create() method.
-///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-AllEdges *EdgesFactory::invokeCreateFunction(const string &className)
-{
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createEdgesIter = createFunctions.find(className);
+   if (createEdgesIter != createFunctions.end()) {
+      edgesInstance_ = shared_ptr<AllEdges>(createEdgesIter->second());
+   } else {
+      edgesInstance_ = nullptr;
    }
-   return nullptr;
+
+   return edgesInstance_;
 }

--- a/Simulator/Edges/EdgesFactory.cpp
+++ b/Simulator/Edges/EdgesFactory.cpp
@@ -48,10 +48,8 @@ shared_ptr<AllEdges> EdgesFactory::createEdges(const string &className)
 {
    auto createEdgesIter = createFunctions.find(className);
    if (createEdgesIter != createFunctions.end()) {
-      edgesInstance_ = shared_ptr<AllEdges>(createEdgesIter->second());
-   } else {
-      edgesInstance_ = nullptr;
+      return shared_ptr<AllEdges>(createEdgesIter->second());
    }
 
-   return edgesInstance_;
+   return nullptr;
 }

--- a/Simulator/Edges/EdgesFactory.h
+++ b/Simulator/Edges/EdgesFactory.h
@@ -49,9 +49,6 @@ private:
    /// Makes class-to-function map an internal factory member.
    EdgesFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   AllEdges *invokeCreateFunction(const string &className);
-
    /// Register edges class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);
 };

--- a/Simulator/Edges/EdgesFactory.h
+++ b/Simulator/Edges/EdgesFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    EdgesFactory();
 
-   /// Pointer to edges instance
-   shared_ptr<AllEdges> edgesInstance_;
-
    /// Defines function type for usage in internal map
    typedef AllEdges *(*CreateFunction)(void);
 

--- a/Simulator/Edges/EdgesFactory.h
+++ b/Simulator/Edges/EdgesFactory.h
@@ -20,10 +20,10 @@ class EdgesFactory {
 public:
    ~EdgesFactory();
 
-   static EdgesFactory *getInstance()
+   static EdgesFactory &getInstance()
    {
       static EdgesFactory instance;
-      return &instance;
+      return instance;
    }
 
    // Invokes constructor for desired concrete class

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -27,7 +27,7 @@ Layout::Layout() : numEndogenouslyActiveNeurons_(0), gridLayout_(true)
    // Create Vertices/Neurons class using type definition in configuration file
    string type;
    ParameterManager::getInstance().getStringByXpath("//VerticesParams/@class", type);
-   vertices_ = VerticesFactory::getInstance()->createVertices(type);
+   vertices_ = VerticesFactory::getInstance().createVertices(type);
 
    // Register loadParameters function as a loadParameters operation in the Operation Manager
    function<void()> loadParametersFunc = std::bind(&Layout::loadParameters, this);

--- a/Simulator/Layouts/LayoutFactory.cpp
+++ b/Simulator/Layouts/LayoutFactory.cpp
@@ -27,8 +27,8 @@ LayoutFactory::~LayoutFactory()
 
 ///  Register layout class and its creation function to the factory.
 ///
-///  @param  className  vertices class name.
-///  @param  Pointer to the class creation function.
+///  @param  className  Layout class name.
+///  @param  function Pointer to the class creation function.
 void LayoutFactory::registerClass(const string &className, CreateFunction function)
 {
    createFunctions[className] = function;
@@ -36,21 +36,18 @@ void LayoutFactory::registerClass(const string &className, CreateFunction functi
 
 
 /// Creates concrete instance of the desired layout class.
+///
+/// @param className Layout class name.
+/// @return Shared pointer to layout instance if className is found in
+///         createFunctions map, nullptr otherwise.
 shared_ptr<Layout> LayoutFactory::createLayout(const string &className)
 {
-   layoutInstance = shared_ptr<Layout>(invokeCreateFunction(className));
-   return layoutInstance;
-}
-
-/// Create an instance of the layout class using the static ::Create() method.
-///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-Layout *LayoutFactory::invokeCreateFunction(const string &className)
-{
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createLayoutIter = createFunctions.find(className);
+   if (createLayoutIter != createFunctions.end()) {
+      layoutInstance = shared_ptr<Layout>(createLayoutIter->second());
+   } else {
+      layoutInstance = nullptr;
    }
-   return nullptr;
+
+   return layoutInstance;
 }

--- a/Simulator/Layouts/LayoutFactory.cpp
+++ b/Simulator/Layouts/LayoutFactory.cpp
@@ -44,10 +44,8 @@ shared_ptr<Layout> LayoutFactory::createLayout(const string &className)
 {
    auto createLayoutIter = createFunctions.find(className);
    if (createLayoutIter != createFunctions.end()) {
-      layoutInstance = shared_ptr<Layout>(createLayoutIter->second());
-   } else {
-      layoutInstance = nullptr;
+      return shared_ptr<Layout>(createLayoutIter->second());
    }
 
-   return layoutInstance;
+   return nullptr;
 }

--- a/Simulator/Layouts/LayoutFactory.h
+++ b/Simulator/Layouts/LayoutFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    LayoutFactory();
 
-   /// Smart pointer to layout instance
-   shared_ptr<Layout> layoutInstance;
-
    /// Defines function type for usage in internal map
    typedef Layout *(*CreateFunction)(void);
 

--- a/Simulator/Layouts/LayoutFactory.h
+++ b/Simulator/Layouts/LayoutFactory.h
@@ -20,10 +20,10 @@ class LayoutFactory {
 public:
    ~LayoutFactory();
 
-   static LayoutFactory *getInstance()
+   static LayoutFactory &getInstance()
    {
       static LayoutFactory instance;
-      return &instance;
+      return instance;
    }
 
    // Invokes constructor for desired concrete class

--- a/Simulator/Layouts/LayoutFactory.h
+++ b/Simulator/Layouts/LayoutFactory.h
@@ -49,9 +49,6 @@ private:
    /// Makes class-to-function map an internal factory member.
    LayoutFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   Layout *invokeCreateFunction(const string &className);
-
    /// Register neuron class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);
 };

--- a/Simulator/Recorders/RecorderFactory.cpp
+++ b/Simulator/Recorders/RecorderFactory.cpp
@@ -51,10 +51,8 @@ shared_ptr<IRecorder> RecorderFactory::createRecorder(const string &className)
 {
    auto createRecorderIter = createFunctions.find(className);
    if (createRecorderIter != createFunctions.end()) {
-      recorderInstance = shared_ptr<IRecorder>(createRecorderIter->second());
-   } else {
-      recorderInstance = nullptr;
+      return shared_ptr<IRecorder>(createRecorderIter->second());
    }
 
-   return recorderInstance;
+   return nullptr;
 }

--- a/Simulator/Recorders/RecorderFactory.cpp
+++ b/Simulator/Recorders/RecorderFactory.cpp
@@ -34,8 +34,8 @@ RecorderFactory::~RecorderFactory()
 
 ///  Register recorder class and its creation function to the factory.
 ///
-///  @param  className  vertices class name.
-///  @param  Pointer to the class creation function.
+///  @param  className  recorder class name.
+///  @param  function Pointer to the class creation function.
 void RecorderFactory::registerClass(const string &className, CreateFunction function)
 {
    createFunctions[className] = function;
@@ -43,21 +43,18 @@ void RecorderFactory::registerClass(const string &className, CreateFunction func
 
 
 /// Creates concrete instance of the desired recorder class.
+///
+/// @param className Recorder class name.
+/// @return Shared pointer to recorder instance if className is found in
+///         createFunctions map, nullptr otherwise.
 shared_ptr<IRecorder> RecorderFactory::createRecorder(const string &className)
 {
-   recorderInstance = shared_ptr<IRecorder>(invokeCreateFunction(className));
-   return recorderInstance;
-}
-
-/// Create an instance of the vertices class using the static ::Create() method.
-///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-IRecorder *RecorderFactory::invokeCreateFunction(const string &className)
-{
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createRecorderIter = createFunctions.find(className);
+   if (createRecorderIter != createFunctions.end()) {
+      recorderInstance = shared_ptr<IRecorder>(createRecorderIter->second());
+   } else {
+      recorderInstance = nullptr;
    }
-   return nullptr;
+
+   return recorderInstance;
 }

--- a/Simulator/Recorders/RecorderFactory.h
+++ b/Simulator/Recorders/RecorderFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    RecorderFactory();
 
-   /// Pointer to neurons instance
-   shared_ptr<IRecorder> recorderInstance;
-
    /// Defines function type for usage in internal map
    typedef IRecorder *(*CreateFunction)(void);
 

--- a/Simulator/Recorders/RecorderFactory.h
+++ b/Simulator/Recorders/RecorderFactory.h
@@ -49,9 +49,6 @@ private:
    /// Makes class-to-function map an internal factory member.
    RecorderFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   IRecorder *invokeCreateFunction(const string &className);
-
    /// Register neuron class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);
 };

--- a/Simulator/Recorders/RecorderFactory.h
+++ b/Simulator/Recorders/RecorderFactory.h
@@ -20,10 +20,10 @@ class RecorderFactory {
 public:
    ~RecorderFactory();
 
-   static RecorderFactory *getInstance()
+   static RecorderFactory &getInstance()
    {
       static RecorderFactory instance;
-      return &instance;
+      return instance;
    }
 
    // Invokes constructor for desired concrete class

--- a/Simulator/Utils/Global.cpp
+++ b/Simulator/Utils/Global.cpp
@@ -77,7 +77,7 @@ int g_deviceId = 0;
 MTRand initRNG;
 
 // A normalized random number generator.
-MTRand *noiseRNG;
+shared_ptr<MTRand> noiseRNG;
 
 //		simulation vars
 uint64_t g_simulationStep = 0;

--- a/Simulator/Utils/Global.h
+++ b/Simulator/Utils/Global.h
@@ -53,6 +53,7 @@
 extern int g_debug_mask;
 
    #include <cassert>
+   #include <memory>
    #include <sstream>
    #ifdef _WIN32   //needs to be before #include "bgtypes.h" or the #define BGFLOAT will cause problems
       #include <windows.h>                 //warning! windows.h also defines BGFLOAT
@@ -64,7 +65,6 @@ typedef unsigned long long int uint64_t;   //included in inttypes.h, which is no
    //#include "Norm.h"
    #include "Coordinate.h"
    #include "VectorMatrix.h"
-   #include "memory"
 
 using namespace std;
 

--- a/Simulator/Utils/Global.h
+++ b/Simulator/Utils/Global.h
@@ -54,7 +54,6 @@ extern int g_debug_mask;
 
    #include <cassert>
    #include <sstream>
-   #include <vector>
    #ifdef _WIN32   //needs to be before #include "bgtypes.h" or the #define BGFLOAT will cause problems
       #include <windows.h>                 //warning! windows.h also defines BGFLOAT
 typedef unsigned long long int uint64_t;   //included in inttypes.h, which is not available in WIN32
@@ -65,6 +64,7 @@ typedef unsigned long long int uint64_t;   //included in inttypes.h, which is no
    //#include "Norm.h"
    #include "Coordinate.h"
    #include "VectorMatrix.h"
+   #include "memory"
 
 using namespace std;
 
@@ -83,7 +83,7 @@ extern const BGFLOAT pi;
 extern MTRand initRNG;
 
 // A normalized random number generator.
-extern MTRand *noiseRNG;
+extern shared_ptr<MTRand> noiseRNG;
 
 // The current simulation step.
 extern uint64_t g_simulationStep;

--- a/Simulator/Utils/RNG/RNGFactory.cpp
+++ b/Simulator/Utils/RNG/RNGFactory.cpp
@@ -34,20 +34,15 @@ void RNGFactory::registerClass(const string &className, CreateFunction function)
 
 
 /// Creates concrete instance of the desired rng class.
-MTRand *RNGFactory::createRNG(const string &className)
-{
-   return invokeCreateFunction(className);
-}
-
-/// Create an instance of the rng class using the static ::Create() method.
 ///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-MTRand *RNGFactory::invokeCreateFunction(const string &className)
+/// @param className rng class name.
+/// @return Shared pointer to RNG instance if className is found in
+///         createFunctions map, nullptr otherwise.
+shared_ptr<MTRand> RNGFactory::createRNG(const string &className)
 {
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createRNGIter = createFunctions.find(className);
+   if (createRNGIter != createFunctions.end()) {
+      return shared_ptr<MTRand>(createRNGIter->second());
    }
    return nullptr;
 }

--- a/Simulator/Utils/RNG/RNGFactory.h
+++ b/Simulator/Utils/RNG/RNGFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    RNGFactory();
 
-   /// Pointer to rng instance
-   shared_ptr<MTRand> rngInstance;
-
    /* Type definitions */
    /// Defines function type for usage in internal map
    typedef MTRand *(*CreateFunction)(void);

--- a/Simulator/Utils/RNG/RNGFactory.h
+++ b/Simulator/Utils/RNG/RNGFactory.h
@@ -27,7 +27,7 @@ public:
    }
 
    // Invokes constructor for desired concrete class
-   MTRand *createRNG(const string &className);
+   shared_ptr<MTRand> createRNG(const string &className);
 
    /// Delete these methods because they can cause copy instances of the singleton when using threads.
    RNGFactory(RNGFactory const &) = delete;
@@ -49,9 +49,6 @@ private:
 
    /// Makes class-to-function map an internal factory member.
    RNGFunctionMap createFunctions;
-
-   /// Retrieves and invokes correct ::Create() function.
-   MTRand *invokeCreateFunction(const string &className);
 
    /// Register rng class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);

--- a/Simulator/Utils/RNG/RNGFactory.h
+++ b/Simulator/Utils/RNG/RNGFactory.h
@@ -20,10 +20,10 @@ class RNGFactory {
 public:
    ~RNGFactory();
 
-   static RNGFactory *getInstance()
+   static RNGFactory &getInstance()
    {
       static RNGFactory instance;
-      return &instance;
+      return instance;
    }
 
    // Invokes constructor for desired concrete class

--- a/Simulator/Vertices/VerticesFactory.cpp
+++ b/Simulator/Vertices/VerticesFactory.cpp
@@ -44,10 +44,8 @@ shared_ptr<AllVertices> VerticesFactory::createVertices(const string &className)
 {
    auto createVerticesIter = createFunctions.find(className);
    if (createVerticesIter != createFunctions.end()) {
-      verticesInstance = shared_ptr<AllVertices>(createVerticesIter->second());
-   } else {
-      verticesInstance = nullptr;
+      return shared_ptr<AllVertices>(createVerticesIter->second());
    }
 
-   return verticesInstance;
+   return nullptr;
 }

--- a/Simulator/Vertices/VerticesFactory.cpp
+++ b/Simulator/Vertices/VerticesFactory.cpp
@@ -27,8 +27,8 @@ VerticesFactory::~VerticesFactory()
 
 ///  Register vertices class and its creation function to the factory.
 ///
-///  @param  className  vertices class name.
-///  @param  Pointer to the class creation function.
+///  @param  className  Vertices class name.
+///  @param  function   Pointer to the class creation function.
 void VerticesFactory::registerClass(const string &className, CreateFunction function)
 {
    createFunctions[className] = function;
@@ -36,21 +36,18 @@ void VerticesFactory::registerClass(const string &className, CreateFunction func
 
 
 /// Creates concrete instance of the desired vertices class.
+///
+/// @param className Vertices class name.
+/// @return Shared pointer to vertices instance if className is found in
+///         createFunctions map, nullptr otherwise.
 shared_ptr<AllVertices> VerticesFactory::createVertices(const string &className)
 {
-   verticesInstance = shared_ptr<AllVertices>(invokeCreateFunction(className));
-   return verticesInstance;
-}
-
-/// Create an instance of the vertices class using the static ::Create() method.
-///
-/// The calling method uses this retrieval mechanism in
-/// value assignment.
-AllVertices *VerticesFactory::invokeCreateFunction(const string &className)
-{
-   for (auto i = createFunctions.begin(); i != createFunctions.end(); ++i) {
-      if (className == i->first)
-         return i->second();
+   auto createVerticesIter = createFunctions.find(className);
+   if (createVerticesIter != createFunctions.end()) {
+      verticesInstance = shared_ptr<AllVertices>(createVerticesIter->second());
+   } else {
+      verticesInstance = nullptr;
    }
-   return nullptr;
+
+   return verticesInstance;
 }

--- a/Simulator/Vertices/VerticesFactory.h
+++ b/Simulator/Vertices/VerticesFactory.h
@@ -20,10 +20,10 @@ class VerticesFactory {
 public:
    ~VerticesFactory();
 
-   static VerticesFactory *getInstance()
+   static VerticesFactory &getInstance()
    {
       static VerticesFactory instance;
-      return &instance;
+      return instance;
    }
 
    // Invokes constructor for desired concrete class

--- a/Simulator/Vertices/VerticesFactory.h
+++ b/Simulator/Vertices/VerticesFactory.h
@@ -37,9 +37,6 @@ private:
    /// Constructor is private to keep a singleton instance of this class.
    VerticesFactory();
 
-   /// Pointer to vertices instance
-   shared_ptr<AllVertices> verticesInstance;
-
    /* Type definitions */
    /// Defines function type for usage in internal map
    typedef AllVertices *(*CreateFunction)(void);

--- a/Simulator/Vertices/VerticesFactory.h
+++ b/Simulator/Vertices/VerticesFactory.h
@@ -50,9 +50,6 @@ private:
    /// Makes class-to-function map an internal factory member.
    VerticesFunctionMap createFunctions;
 
-   /// Retrieves and invokes correct ::Create() function.
-   AllVertices *invokeCreateFunction(const string &className);
-
    /// Register vertex class and it's create function to the factory.
    void registerClass(const string &className, CreateFunction function);
 };

--- a/Testing/Core/ConnectionsFactoryTests.cpp
+++ b/Testing/Core/ConnectionsFactoryTests.cpp
@@ -9,45 +9,45 @@
  * we are requesting.
  */
 
-#include "ConnectionsFactory.h"
 #include "ConnGrowth.h"
 #include "ConnStatic.h"
 #include "Connections911.h"
+#include "ConnectionsFactory.h"
 #include "gtest/gtest.h"
 
 TEST(ConnectionsFactory, GetInstanceReturnsInstance)
 {
-    ConnectionsFactory *connectionsFactory = &ConnectionsFactory::getInstance();
-    ASSERT_NE(nullptr, connectionsFactory);
+   ConnectionsFactory *connectionsFactory = &ConnectionsFactory::getInstance();
+   ASSERT_NE(nullptr, connectionsFactory);
 }
 
 TEST(ConnectionsFactory, CreateConnstaticInstance)
 {
-    shared_ptr<Connections> connections =
-            ConnectionsFactory::getInstance().createConnections("ConnStatic");
-    ASSERT_NE(nullptr, connections);
-    ASSERT_NE(nullptr, dynamic_cast<ConnStatic *>(connections.get()));
+   shared_ptr<Connections> connections
+      = ConnectionsFactory::getInstance().createConnections("ConnStatic");
+   ASSERT_NE(nullptr, connections);
+   ASSERT_NE(nullptr, dynamic_cast<ConnStatic *>(connections.get()));
 }
 
 TEST(ConnectionsFactory, CreateConnGrowthInstance)
 {
-    shared_ptr<Connections> connections =
-            ConnectionsFactory::getInstance().createConnections("ConnGrowth");
-    ASSERT_NE(nullptr, connections);
-    ASSERT_NE(nullptr, dynamic_cast<ConnGrowth *>(connections.get()));
+   shared_ptr<Connections> connections
+      = ConnectionsFactory::getInstance().createConnections("ConnGrowth");
+   ASSERT_NE(nullptr, connections);
+   ASSERT_NE(nullptr, dynamic_cast<ConnGrowth *>(connections.get()));
 }
 
 TEST(ConnectionsFactory, CreateConnections911Instance)
 {
-    shared_ptr<Connections> connections =
-            ConnectionsFactory::getInstance().createConnections("Connections911");
-    ASSERT_NE(nullptr, connections);
-    ASSERT_NE(nullptr, dynamic_cast<Connections911 *>(connections.get()));
+   shared_ptr<Connections> connections
+      = ConnectionsFactory::getInstance().createConnections("Connections911");
+   ASSERT_NE(nullptr, connections);
+   ASSERT_NE(nullptr, dynamic_cast<Connections911 *>(connections.get()));
 }
 
 TEST(ConnectionsFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<Connections> connections = 
-                ConnectionsFactory::getInstance().createConnections("NonExistent");
-    ASSERT_EQ(nullptr, connections);
+   shared_ptr<Connections> connections
+      = ConnectionsFactory::getInstance().createConnections("NonExistent");
+   ASSERT_EQ(nullptr, connections);
 }

--- a/Testing/Core/ConnectionsFactoryTests.cpp
+++ b/Testing/Core/ConnectionsFactoryTests.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file ConnectionsFactoryTests.cpp
+ *
+ * @brief This file contains unit tests for the ConnectionsFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the ConnectionsFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "ConnectionsFactory.h"
+#include "ConnGrowth.h"
+#include "ConnStatic.h"
+#include "Connections911.h"
+#include "gtest/gtest.h"
+
+TEST(ConnectionsFactory, GetInstanceReturnsInstance)
+{
+    ConnectionsFactory *connectionsFactory = &ConnectionsFactory::getInstance();
+    ASSERT_NE(nullptr, connectionsFactory);
+}
+
+TEST(ConnectionsFactory, CreateConnstaticInstance)
+{
+    shared_ptr<Connections> connections =
+            ConnectionsFactory::getInstance().createConnections("ConnStatic");
+    ASSERT_NE(nullptr, connections);
+    ASSERT_NE(nullptr, dynamic_cast<ConnStatic *>(connections.get()));
+}
+
+TEST(ConnectionsFactory, CreateConnGrowthInstance)
+{
+    shared_ptr<Connections> connections =
+            ConnectionsFactory::getInstance().createConnections("ConnGrowth");
+    ASSERT_NE(nullptr, connections);
+    ASSERT_NE(nullptr, dynamic_cast<ConnGrowth *>(connections.get()));
+}
+
+TEST(ConnectionsFactory, CreateConnections911Instance)
+{
+    shared_ptr<Connections> connections =
+            ConnectionsFactory::getInstance().createConnections("Connections911");
+    ASSERT_NE(nullptr, connections);
+    ASSERT_NE(nullptr, dynamic_cast<Connections911 *>(connections.get()));
+}
+
+TEST(ConnectionsFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<Connections> connections = 
+                ConnectionsFactory::getInstance().createConnections("NonExistent");
+    ASSERT_EQ(nullptr, connections);
+}

--- a/Testing/Core/EdgesFactoryTests.cpp
+++ b/Testing/Core/EdgesFactoryTests.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file EdgesFactoryTests.cpp
+ *
+ * @brief This file contains unit tests for the EdgesFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the EdgesFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "EdgesFactory.h"
+#include "All911Edges.h"
+#include "AllDSSynapses.h"
+#include "AllDynamicSTDPSynapses.h"
+#include "AllSTDPSynapses.h"
+#include "AllSpikingSynapses.h"
+#include "gtest/gtest.h"
+
+TEST(EdgesFactory, GetInstanceReturnsInstance)
+{
+    EdgesFactory *edgesFactory = &EdgesFactory::getInstance();
+    ASSERT_NE(nullptr, edgesFactory);
+}
+
+TEST(EdgesFactory, CreateAll911EdgesInstance)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("All911Edges");
+    ASSERT_NE(nullptr, edges);
+    ASSERT_NE(nullptr, dynamic_cast<All911Edges *>(edges.get()));
+}
+
+TEST(EdgesFactory, CreateAllDSSynapsesInstance)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("AllDSSynapses");
+    ASSERT_NE(nullptr, edges);
+    ASSERT_NE(nullptr, dynamic_cast<AllDSSynapses *>(edges.get()));
+}
+
+TEST(EdgesFactory, CreateAllDynamicSTDPSynapsesInstance)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("AllDynamicSTDPSynapses");
+    ASSERT_NE(nullptr, edges);
+    ASSERT_NE(nullptr, dynamic_cast<AllDynamicSTDPSynapses *>(edges.get()));
+}
+
+TEST(EdgesFactory, CreateAllSTDPSynapsesInstance)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("AllSTDPSynapses");
+    ASSERT_NE(nullptr, edges);
+    ASSERT_NE(nullptr, dynamic_cast<AllSTDPSynapses *>(edges.get()));
+}
+
+TEST(EdgesFactory, CreateAllSpikingSynapsesInstance)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("AllSpikingSynapses");
+    ASSERT_NE(nullptr, edges);
+    ASSERT_NE(nullptr, dynamic_cast<AllSpikingSynapses *>(edges.get()));
+}
+
+TEST(EdgesFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<AllEdges> edges =
+            EdgesFactory::getInstance().createEdges("NonExistent");
+    ASSERT_EQ(nullptr, edges);
+}

--- a/Testing/Core/EdgesFactoryTests.cpp
+++ b/Testing/Core/EdgesFactoryTests.cpp
@@ -9,63 +9,57 @@
  * we are requesting.
  */
 
-#include "EdgesFactory.h"
 #include "All911Edges.h"
 #include "AllDSSynapses.h"
 #include "AllDynamicSTDPSynapses.h"
 #include "AllSTDPSynapses.h"
 #include "AllSpikingSynapses.h"
+#include "EdgesFactory.h"
 #include "gtest/gtest.h"
 
 TEST(EdgesFactory, GetInstanceReturnsInstance)
 {
-    EdgesFactory *edgesFactory = &EdgesFactory::getInstance();
-    ASSERT_NE(nullptr, edgesFactory);
+   EdgesFactory *edgesFactory = &EdgesFactory::getInstance();
+   ASSERT_NE(nullptr, edgesFactory);
 }
 
 TEST(EdgesFactory, CreateAll911EdgesInstance)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("All911Edges");
-    ASSERT_NE(nullptr, edges);
-    ASSERT_NE(nullptr, dynamic_cast<All911Edges *>(edges.get()));
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("All911Edges");
+   ASSERT_NE(nullptr, edges);
+   ASSERT_NE(nullptr, dynamic_cast<All911Edges *>(edges.get()));
 }
 
 TEST(EdgesFactory, CreateAllDSSynapsesInstance)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("AllDSSynapses");
-    ASSERT_NE(nullptr, edges);
-    ASSERT_NE(nullptr, dynamic_cast<AllDSSynapses *>(edges.get()));
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("AllDSSynapses");
+   ASSERT_NE(nullptr, edges);
+   ASSERT_NE(nullptr, dynamic_cast<AllDSSynapses *>(edges.get()));
 }
 
 TEST(EdgesFactory, CreateAllDynamicSTDPSynapsesInstance)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("AllDynamicSTDPSynapses");
-    ASSERT_NE(nullptr, edges);
-    ASSERT_NE(nullptr, dynamic_cast<AllDynamicSTDPSynapses *>(edges.get()));
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("AllDynamicSTDPSynapses");
+   ASSERT_NE(nullptr, edges);
+   ASSERT_NE(nullptr, dynamic_cast<AllDynamicSTDPSynapses *>(edges.get()));
 }
 
 TEST(EdgesFactory, CreateAllSTDPSynapsesInstance)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("AllSTDPSynapses");
-    ASSERT_NE(nullptr, edges);
-    ASSERT_NE(nullptr, dynamic_cast<AllSTDPSynapses *>(edges.get()));
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("AllSTDPSynapses");
+   ASSERT_NE(nullptr, edges);
+   ASSERT_NE(nullptr, dynamic_cast<AllSTDPSynapses *>(edges.get()));
 }
 
 TEST(EdgesFactory, CreateAllSpikingSynapsesInstance)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("AllSpikingSynapses");
-    ASSERT_NE(nullptr, edges);
-    ASSERT_NE(nullptr, dynamic_cast<AllSpikingSynapses *>(edges.get()));
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("AllSpikingSynapses");
+   ASSERT_NE(nullptr, edges);
+   ASSERT_NE(nullptr, dynamic_cast<AllSpikingSynapses *>(edges.get()));
 }
 
 TEST(EdgesFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<AllEdges> edges =
-            EdgesFactory::getInstance().createEdges("NonExistent");
-    ASSERT_EQ(nullptr, edges);
+   shared_ptr<AllEdges> edges = EdgesFactory::getInstance().createEdges("NonExistent");
+   ASSERT_EQ(nullptr, edges);
 }

--- a/Testing/Core/LayoutFactoryTests.cpp
+++ b/Testing/Core/LayoutFactoryTests.cpp
@@ -9,45 +9,41 @@
  * we are requesting.
  */
 
-#include "LayoutFactory.h"
 #include "DynamicLayout.h"
 #include "FixedLayout.h"
 #include "Layout911.h"
+#include "LayoutFactory.h"
 #include "gtest/gtest.h"
 
 TEST(LayoutFactory, GetInstanceReturnsInstance)
 {
-    LayoutFactory *layoutFactory = &LayoutFactory::getInstance();
-    ASSERT_NE(nullptr, layoutFactory);
+   LayoutFactory *layoutFactory = &LayoutFactory::getInstance();
+   ASSERT_NE(nullptr, layoutFactory);
 }
 
 TEST(LayoutFactory, CreateDynamicLayoutInstance)
 {
-    shared_ptr<Layout> layout =
-            LayoutFactory::getInstance().createLayout("DynamicLayout");
-    ASSERT_NE(nullptr, layout);
-    ASSERT_NE(nullptr, dynamic_cast<DynamicLayout *>(layout.get()));
+   shared_ptr<Layout> layout = LayoutFactory::getInstance().createLayout("DynamicLayout");
+   ASSERT_NE(nullptr, layout);
+   ASSERT_NE(nullptr, dynamic_cast<DynamicLayout *>(layout.get()));
 }
 
 TEST(LayoutFactory, CreateFixedLayoutInstance)
 {
-    shared_ptr<Layout> layout =
-            LayoutFactory::getInstance().createLayout("FixedLayout");
-    ASSERT_NE(nullptr, layout);
-    ASSERT_NE(nullptr, dynamic_cast<FixedLayout *>(layout.get()));
+   shared_ptr<Layout> layout = LayoutFactory::getInstance().createLayout("FixedLayout");
+   ASSERT_NE(nullptr, layout);
+   ASSERT_NE(nullptr, dynamic_cast<FixedLayout *>(layout.get()));
 }
 
 TEST(LayoutFactory, CreateLayout911Instance)
 {
-    shared_ptr<Layout> layout =
-            LayoutFactory::getInstance().createLayout("Layout911");
-    ASSERT_NE(nullptr, layout);
-    ASSERT_NE(nullptr, dynamic_cast<Layout911 *>(layout.get()));
+   shared_ptr<Layout> layout = LayoutFactory::getInstance().createLayout("Layout911");
+   ASSERT_NE(nullptr, layout);
+   ASSERT_NE(nullptr, dynamic_cast<Layout911 *>(layout.get()));
 }
 
 TEST(LayoutFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<Layout> layout =
-            LayoutFactory::getInstance().createLayout("NonExistent");
-    ASSERT_EQ(nullptr, layout);
+   shared_ptr<Layout> layout = LayoutFactory::getInstance().createLayout("NonExistent");
+   ASSERT_EQ(nullptr, layout);
 }

--- a/Testing/Core/LayoutFactoryTests.cpp
+++ b/Testing/Core/LayoutFactoryTests.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file LayoutFactoryTests.cpp
+ *
+ * @brief This file contains unit tests for the LayoutFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the LayoutFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "LayoutFactory.h"
+#include "DynamicLayout.h"
+#include "FixedLayout.h"
+#include "Layout911.h"
+#include "gtest/gtest.h"
+
+TEST(LayoutFactory, GetInstanceReturnsInstance)
+{
+    LayoutFactory *layoutFactory = &LayoutFactory::getInstance();
+    ASSERT_NE(nullptr, layoutFactory);
+}
+
+TEST(LayoutFactory, CreateDynamicLayoutInstance)
+{
+    shared_ptr<Layout> layout =
+            LayoutFactory::getInstance().createLayout("DynamicLayout");
+    ASSERT_NE(nullptr, layout);
+    ASSERT_NE(nullptr, dynamic_cast<DynamicLayout *>(layout.get()));
+}
+
+TEST(LayoutFactory, CreateFixedLayoutInstance)
+{
+    shared_ptr<Layout> layout =
+            LayoutFactory::getInstance().createLayout("FixedLayout");
+    ASSERT_NE(nullptr, layout);
+    ASSERT_NE(nullptr, dynamic_cast<FixedLayout *>(layout.get()));
+}
+
+TEST(LayoutFactory, CreateLayout911Instance)
+{
+    shared_ptr<Layout> layout =
+            LayoutFactory::getInstance().createLayout("Layout911");
+    ASSERT_NE(nullptr, layout);
+    ASSERT_NE(nullptr, dynamic_cast<Layout911 *>(layout.get()));
+}
+
+TEST(LayoutFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<Layout> layout =
+            LayoutFactory::getInstance().createLayout("NonExistent");
+    ASSERT_EQ(nullptr, layout);
+}

--- a/Testing/Core/RNGFactoryTests.cpp
+++ b/Testing/Core/RNGFactoryTests.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file RNGFactoryTests.cpp
+ *
+ * @brief This file contains unit tests for the RNGFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the RNGFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "RNGFactory.h"
+#include "MTRand.h"
+#include "Norm.h"
+#include "gtest/gtest.h"
+
+TEST(RNGFactory, GetInstanceReturnsInstance)
+{
+    RNGFactory *rngFactory = &RNGFactory::getInstance();
+    ASSERT_NE(nullptr, rngFactory);
+}
+
+TEST(RNGFactory, CreateMTRandInstance)
+{
+    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("MTRand");
+    ASSERT_NE(nullptr, rng);
+    ASSERT_NE(nullptr, dynamic_cast<MTRand *>(rng.get()));
+}
+
+TEST(RNGFactory, CreateNormInstance)
+{
+    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("Norm");
+    ASSERT_NE(nullptr, rng);
+    ASSERT_NE(nullptr, dynamic_cast<Norm *>(rng.get()));
+}
+
+TEST(RNGFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("NonExistent");
+    ASSERT_EQ(nullptr, rng);
+}

--- a/Testing/Core/RNGFactoryTests.cpp
+++ b/Testing/Core/RNGFactoryTests.cpp
@@ -9,33 +9,33 @@
  * we are requesting.
  */
 
-#include "RNGFactory.h"
 #include "MTRand.h"
 #include "Norm.h"
+#include "RNGFactory.h"
 #include "gtest/gtest.h"
 
 TEST(RNGFactory, GetInstanceReturnsInstance)
 {
-    RNGFactory *rngFactory = &RNGFactory::getInstance();
-    ASSERT_NE(nullptr, rngFactory);
+   RNGFactory *rngFactory = &RNGFactory::getInstance();
+   ASSERT_NE(nullptr, rngFactory);
 }
 
 TEST(RNGFactory, CreateMTRandInstance)
 {
-    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("MTRand");
-    ASSERT_NE(nullptr, rng);
-    ASSERT_NE(nullptr, dynamic_cast<MTRand *>(rng.get()));
+   shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("MTRand");
+   ASSERT_NE(nullptr, rng);
+   ASSERT_NE(nullptr, dynamic_cast<MTRand *>(rng.get()));
 }
 
 TEST(RNGFactory, CreateNormInstance)
 {
-    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("Norm");
-    ASSERT_NE(nullptr, rng);
-    ASSERT_NE(nullptr, dynamic_cast<Norm *>(rng.get()));
+   shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("Norm");
+   ASSERT_NE(nullptr, rng);
+   ASSERT_NE(nullptr, dynamic_cast<Norm *>(rng.get()));
 }
 
 TEST(RNGFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("NonExistent");
-    ASSERT_EQ(nullptr, rng);
+   shared_ptr<MTRand> rng = RNGFactory::getInstance().createRNG("NonExistent");
+   ASSERT_EQ(nullptr, rng);
 }

--- a/Testing/Core/RecorderFactoryTests.cpp
+++ b/Testing/Core/RecorderFactoryTests.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file RecorderFactoryTests.cpp
+ *
+ * @brief This file contains unit tests for the RecorderFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the RecorderFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "RecorderFactory.h"
+#include "Hdf5GrowthRecorder.h"
+#include "Xml911Recorder.h"
+#include "XmlGrowthRecorder.h"
+#include "XmlSTDPRecorder.h"
+#include "gtest/gtest.h"
+
+TEST(RecorderFactory, GetInstanceReturnsInstance)
+{
+    RecorderFactory *recorderFactory = &RecorderFactory::getInstance();
+    ASSERT_NE(nullptr, recorderFactory);
+}
+
+TEST(RecorderFactory, CreateXml911RecorderInstance)
+{
+    shared_ptr<IRecorder> recorder =
+            RecorderFactory::getInstance().createRecorder("Xml911Recorder");
+    ASSERT_NE(nullptr, recorder);
+    ASSERT_NE(nullptr, dynamic_cast<Xml911Recorder *>(recorder.get()));
+}
+
+TEST(RecorderFactory, CreateXmlGrowthRecorderInstance)
+{
+    shared_ptr<IRecorder> recorder =
+            RecorderFactory::getInstance().createRecorder("XmlGrowthRecorder");
+    ASSERT_NE(nullptr, recorder);
+    ASSERT_NE(nullptr, dynamic_cast<XmlGrowthRecorder *>(recorder.get()));
+}
+
+TEST(RecorderFactory, CreateXmlSTDPRecorderInstance)
+{
+    shared_ptr<IRecorder> recorder =
+            RecorderFactory::getInstance().createRecorder("XmlSTDPRecorder");
+    ASSERT_NE(nullptr, recorder);
+    ASSERT_NE(nullptr, dynamic_cast<XmlSTDPRecorder *>(recorder.get()));
+}
+
+TEST(RecorderFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<IRecorder> recorder =
+            RecorderFactory::getInstance().createRecorder("NonExistent");
+    ASSERT_EQ(nullptr, recorder);
+}
+
+#if defined(HDF5)
+// This test is only possible if HDF5 compilation is available and enabled
+TEST(RecorderFactory, CreateHdf5GrowthRecorderInstance)
+{
+    shared_ptr<IRecorder> recorder =
+            RecorderFactory::getInstance().createRecorder("Hdf5GrowthRecorder");
+    ASSERT_NE(nullptr, recorder);
+    ASSERT_NE(nullptr, dynamic_cast<Hdf5GrowthRecorder *>(recorder.get()));
+}
+#endif

--- a/Testing/Core/RecorderFactoryTests.cpp
+++ b/Testing/Core/RecorderFactoryTests.cpp
@@ -9,8 +9,8 @@
  * we are requesting.
  */
 
-#include "RecorderFactory.h"
 #include "Hdf5GrowthRecorder.h"
+#include "RecorderFactory.h"
 #include "Xml911Recorder.h"
 #include "XmlGrowthRecorder.h"
 #include "XmlSTDPRecorder.h"
@@ -18,48 +18,46 @@
 
 TEST(RecorderFactory, GetInstanceReturnsInstance)
 {
-    RecorderFactory *recorderFactory = &RecorderFactory::getInstance();
-    ASSERT_NE(nullptr, recorderFactory);
+   RecorderFactory *recorderFactory = &RecorderFactory::getInstance();
+   ASSERT_NE(nullptr, recorderFactory);
 }
 
 TEST(RecorderFactory, CreateXml911RecorderInstance)
 {
-    shared_ptr<IRecorder> recorder =
-            RecorderFactory::getInstance().createRecorder("Xml911Recorder");
-    ASSERT_NE(nullptr, recorder);
-    ASSERT_NE(nullptr, dynamic_cast<Xml911Recorder *>(recorder.get()));
+   shared_ptr<IRecorder> recorder = RecorderFactory::getInstance().createRecorder("Xml911Recorder");
+   ASSERT_NE(nullptr, recorder);
+   ASSERT_NE(nullptr, dynamic_cast<Xml911Recorder *>(recorder.get()));
 }
 
 TEST(RecorderFactory, CreateXmlGrowthRecorderInstance)
 {
-    shared_ptr<IRecorder> recorder =
-            RecorderFactory::getInstance().createRecorder("XmlGrowthRecorder");
-    ASSERT_NE(nullptr, recorder);
-    ASSERT_NE(nullptr, dynamic_cast<XmlGrowthRecorder *>(recorder.get()));
+   shared_ptr<IRecorder> recorder
+      = RecorderFactory::getInstance().createRecorder("XmlGrowthRecorder");
+   ASSERT_NE(nullptr, recorder);
+   ASSERT_NE(nullptr, dynamic_cast<XmlGrowthRecorder *>(recorder.get()));
 }
 
 TEST(RecorderFactory, CreateXmlSTDPRecorderInstance)
 {
-    shared_ptr<IRecorder> recorder =
-            RecorderFactory::getInstance().createRecorder("XmlSTDPRecorder");
-    ASSERT_NE(nullptr, recorder);
-    ASSERT_NE(nullptr, dynamic_cast<XmlSTDPRecorder *>(recorder.get()));
+   shared_ptr<IRecorder> recorder
+      = RecorderFactory::getInstance().createRecorder("XmlSTDPRecorder");
+   ASSERT_NE(nullptr, recorder);
+   ASSERT_NE(nullptr, dynamic_cast<XmlSTDPRecorder *>(recorder.get()));
 }
 
 TEST(RecorderFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<IRecorder> recorder =
-            RecorderFactory::getInstance().createRecorder("NonExistent");
-    ASSERT_EQ(nullptr, recorder);
+   shared_ptr<IRecorder> recorder = RecorderFactory::getInstance().createRecorder("NonExistent");
+   ASSERT_EQ(nullptr, recorder);
 }
 
 #if defined(HDF5)
 // This test is only possible if HDF5 compilation is available and enabled
 TEST(RecorderFactory, CreateHdf5GrowthRecorderInstance)
 {
-    shared_ptr<IRecorder> recorder =
-            RecorderFactory::getInstance().createRecorder("Hdf5GrowthRecorder");
-    ASSERT_NE(nullptr, recorder);
-    ASSERT_NE(nullptr, dynamic_cast<Hdf5GrowthRecorder *>(recorder.get()));
+   shared_ptr<IRecorder> recorder
+      = RecorderFactory::getInstance().createRecorder("Hdf5GrowthRecorder");
+   ASSERT_NE(nullptr, recorder);
+   ASSERT_NE(nullptr, dynamic_cast<Hdf5GrowthRecorder *>(recorder.get()));
 }
 #endif

--- a/Testing/Core/VerticesFactoryTests.cpp
+++ b/Testing/Core/VerticesFactoryTests.cpp
@@ -9,45 +9,44 @@
  * we are requesting.
  */
 
-#include "VerticesFactory.h"
 #include "All911Vertices.h"
 #include "AllIZHNeurons.h"
 #include "AllLIFNeurons.h"
+#include "VerticesFactory.h"
 #include "gtest/gtest.h"
 
 TEST(VerticesFactory, GetInstanceReturnsInstance)
 {
-    VerticesFactory *verticesFactory = &VerticesFactory::getInstance();
-    ASSERT_NE(nullptr, verticesFactory);
+   VerticesFactory *verticesFactory = &VerticesFactory::getInstance();
+   ASSERT_NE(nullptr, verticesFactory);
 }
 
 TEST(VerticesFactory, CreateAllLIFNeuronsInstance)
 {
-    shared_ptr<AllVertices> vertices = 
-            VerticesFactory::getInstance().createVertices("AllLIFNeurons");
-    ASSERT_NE(nullptr, vertices);
-    ASSERT_NE(nullptr, dynamic_cast<AllLIFNeurons *>(vertices.get()));
+   shared_ptr<AllVertices> vertices
+      = VerticesFactory::getInstance().createVertices("AllLIFNeurons");
+   ASSERT_NE(nullptr, vertices);
+   ASSERT_NE(nullptr, dynamic_cast<AllLIFNeurons *>(vertices.get()));
 }
 
 TEST(VerticesFactory, CreateAllIZNeuronsInstance)
 {
-    shared_ptr<AllVertices> vertices = 
-            VerticesFactory::getInstance().createVertices("AllIZHNeurons");
-    ASSERT_NE(nullptr, vertices);
-    ASSERT_NE(nullptr, dynamic_cast<AllIZHNeurons *>(vertices.get()));
+   shared_ptr<AllVertices> vertices
+      = VerticesFactory::getInstance().createVertices("AllIZHNeurons");
+   ASSERT_NE(nullptr, vertices);
+   ASSERT_NE(nullptr, dynamic_cast<AllIZHNeurons *>(vertices.get()));
 }
 
 TEST(VerticesFactory, CreateAll911VerticesInstance)
 {
-    shared_ptr<AllVertices> vertices = 
-            VerticesFactory::getInstance().createVertices("All911Vertices");
-    ASSERT_NE(nullptr, vertices);
-    ASSERT_NE(nullptr, dynamic_cast<All911Vertices *>(vertices.get()));
+   shared_ptr<AllVertices> vertices
+      = VerticesFactory::getInstance().createVertices("All911Vertices");
+   ASSERT_NE(nullptr, vertices);
+   ASSERT_NE(nullptr, dynamic_cast<All911Vertices *>(vertices.get()));
 }
 
 TEST(VerticesFactory, CreateNonExistentClassReturnsNullPtr)
 {
-    shared_ptr<AllVertices> vertices = 
-            VerticesFactory::getInstance().createVertices("NonExistent");
-    ASSERT_TRUE(vertices == nullptr);
+   shared_ptr<AllVertices> vertices = VerticesFactory::getInstance().createVertices("NonExistent");
+   ASSERT_TRUE(vertices == nullptr);
 }

--- a/Testing/Core/VerticesFactoryTests.cpp
+++ b/Testing/Core/VerticesFactoryTests.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file VerticesFactoryTests.cpp
+ * 
+ * @brief This file contains unit tests for the VerticesFactory using GTest.
+ * 
+ * @ingroup Testing/Core
+ * 
+ * We test that the VerticesFactory returns an instance of the correct class
+ * we are requesting.
+ */
+
+#include "VerticesFactory.h"
+#include "All911Vertices.h"
+#include "AllIZHNeurons.h"
+#include "AllLIFNeurons.h"
+#include "gtest/gtest.h"
+
+TEST(VerticesFactory, GetInstanceReturnsInstance)
+{
+    VerticesFactory *verticesFactory = &VerticesFactory::getInstance();
+    ASSERT_NE(nullptr, verticesFactory);
+}
+
+TEST(VerticesFactory, CreateAllLIFNeuronsInstance)
+{
+    shared_ptr<AllVertices> vertices = 
+            VerticesFactory::getInstance().createVertices("AllLIFNeurons");
+    ASSERT_NE(nullptr, vertices);
+    ASSERT_NE(nullptr, dynamic_cast<AllLIFNeurons *>(vertices.get()));
+}
+
+TEST(VerticesFactory, CreateAllIZNeuronsInstance)
+{
+    shared_ptr<AllVertices> vertices = 
+            VerticesFactory::getInstance().createVertices("AllIZHNeurons");
+    ASSERT_NE(nullptr, vertices);
+    ASSERT_NE(nullptr, dynamic_cast<AllIZHNeurons *>(vertices.get()));
+}
+
+TEST(VerticesFactory, CreateAll911VerticesInstance)
+{
+    shared_ptr<AllVertices> vertices = 
+            VerticesFactory::getInstance().createVertices("All911Vertices");
+    ASSERT_NE(nullptr, vertices);
+    ASSERT_NE(nullptr, dynamic_cast<All911Vertices *>(vertices.get()));
+}
+
+TEST(VerticesFactory, CreateNonExistentClassReturnsNullPtr)
+{
+    shared_ptr<AllVertices> vertices = 
+            VerticesFactory::getInstance().createVertices("NonExistent");
+    ASSERT_TRUE(vertices == nullptr);
+}


### PR DESCRIPTION
Closes #361.

I did some cleaned up of the various factory classes. If nothing else, this should improve readability.

Summary:

- Switched to using `find`, instead of looping over the `createFunctions` map.
- Changed `noiseRNG` from a naked pointer to a `shared_ptr`.
- Removed not needed class member pointer to the instance created by the factory.
- Wrote Unit Tests for all factory classes.
- Fixed Segmentation fault on destruction of `Connections911` class (revealed by the unit tests).