### PR TITLE
[Issue-387] Add CEREAL_CLASS_VERSION macro to the serializable classes

### DIFF
--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -109,11 +109,11 @@ public:
 
    ///  Cereal serialization method
    ///  (Serializes radii)
-   template <class Archive> void save(Archive &archive) const;
+   template <class Archive> void save(Archive &archive, std::uint32_t const version) const;
 
    ///  Cereal deserialization method
    ///  (Deserializes radii)
-   template <class Archive> void load(Archive &archive);
+   template <class Archive> void load(Archive &archive, std::uint32_t const version);
 
    ///  Prints radii
    void printRadii() const;
@@ -192,9 +192,11 @@ public:
    VectorMatrix *deltaR_;
 };
 
+CEREAL_CLASS_VERSION(ConnGrowth, 1);
+
 ///  Cereal serialization method
 ///  (Serializes radii)
-template <class Archive> void ConnGrowth::save(Archive &archive) const
+template <class Archive> void ConnGrowth::save(Archive &archive, std::uint32_t const version) const
 {
    // uses vector to save radii
    vector<BGFLOAT> radiiVector;
@@ -207,7 +209,7 @@ template <class Archive> void ConnGrowth::save(Archive &archive) const
 
 ///  Cereal deserialization method
 ///  (Deserializes radii)
-template <class Archive> void ConnGrowth::load(Archive &archive)
+template <class Archive> void ConnGrowth::load(Archive &archive, std::uint32_t const version)
 {
    // uses vector to load radii
    vector<BGFLOAT> radiiVector;

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -59,7 +59,8 @@ bool Serializer::deserializeSynapses()
    try {
       archive(*(dynamic_cast<AllEdges *>(connections->getEdges().get())));
    } catch (cereal::Exception e) {
-      cerr << "Failed deserializing synapse weights, source vertices, and/or destination vertices."
+      cerr << e.what() << endl
+           << "Failed to deserialize synapse weights, source vertices, and/or destination vertices."
            << endl;
       return false;
    }
@@ -93,7 +94,7 @@ bool Serializer::deserializeSynapses()
       try {
          archive(*(dynamic_cast<ConnGrowth *>(connections.get())));
       } catch (cereal::Exception e) {
-         cerr << "Failed deserializing radii." << endl;
+         cerr << e.what() << endl << "Failed to deserialize radii." << endl;
          return false;
       }
    }

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -62,11 +62,11 @@ public:
 
    ///  Cereal serialization method
    ///  (Serializes edge weights, source vertices, and destination vertices)
-   template <class Archive> void save(Archive &archive) const;
+   template <class Archive> void save(Archive &archive, std::uint32_t const version) const;
 
    ///  Cereal deserialization method
    ///  (Deserializes edge weights, source vertices, and destination vertices)
-   template <class Archive> void load(Archive &archive);
+   template <class Archive> void load(Archive &archive, std::uint32_t const version);
 
 protected:
    ///  Setup the internal structure of the class (allocate memories and initialize them).
@@ -231,9 +231,11 @@ public:
    int countVertices_;
 };
 
+CEREAL_CLASS_VERSION(AllEdges, 1);
+
 ///  Cereal serialization method
 ///  (Serializes edge weights, source vertices, and destination vertices)
-template <class Archive> void AllEdges::save(Archive &archive) const
+template <class Archive> void AllEdges::save(Archive &archive, std::uint32_t const version) const
 {
    // uses vector to save edge weights, source vertices, and destination vertices
    vector<BGFLOAT> WVector;
@@ -257,7 +259,7 @@ template <class Archive> void AllEdges::save(Archive &archive) const
 
 ///  Cereal deserialization method
 ///  (Deserializes edge weights, source vertices, and destination vertices)
-template <class Archive> void AllEdges::load(Archive &archive)
+template <class Archive> void AllEdges::load(Archive &archive, std::uint32_t const version)
 {
    // uses vectors to load edge weights, source vertices, and destination vertices
    int WVectorSize = 0;

--- a/Testing/Core/SerializationTests.cpp
+++ b/Testing/Core/SerializationTests.cpp
@@ -8,6 +8,8 @@
 
 #include "Core.h"
 #include "gtest/gtest.h"
+#include <iostream>
+#include <tinyxml.h>
 
 using namespace std;
 
@@ -28,4 +30,43 @@ TEST(Serialization, SerializeFileTest)
    bool fileExist = f != NULL;
    fclose(f);
    ASSERT_TRUE(fileExist);
+
+   // Test to confirm class version is correctly populated
+
+   string classElements[] = {"AllEdges", "Connections"};
+   string classVersion[] = {"1", "1"};
+   int index = 0;
+
+   // Load the XML file
+   TiXmlDocument doc("../build/Output/serial1.xml");
+   bool loadOkay = doc.LoadFile();
+
+   // Check that the file was successfully loaded
+   EXPECT_TRUE(loadOkay);
+
+   if (loadOkay) {
+      // Get the root element
+      TiXmlElement *root = doc.RootElement();
+
+      // Iterate through all the elements in the root
+      for (TiXmlElement *elem = root->FirstChildElement(); elem != NULL;
+           elem = elem->NextSiblingElement()) {
+         // Get the element name
+         string elemName = elem->Value();
+
+         // Perform assertions on the element name
+         EXPECT_EQ(elemName, classElements[index++]);
+
+         //Iterate through all the attributes of the element
+         for (TiXmlAttribute *attr = elem->FirstAttribute(); attr != NULL; attr = attr->Next()) {
+            // Get the attribute name and value
+            string attrName = attr->Name();
+            string attrValue = attr->Value();
+
+            // Perform assertions on the attribute name and value
+            EXPECT_EQ(attrName, "cereal_class_version");
+            EXPECT_EQ(attrValue, classVersion[index++]);
+         }
+      }
+   }
 };


### PR DESCRIPTION
Closes #387 

This PR adds CEREAL_CLASS_VERSION macro on AllEdges and ConnGrowth class. 
In addition, we also extend the serialization unit test to confirm that the output XML file contains the expected class version.   