### PR TITLE
[ISSUE 423] Change return value of getter methods from pointer to reference

### DIFF
--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -109,7 +109,7 @@ void Connections::updateSynapsesWeights()
 void Connections::createSynapsesFromWeights()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // for each neuron

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -54,9 +54,9 @@ AllEdges &Connections::getEdges() const
    return *edges_;
 }
 
-EdgeIndexMap *Connections::getEdgeIndexMap() const
+EdgeIndexMap &Connections::getEdgeIndexMap() const
 {
-   return synapseIndexMap_.get();
+   return *synapseIndexMap_;
 }
 
 void Connections::registerGraphProperties()

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -109,7 +109,7 @@ void Connections::updateSynapsesWeights()
 void Connections::createSynapsesFromWeights()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // for each neuron

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -93,7 +93,7 @@ void Connections::updateSynapsesWeights(const int numVertices, AllVertices &vert
                                         AllEdges &synapses,
                                         AllSpikingNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        Layout *layout)
+                                        Layout &layout)
 {
 }
 #else

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -49,9 +49,9 @@ Connections::Connections()
    edgeLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("edge"));
 }
 
-AllEdges *Connections::getEdges() const
+AllEdges &Connections::getEdges() const
 {
-   return edges_.get();
+   return *edges_;
 }
 
 EdgeIndexMap *Connections::getEdgeIndexMap() const

--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -110,7 +110,7 @@ void Connections::createSynapsesFromWeights()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
    Layout &layout = *Simulator::getInstance().getModel()->getLayout();
-   AllVertices &vertices = *layout.getVertices();
+   AllVertices &vertices = layout.getVertices();
 
    // for each neuron
    for (int i = 0; i < numVertices; i++) {

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -43,7 +43,7 @@ public:
    virtual ~Connections() = default;
 
    /// Returns pointer to Synapses/Edges
-   AllEdges *getEdges() const;
+   AllEdges &getEdges() const;
 
    /// Returns a pointer to the EdgeIndexMap
    EdgeIndexMap *getEdgeIndexMap() const;

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -89,7 +89,7 @@ public:
                                       AllEdges &synapses,
                                       AllSpikingNeuronsDeviceProperties *allVerticesDevice,
                                       AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                      Layout *layout);
+                                      Layout &layout);
 #else
 public:
    ///  Update the weight of the Synapses in the simulation.

--- a/Simulator/Connections/Connections.h
+++ b/Simulator/Connections/Connections.h
@@ -42,11 +42,11 @@ public:
    ///  Destructor
    virtual ~Connections() = default;
 
-   /// Returns pointer to Synapses/Edges
+   /// Returns reference to Synapses/Edges
    AllEdges &getEdges() const;
 
-   /// Returns a pointer to the EdgeIndexMap
-   EdgeIndexMap *getEdgeIndexMap() const;
+   /// Returns a reference to the EdgeIndexMap
+   EdgeIndexMap &getEdgeIndexMap() const;
 
    /// Calls Synapses to create EdgeIndexMap and stores it as a member variable
    void createEdgeIndexMap();

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -19,7 +19,7 @@ void Connections911::setup()
    LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
 
    // we can obtain the Layout, which holds the vertices, from the Model
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // Get list of edges sorted by target in ascending order from GraphManager
@@ -78,7 +78,7 @@ bool Connections911::updateConnections(AllVertices &vertices)
 
    // Record old type map
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
    oldTypeMap_ = layout.vertexTypeMap_;
 
    // Erase PSAPs

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -20,7 +20,7 @@ void Connections911::setup()
 
    // we can obtain the Layout, which holds the vertices, from the Model
    Layout &layout = *Simulator::getInstance().getModel()->getLayout();
-   AllVertices &vertices = *layout.getVertices();
+   AllVertices &vertices = layout.getVertices();
 
    // Get list of edges sorted by target in ascending order from GraphManager
    GraphManager &gm = GraphManager::getInstance();

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -19,7 +19,7 @@ void Connections911::setup()
    LOG4CPLUS_INFO(fileLogger_, "Initializing connections");
 
    // we can obtain the Layout, which holds the vertices, from the Model
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // Get list of edges sorted by target in ascending order from GraphManager
@@ -78,7 +78,7 @@ bool Connections911::updateConnections(AllVertices &vertices)
 
    // Record old type map
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
    oldTypeMap_ = layout.vertexTypeMap_;
 
    // Erase PSAPs

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -224,7 +224,7 @@ void ConnGrowth::updateSynapsesWeights()
    int numVertices = Simulator::getInstance().getTotalVertices();
    AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(*edges_);
    Layout &layout = *Simulator::getInstance().getModel()->getLayout();
-   AllVertices &vertices = *layout.getVertices();
+   AllVertices &vertices = layout.getVertices();
 
    // For now, we just set the weights to equal the areas. We will later
    // scale it and set its sign (when we index and get its sign).

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -164,7 +164,7 @@ void ConnGrowth::updateConns(AllVertices &vertices)
 void ConnGrowth::updateOverlap()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
 
    LOG4CPLUS_INFO(fileLogger_, "Computing areas of overlap");
 
@@ -223,7 +223,7 @@ void ConnGrowth::updateSynapsesWeights()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
    AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(*edges_);
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // For now, we just set the weights to equal the areas. We will later

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -164,7 +164,7 @@ void ConnGrowth::updateConns(AllVertices &vertices)
 void ConnGrowth::updateOverlap()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
 
    LOG4CPLUS_INFO(fileLogger_, "Computing areas of overlap");
 
@@ -223,7 +223,7 @@ void ConnGrowth::updateSynapsesWeights()
 {
    int numVertices = Simulator::getInstance().getTotalVertices();
    AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(*edges_);
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
    AllVertices &vertices = layout.getVertices();
 
    // For now, we just set the weights to equal the areas. We will later

--- a/Simulator/Connections/Neuro/ConnGrowth.h
+++ b/Simulator/Connections/Neuro/ConnGrowth.h
@@ -134,7 +134,7 @@ public:
                                       AllEdges &synapses,
                                       AllSpikingNeuronsDeviceProperties *allVerticesDevice,
                                       AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                      Layout *layout) override;
+                                      Layout &layout) override;
 #else
    ///  Update the weights of the Synapses in the simulation. To be clear,
    ///  iterates through all source and destination neurons and updates their

--- a/Simulator/Connections/Neuro/ConnGrowth_d.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth_d.cpp
@@ -30,7 +30,7 @@ void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices &verti
                                        AllEdges &synapses,
                                        AllSpikingNeuronsDeviceProperties *allVerticesDevice,
                                        AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                       Layout *layout)
+                                       Layout &layout)
 {
    Simulator &simulator = Simulator::getInstance();
    // For now, we just set the weights to equal the areas. We will later
@@ -60,7 +60,7 @@ void ConnGrowth::updateSynapsesWeights(const int numVertices, AllVertices &verti
 
    HANDLE_ERROR(cudaMemcpy(W_d, W_h, W_d_size, cudaMemcpyHostToDevice));
 
-   HANDLE_ERROR(cudaMemcpy(neuronTypeMapD, layout->vertexTypeMap_.data(),
+   HANDLE_ERROR(cudaMemcpy(neuronTypeMapD, layout.vertexTypeMap_.data(),
                            simulator.getTotalVertices() * sizeof(vertexType),
                            cudaMemcpyHostToDevice));
 

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -37,7 +37,7 @@ ConnStatic::ConnStatic()
 void ConnStatic::setup()
 {
    // we can obtain the Layout, which holds the vertices, from the Model
-   Layout &layout = *Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel()->getLayout();
    AllVertices &vertices = layout.getVertices();
 
    Simulator &simulator = Simulator::getInstance();

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -38,7 +38,7 @@ void ConnStatic::setup()
 {
    // we can obtain the Layout, which holds the vertices, from the Model
    Layout &layout = *Simulator::getInstance().getModel()->getLayout();
-   AllVertices &vertices = *layout.getVertices();
+   AllVertices &vertices = layout.getVertices();
 
    Simulator &simulator = Simulator::getInstance();
    int numVertices = simulator.getTotalVertices();

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -37,7 +37,7 @@ ConnStatic::ConnStatic()
 void ConnStatic::setup()
 {
    // we can obtain the Layout, which holds the vertices, from the Model
-   Layout &layout = Simulator::getInstance().getModel()->getLayout();
+   Layout &layout = Simulator::getInstance().getModel().getLayout();
    AllVertices &vertices = layout.getVertices();
 
    Simulator &simulator = Simulator::getInstance();

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -23,16 +23,17 @@ void CPUModel::advance()
 {
    // ToDo: look at pointer v no pointer in params - to change
    // dereferencing the ptr, lose late binding -- look into changing!
-   layout_->getVertices()->advanceVertices(connections_->getEdges(),
-                                           connections_->getEdgeIndexMap());
-   connections_->getEdges().advanceEdges(layout_->getVertices(), connections_->getEdgeIndexMap());
+   layout_->getVertices().advanceVertices(connections_->getEdges(),
+                                          connections_->getEdgeIndexMap());
+   connections_->getEdges().advanceEdges(&(layout_->getVertices()),
+                                         connections_->getEdgeIndexMap());
 }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.
 void CPUModel::updateConnections()
 {
    // Update Connections data
-   if (connections_->updateConnections(*layout_->getVertices())) {
+   if (connections_->updateConnections(layout_->getVertices())) {
       connections_->updateSynapsesWeights();
       // create synapse inverse map
       connections_->createEdgeIndexMap();

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -25,8 +25,7 @@ void CPUModel::advance()
    // dereferencing the ptr, lose late binding -- look into changing!
    layout_->getVertices().advanceVertices(connections_->getEdges(),
                                           connections_->getEdgeIndexMap());
-   connections_->getEdges().advanceEdges(&(layout_->getVertices()),
-                                         connections_->getEdgeIndexMap());
+   connections_->getEdges().advanceEdges(layout_->getVertices(), connections_->getEdgeIndexMap());
 }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.

--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -23,9 +23,9 @@ void CPUModel::advance()
 {
    // ToDo: look at pointer v no pointer in params - to change
    // dereferencing the ptr, lose late binding -- look into changing!
-   layout_->getVertices()->advanceVertices(*(connections_->getEdges()),
+   layout_->getVertices()->advanceVertices(connections_->getEdges(),
                                            connections_->getEdgeIndexMap());
-   connections_->getEdges()->advanceEdges(layout_->getVertices(), connections_->getEdgeIndexMap());
+   connections_->getEdges().advanceEdges(layout_->getVertices(), connections_->getEdgeIndexMap());
 }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -207,9 +207,8 @@ int Core::runSimulation(string executableName, string cmdLineArguments)
    simulator.finish();
 
    // terminates the simulation recorder
-   if (simulator.getModel()->getRecorder() != nullptr) {
-      simulator.getModel()->getRecorder()->term();
-   }
+   simulator.getModel()->getRecorder().term();
+
 
    time(&end_time);
    double timeElapsed = difftime(end_time, start_time);

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -207,7 +207,7 @@ int Core::runSimulation(string executableName, string cmdLineArguments)
    simulator.finish();
 
    // terminates the simulation recorder
-   simulator.getModel()->getRecorder().term();
+   simulator.getModel().getRecorder().term();
 
 
    time(&end_time);

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -107,7 +107,7 @@ void GPUModel::setupSim()
    allocDeviceStruct((void **)&allVerticesDevice_, (void **)&allEdgesDevice_);
 
    // copy inverse map to the device memory
-   copySynapseIndexMapHostToDevice(*(connections_->getEdgeIndexMap()),
+   copySynapseIndexMapHostToDevice(connections_->getEdgeIndexMap(),
                                    Simulator::getInstance().getTotalVertices());
 
    // set some parameters used for advanceVerticesDevice
@@ -155,7 +155,7 @@ void GPUModel::advance()
    // Advance neurons ------------->
    dynamic_cast<AllSpikingNeurons &>(neurons).advanceVertices(connections_->getEdges(),
                                                               allVerticesDevice_, allEdgesDevice_,
-                                                              randNoise_d, synapseIndexMapDevice_);
+                                                              randNoise_d, *synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_advanceNeurons);
@@ -210,7 +210,7 @@ void GPUModel::updateConnections()
       // create synapse index map
       connections_->createEdgeIndexMap();
       // copy index map to the device memory
-      copySynapseIndexMapHostToDevice(*(connections_->getEdgeIndexMap()),
+      copySynapseIndexMapHostToDevice(connections_->getEdgeIndexMap(),
                                       Simulator::getInstance().getTotalVertices());
    }
 }

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -155,7 +155,7 @@ void GPUModel::advance()
    // Advance neurons ------------->
    dynamic_cast<AllSpikingNeurons &>(neurons).advanceVertices(connections_->getEdges(),
                                                               allVerticesDevice_, allEdgesDevice_,
-                                                              randNoise_d, *synapseIndexMapDevice_);
+                                                              randNoise_d, synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_advanceNeurons);
@@ -206,7 +206,7 @@ void GPUModel::updateConnections()
    if (connections_->updateConnections(neurons)) {
       connections_->updateSynapsesWeights(Simulator::getInstance().getTotalVertices(), neurons,
                                           synapses, allVerticesDevice_, allEdgesDevice_,
-                                          layout_.get());
+                                          getLayout());
       // create synapse index map
       connections_->createEdgeIndexMap();
       // copy index map to the device memory

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -47,7 +47,7 @@ Model::Model()
 void Model::saveResults()
 {
    if (recorder_ != nullptr) {
-      recorder_->saveSimData(*layout_->getVertices());
+      recorder_->saveSimData(layout_->getVertices());
    }
 }
 
@@ -61,14 +61,14 @@ void Model::createAllVertices()
    layout_->initStarterMap(Simulator::getInstance().getTotalVertices());
 
    // set their specific types
-   layout_->getVertices()->createAllVertices(layout_.get());
+   layout_->getVertices().createAllVertices(layout_.get());
 }
 
 /// Sets up the Simulation.
 void Model::setupSim()
 {
    LOG4CPLUS_INFO(fileLogger_, "Setting up Vertices...");
-   layout_->getVertices()->setupVertices();
+   layout_->getVertices().setupVertices();
    LOG4CPLUS_INFO(fileLogger_, "Setting up Edges...");
    connections_->getEdges().setupEdges();
 #ifdef PERFORMANCE_METRICS
@@ -164,7 +164,7 @@ void Model::updateHistory()
       LOG4CPLUS_INFO(fileLogger_, "ERROR: Recorder class is null.");
    }
    if (recorder_ != nullptr) {
-      recorder_->compileHistories(*layout_->getVertices());
+      recorder_->compileHistories(layout_->getVertices());
    }
 }
 

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -186,7 +186,7 @@ Layout &Model::getLayout() const
 /// Get the IRecorder class object.
 /// @return Pointer to the IRecorder class object.
 // ToDo: make smart ptr
-IRecorder *Model::getRecorder() const
+IRecorder &Model::getRecorder() const
 {
-   return recorder_.get();
+   return *recorder_;
 }

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -61,7 +61,7 @@ void Model::createAllVertices()
    layout_->initStarterMap(Simulator::getInstance().getTotalVertices());
 
    // set their specific types
-   layout_->getVertices().createAllVertices(layout_.get());
+   layout_->getVertices().createAllVertices(*layout_);
 }
 
 /// Sets up the Simulation.

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -171,9 +171,9 @@ void Model::updateHistory()
 /// Get the Connections class object.
 /// @return Pointer to the Connections class object.
 // ToDo: make smart ptr
-Connections *Model::getConnections() const
+Connections &Model::getConnections() const
 {
-   return connections_.get();
+   return *connections_;
 }
 
 /// Get the Layout class object.

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -70,7 +70,7 @@ void Model::setupSim()
    LOG4CPLUS_INFO(fileLogger_, "Setting up Vertices...");
    layout_->getVertices()->setupVertices();
    LOG4CPLUS_INFO(fileLogger_, "Setting up Edges...");
-   connections_->getEdges()->setupEdges();
+   connections_->getEdges().setupEdges();
 #ifdef PERFORMANCE_METRICS
    // Start timer for initialization
    Simulator::getInstance().getShort_timer().start();

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -178,9 +178,9 @@ Connections &Model::getConnections() const
 
 /// Get the Layout class object.
 /// @return Pointer to the Layout class object.
-Layout *Model::getLayout() const
+Layout &Model::getLayout() const
 {
-   return layout_.get();
+   return *layout_;
 }
 
 /// Get the IRecorder class object.

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -37,7 +37,7 @@ public:
    /// Destructor
    virtual ~Model() = default;
 
-   Connections *getConnections() const;
+   Connections &getConnections() const;
 
    Layout *getLayout() const;
 

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -39,7 +39,7 @@ public:
 
    Connections &getConnections() const;
 
-   Layout *getLayout() const;
+   Layout &getLayout() const;
 
    IRecorder *getRecorder() const;
 

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -37,10 +37,13 @@ public:
    /// Destructor
    virtual ~Model() = default;
 
+   /// Returns reference to Connections
    Connections &getConnections() const;
 
+   /// Returns reference to Layout
    Layout &getLayout() const;
 
+   /// Returns reference to Recorder
    IRecorder &getRecorder() const;
 
    /// Writes simulation results to an output destination.

--- a/Simulator/Core/Model.h
+++ b/Simulator/Core/Model.h
@@ -41,7 +41,7 @@ public:
 
    Layout &getLayout() const;
 
-   IRecorder *getRecorder() const;
+   IRecorder &getRecorder() const;
 
    /// Writes simulation results to an output destination.
    /// Downstream from IModel saveData()

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -57,7 +57,7 @@ bool Serializer::deserializeSynapses()
    // Deserializes synapse weights along with each synapse's source vertex and destination vertex
    // Uses "try catch" to catch any cereal exception
    try {
-      archive(*(dynamic_cast<AllEdges *>(connections->getEdges())));
+      archive(dynamic_cast<AllEdges &>(connections->getEdges()));
    } catch (cereal::Exception e) {
       cerr << e.what() << endl
            << "Failed to deserialize synapse weights, source vertices, and/or destination vertices."
@@ -67,7 +67,7 @@ bool Serializer::deserializeSynapses()
 
    // Creates synapses from weight
    //    connections->createSynapsesFromWeights(simulator.getTotalVertices(), layout.get(),
-   //                                           (*layout->getVertices()), (*connections->getEdges()));
+   //                                           (*layout->getVertices()), (connections->getEdges()));
 
    //Creates synapses from weight
    connections->createSynapsesFromWeights();
@@ -134,8 +134,8 @@ void Serializer::serializeSynapses()
    Model *model = simulator.getModel();
 
    // Serializes synapse weights along with each synapse's source vertex and destination vertex
-   archive(cereal::make_nvp("AllEdges",
-                            *(dynamic_cast<AllEdges *>(model->getConnections()->getEdges()))));
+   archive(
+      cereal::make_nvp("AllEdges", dynamic_cast<AllEdges &>(model->getConnections()->getEdges())));
 
    // Serializes radii (only if it is a connGrowth model)
    if (dynamic_cast<ConnGrowth *>(model->getConnections()) != nullptr) {

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -80,7 +80,7 @@ bool Serializer::deserializeSynapses()
 
 #if defined(USE_GPU)
    GPUModel &gpuModel = static_cast<GPUModel &>(simulator.getModel());
-   gpuModel.copySynapseIndexMapHostToDevice(*(connections.getEdgeIndexMap()),
+   gpuModel.copySynapseIndexMapHostToDevice(connections.getEdgeIndexMap(),
                                             simulator.getTotalVertices());
 #endif   // USE_GPU
 

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -47,8 +47,8 @@ bool Serializer::deserializeSynapses()
    cereal::XMLInputArchive archive(memory_in);
    //cereal::BinaryInputArchive archive(memory_in);
 
-   Connections &connections = simulator.getModel()->getConnections();
-   //Layout &layout = simulator.getModel()->getLayout();
+   Connections &connections = simulator.getModel().getConnections();
+   //Layout &layout = simulator.getModel().getLayout();
 
    // Deserializes synapse weights along with each synapse's source vertex and destination vertex
    // Uses "try catch" to catch any cereal exception
@@ -79,9 +79,9 @@ bool Serializer::deserializeSynapses()
    connections.createEdgeIndexMap();
 
 #if defined(USE_GPU)
-   GPUModel *gpuModel = static_cast<GPUModel *>(simulator.getModel());
-   gpuModel->copySynapseIndexMapHostToDevice(*(connections.getEdgeIndexMap()),
-                                             simulator.getTotalVertices());
+   GPUModel &gpuModel = static_cast<GPUModel &>(simulator.getModel());
+   gpuModel.copySynapseIndexMapHostToDevice(*(connections.getEdgeIndexMap()),
+                                            simulator.getTotalVertices());
 #endif   // USE_GPU
 
    // Uses "try catch" to catch any cereal exception
@@ -125,11 +125,11 @@ void Serializer::serializeSynapses()
    simulator.copyGPUSynapseToCPU();
 #endif   // USE_GPU
 
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
    // Serializes synapse weights along with each synapse's source vertex and destination vertex
    archive(
-      cereal::make_nvp("AllEdges", dynamic_cast<AllEdges &>(model->getConnections().getEdges())));
+      cereal::make_nvp("AllEdges", dynamic_cast<AllEdges &>(model.getConnections().getEdges())));
 
-   archive(cereal::make_nvp("Connections", dynamic_cast<ConnGrowth &>(model->getConnections())));
+   archive(cereal::make_nvp("Connections", dynamic_cast<ConnGrowth &>(model.getConnections())));
 }

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -67,7 +67,7 @@ bool Serializer::deserializeSynapses()
 
    // Creates synapses from weight
    //    connections->createSynapsesFromWeights(simulator.getTotalVertices(), layout.get(),
-   //                                           (*layout->getVertices()), (connections->getEdges()));
+   //                                           (layout->getVertices()), (connections->getEdges()));
 
    //Creates synapses from weight
    connections->createSynapsesFromWeights();

--- a/Simulator/Core/Serializer.cpp
+++ b/Simulator/Core/Serializer.cpp
@@ -48,11 +48,7 @@ bool Serializer::deserializeSynapses()
    //cereal::BinaryInputArchive archive(memory_in);
 
    Connections &connections = simulator.getModel()->getConnections();
-   Layout *layout = simulator.getModel()->getLayout();
-
-   if (layout == nullptr) {
-      cerr << "Either connections or layout is not instantiated," << endl;
-   }
+   //Layout &layout = simulator.getModel()->getLayout();
 
    // Deserializes synapse weights along with each synapse's source vertex and destination vertex
    // Uses "try catch" to catch any cereal exception

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -242,7 +242,7 @@ bool Simulator::instantiateSimulatorObjects()
 
    // Perform check on all instantiated objects.
    if (!model_ || (model_->getConnections() == nullptr) || (model_->getLayout() == nullptr)
-       || (model_->getLayout()->getVertices() == nullptr) || (model_->getRecorder() == nullptr)) {
+       || (model_->getRecorder() == nullptr)) {
       return false;
    }
    return true;

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -241,7 +241,7 @@ bool Simulator::instantiateSimulatorObjects()
 #endif
 
    // Perform check on all instantiated objects.
-   if (!model_ || (model_->getRecorder() == nullptr)) {
+   if (!model_) {
       return false;
    }
    return true;

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -241,8 +241,7 @@ bool Simulator::instantiateSimulatorObjects()
 #endif
 
    // Perform check on all instantiated objects.
-   if (!model_ || (model_->getConnections() == nullptr)
-       || (model_->getConnections()->getEdges() == nullptr) || (model_->getLayout() == nullptr)
+   if (!model_ || (model_->getConnections() == nullptr) || (model_->getLayout() == nullptr)
        || (model_->getLayout()->getVertices() == nullptr) || (model_->getRecorder() == nullptr)) {
       return false;
    }

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -358,9 +358,9 @@ string Simulator::getStimulusFileName() const
    return stimulusFileName_;
 }
 
-Model *Simulator::getModel() const
+Model &Simulator::getModel() const
 {
-   return model_.get();
+   return *model_;
 }
 
 #ifdef PERFORMANCE_METRICS

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -241,8 +241,7 @@ bool Simulator::instantiateSimulatorObjects()
 #endif
 
    // Perform check on all instantiated objects.
-   if (!model_ || (model_->getConnections() == nullptr) || (model_->getLayout() == nullptr)
-       || (model_->getRecorder() == nullptr)) {
+   if (!model_ || (model_->getLayout() == nullptr) || (model_->getRecorder() == nullptr)) {
       return false;
    }
    return true;

--- a/Simulator/Core/Simulator.cpp
+++ b/Simulator/Core/Simulator.cpp
@@ -241,7 +241,7 @@ bool Simulator::instantiateSimulatorObjects()
 #endif
 
    // Perform check on all instantiated objects.
-   if (!model_ || (model_->getLayout() == nullptr) || (model_->getRecorder() == nullptr)) {
+   if (!model_ || (model_->getRecorder() == nullptr)) {
       return false;
    }
    return true;
@@ -290,7 +290,7 @@ int Simulator::getHeight() const
 
 int Simulator::getTotalVertices() const
 {
-   return model_->getLayout()->getNumVertices();
+   return model_->getLayout().getNumVertices();
 }
 
 int Simulator::getCurrentStep() const

--- a/Simulator/Core/Simulator.h
+++ b/Simulator/Core/Simulator.h
@@ -29,13 +29,13 @@ public:
                                       /// of singleton object
    virtual ~Simulator() = default;    /// Destructor
 
-   void setup();   /// Setup simulation.
+   void setup();                      /// Setup simulation.
 
-   void finish();   /// Cleanup after simulation.
+   void finish();                     /// Cleanup after simulation.
 
-   void loadParameters();   /// Load member variables from configuration file
+   void loadParameters();             /// Load member variables from configuration file
 
-   void printParameters() const;   /// Prints loaded parameters to logging file.
+   void printParameters() const;      /// Prints loaded parameters to logging file.
 
    // Copied over from STDPFix
    void copyGPUSynapseToCPU();   /// Copy GPU Synapse data to CPU.
@@ -43,7 +43,7 @@ public:
    // Copied over from STDPFix
    void copyCPUSynapseToGPU();   /// Copy CPU Synapse data to GPU.
 
-   void reset();   /// Reset simulation objects.
+   void reset();                 /// Reset simulation objects.
 
    void simulate();
 
@@ -61,20 +61,20 @@ public:
    *  Accessors
    ***********************************************/
    ///@{
-   int getWidth() const;   /// Width of neuron map (assumes square)
+   int getWidth() const;           /// Width of neuron map (assumes square)
 
-   int getHeight() const;   /// Height of neuron map
+   int getHeight() const;          /// Height of neuron map
 
    int getTotalVertices() const;   /// Count of neurons in the simulation
 
-   int getCurrentStep() const;   /// Current simulation step
+   int getCurrentStep() const;     /// Current simulation step
 
-   int getNumEpochs() const;   /// Maximum number of simulation steps
+   int getNumEpochs() const;       /// Maximum number of simulation steps
 
    BGFLOAT
-   getEpochDuration() const;   /// The length of each step in simulation time
+   getEpochDuration() const;           /// The length of each step in simulation time
 
-   int getMaxFiringRate() const;   /// Maximum firing rate. **GPU Only**
+   int getMaxFiringRate() const;       /// Maximum firing rate. **GPU Only**
 
    int getMaxEdgesPerVertex() const;   /// Maximum number of synapses per neuron. **GPU Only**
 
@@ -83,23 +83,23 @@ public:
                         /// simulation step
 
    BGFLOAT
-   getMaxRate() const;   /// growth variable (m_targetRate / m_epsilon) TODO: more
-                         /// detail here
+   getMaxRate() const;             /// growth variable (m_targetRate / m_epsilon) TODO: more
+                                   /// detail here
 
    long getNoiseRngSeed() const;   /// Seed used for the simulation random **SingleThreaded Only**
 
-   long getInitRngSeed() const;   /// Seed used to initialize parameters
+   long getInitRngSeed() const;    /// Seed used to initialize parameters
 
-   string getConfigFileName() const;   /// File name of the parameter configuration file.
+   string getConfigFileName() const;            /// File name of the parameter configuration file.
 
-   string getSerializationFileName() const;   /// File name of the serialization file.
+   string getSerializationFileName() const;     /// File name of the serialization file.
 
    string getDeserializationFileName() const;   /// File name of the deserialization file.
 
-   string getStimulusFileName() const;   /// File name of the stimulus input file.
+   string getStimulusFileName() const;          /// File name of the stimulus input file.
 
-   Model *getModel() const;   /// Neural Network Model interface.
-                              ///@}
+   Model &getModel() const;                     /// Neural Network Model interface.
+                                                ///@}
 
    /************************************************
    *  Mutators
@@ -127,44 +127,44 @@ public:
    Simulator &operator=(Simulator &&simulator) = delete;
 
 private:
-   Simulator();   /// Constructor is private to keep a singleton instance of this
-                  /// class.
+   Simulator();                     /// Constructor is private to keep a singleton instance of this
+                                    /// class.
 
-   int width_;   /// Width of neuron map (assumes square)
+   int width_;                      /// Width of neuron map (assumes square)
 
-   int height_;   /// Height of neuron map
+   int height_;                     /// Height of neuron map
 
-   int totalNeurons_;   /// Count of neurons in the simulation
+   int totalNeurons_;               /// Count of neurons in the simulation
 
-   int currentEpoch_;   /// Current epoch step
+   int currentEpoch_;               /// Current epoch step
 
-   int numEpochs_;   /// Number of simulator epochs
+   int numEpochs_;                  /// Number of simulator epochs
 
-   BGFLOAT epochDuration_;   /// The length of each epoch in simulation time
+   BGFLOAT epochDuration_;          /// The length of each epoch in simulation time
 
-   int maxFiringRate_;   /// Maximum firing rate. **GPU Only**
+   int maxFiringRate_;              /// Maximum firing rate. **GPU Only**
 
-   int maxEdgesPerVertex_;   /// Maximum number of synapses per neuron. **GPU
-                             /// Only**
+   int maxEdgesPerVertex_;          /// Maximum number of synapses per neuron. **GPU
+                                    /// Only**
 
-   BGFLOAT deltaT_;   /// Inner Simulation Step Duration, purely investigative.
+   BGFLOAT deltaT_;                 /// Inner Simulation Step Duration, purely investigative.
 
-   BGFLOAT maxRate_;   /// growth variable (m_targetRate / m_epsilon) TODO: more
-                       /// detail here
+   BGFLOAT maxRate_;                /// growth variable (m_targetRate / m_epsilon) TODO: more
+                                    /// detail here
 
-   long noiseRngSeed_;   /// Seed used for the simulation random SINGLE THREADED
+   long noiseRngSeed_;              /// Seed used for the simulation random SINGLE THREADED
 
-   long initRngSeed_;   /// Seed used to initialize parameters
+   long initRngSeed_;               /// Seed used to initialize parameters
 
-   string configFileName_;   /// File name of the parameter configuration file.
+   string configFileName_;          /// File name of the parameter configuration file.
 
    string serializationFileName_;   /// File name of the serialization file.
 
    string deserializationFileName_;   /// File name of the deserialization file.
 
-   string stimulusFileName_;   /// File name of the stimulus input file.
+   string stimulusFileName_;          /// File name of the stimulus input file.
 
-   unique_ptr<Model> model_;   /// Smart pointer to model class (Model is an interface class)
+   unique_ptr<Model> model_;          /// Smart pointer to model class (Model is an interface class)
 
    log4cplus::Logger
       consoleLogger_;   /// Logger for printing to the console as well as the logging file

--- a/Simulator/Core/Simulator.h
+++ b/Simulator/Core/Simulator.h
@@ -29,13 +29,13 @@ public:
                                       /// of singleton object
    virtual ~Simulator() = default;    /// Destructor
 
-   void setup();                      /// Setup simulation.
+   void setup();   /// Setup simulation.
 
-   void finish();                     /// Cleanup after simulation.
+   void finish();   /// Cleanup after simulation.
 
-   void loadParameters();             /// Load member variables from configuration file
+   void loadParameters();   /// Load member variables from configuration file
 
-   void printParameters() const;      /// Prints loaded parameters to logging file.
+   void printParameters() const;   /// Prints loaded parameters to logging file.
 
    // Copied over from STDPFix
    void copyGPUSynapseToCPU();   /// Copy GPU Synapse data to CPU.
@@ -43,7 +43,7 @@ public:
    // Copied over from STDPFix
    void copyCPUSynapseToGPU();   /// Copy CPU Synapse data to GPU.
 
-   void reset();                 /// Reset simulation objects.
+   void reset();   /// Reset simulation objects.
 
    void simulate();
 
@@ -61,20 +61,20 @@ public:
    *  Accessors
    ***********************************************/
    ///@{
-   int getWidth() const;           /// Width of neuron map (assumes square)
+   int getWidth() const;   /// Width of neuron map (assumes square)
 
-   int getHeight() const;          /// Height of neuron map
+   int getHeight() const;   /// Height of neuron map
 
    int getTotalVertices() const;   /// Count of neurons in the simulation
 
-   int getCurrentStep() const;     /// Current simulation step
+   int getCurrentStep() const;   /// Current simulation step
 
-   int getNumEpochs() const;       /// Maximum number of simulation steps
+   int getNumEpochs() const;   /// Maximum number of simulation steps
 
    BGFLOAT
-   getEpochDuration() const;           /// The length of each step in simulation time
+   getEpochDuration() const;   /// The length of each step in simulation time
 
-   int getMaxFiringRate() const;       /// Maximum firing rate. **GPU Only**
+   int getMaxFiringRate() const;   /// Maximum firing rate. **GPU Only**
 
    int getMaxEdgesPerVertex() const;   /// Maximum number of synapses per neuron. **GPU Only**
 
@@ -83,23 +83,23 @@ public:
                         /// simulation step
 
    BGFLOAT
-   getMaxRate() const;             /// growth variable (m_targetRate / m_epsilon) TODO: more
-                                   /// detail here
+   getMaxRate() const;   /// growth variable (m_targetRate / m_epsilon) TODO: more
+                         /// detail here
 
    long getNoiseRngSeed() const;   /// Seed used for the simulation random **SingleThreaded Only**
 
-   long getInitRngSeed() const;    /// Seed used to initialize parameters
+   long getInitRngSeed() const;   /// Seed used to initialize parameters
 
-   string getConfigFileName() const;            /// File name of the parameter configuration file.
+   string getConfigFileName() const;   /// File name of the parameter configuration file.
 
-   string getSerializationFileName() const;     /// File name of the serialization file.
+   string getSerializationFileName() const;   /// File name of the serialization file.
 
    string getDeserializationFileName() const;   /// File name of the deserialization file.
 
-   string getStimulusFileName() const;          /// File name of the stimulus input file.
+   string getStimulusFileName() const;   /// File name of the stimulus input file.
 
-   Model &getModel() const;                     /// Neural Network Model interface.
-                                                ///@}
+   Model &getModel() const;   /// Neural Network Model interface.
+                              ///@}
 
    /************************************************
    *  Mutators
@@ -127,44 +127,44 @@ public:
    Simulator &operator=(Simulator &&simulator) = delete;
 
 private:
-   Simulator();                     /// Constructor is private to keep a singleton instance of this
-                                    /// class.
+   Simulator();   /// Constructor is private to keep a singleton instance of this
+                  /// class.
 
-   int width_;                      /// Width of neuron map (assumes square)
+   int width_;   /// Width of neuron map (assumes square)
 
-   int height_;                     /// Height of neuron map
+   int height_;   /// Height of neuron map
 
-   int totalNeurons_;               /// Count of neurons in the simulation
+   int totalNeurons_;   /// Count of neurons in the simulation
 
-   int currentEpoch_;               /// Current epoch step
+   int currentEpoch_;   /// Current epoch step
 
-   int numEpochs_;                  /// Number of simulator epochs
+   int numEpochs_;   /// Number of simulator epochs
 
-   BGFLOAT epochDuration_;          /// The length of each epoch in simulation time
+   BGFLOAT epochDuration_;   /// The length of each epoch in simulation time
 
-   int maxFiringRate_;              /// Maximum firing rate. **GPU Only**
+   int maxFiringRate_;   /// Maximum firing rate. **GPU Only**
 
-   int maxEdgesPerVertex_;          /// Maximum number of synapses per neuron. **GPU
-                                    /// Only**
+   int maxEdgesPerVertex_;   /// Maximum number of synapses per neuron. **GPU
+                             /// Only**
 
-   BGFLOAT deltaT_;                 /// Inner Simulation Step Duration, purely investigative.
+   BGFLOAT deltaT_;   /// Inner Simulation Step Duration, purely investigative.
 
-   BGFLOAT maxRate_;                /// growth variable (m_targetRate / m_epsilon) TODO: more
-                                    /// detail here
+   BGFLOAT maxRate_;   /// growth variable (m_targetRate / m_epsilon) TODO: more
+                       /// detail here
 
-   long noiseRngSeed_;              /// Seed used for the simulation random SINGLE THREADED
+   long noiseRngSeed_;   /// Seed used for the simulation random SINGLE THREADED
 
-   long initRngSeed_;               /// Seed used to initialize parameters
+   long initRngSeed_;   /// Seed used to initialize parameters
 
-   string configFileName_;          /// File name of the parameter configuration file.
+   string configFileName_;   /// File name of the parameter configuration file.
 
    string serializationFileName_;   /// File name of the serialization file.
 
    string deserializationFileName_;   /// File name of the deserialization file.
 
-   string stimulusFileName_;          /// File name of the stimulus input file.
+   string stimulusFileName_;   /// File name of the stimulus input file.
 
-   unique_ptr<Model> model_;          /// Smart pointer to model class (Model is an interface class)
+   unique_ptr<Model> model_;   /// Smart pointer to model class (Model is an interface class)
 
    log4cplus::Logger
       consoleLogger_;   /// Logger for printing to the console as well as the logging file

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -227,10 +227,10 @@ void AllEdges::createEdgeIndexMap(EdgeIndexMap &edgeIndexMap)
 ///
 ///  @param  vertices           The vertices.
 ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-void AllEdges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap)
+void AllEdges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap)
 {
    for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
-      BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
+      BGSIZE iEdg = edgeIndexMap.incomingEdgeIndexMap_[i];
       advanceEdge(iEdg, vertices);
    }
 }

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -182,13 +182,13 @@ public:
    ///
    ///  @param  vertices       The Vertex list to search from.
    ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-   virtual void advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap);
+   virtual void advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap);
 
    ///  Advance one specific Edge.
    ///
    ///  @param  iEdg      Index of the Edge to connect to.
    ///  @param  vertices  The Vertex list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *vertices) = 0;
+   virtual void advanceEdge(const BGSIZE iEdg, AllVertices &vertices) = 0;
 
    ///  Remove a edge from the network.
    ///

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -54,15 +54,15 @@ void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, B
 ///
 ///  @param  vertices           The vertex list to search from.
 ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-void All911Edges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap)
+void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap)
 {
-   All911Vertices *allVertices = dynamic_cast<All911Vertices *>(vertices);
+   All911Vertices &allVertices = dynamic_cast<All911Vertices &>(vertices);
    for (BGSIZE i = 0; i < totalEdgeCount_; i++) {
       if (!inUse_[i]) {
          continue;
       }
       // if the edge is in use...
-      BGSIZE iEdg = edgeIndexMap->incomingEdgeIndexMap_[i];
+      BGSIZE iEdg = edgeIndexMap.incomingEdgeIndexMap_[i];
       advance911Edge(iEdg, allVertices);
    }
 }
@@ -71,7 +71,7 @@ void All911Edges::advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap
 ///
 ///  @param  iEdg      Index of the edge to connect to.
 ///  @param  vertices   The vertex list to search from.
-void All911Edges::advance911Edge(const BGSIZE iEdg, All911Vertices *vertices)
+void All911Edges::advance911Edge(const BGSIZE iEdg, All911Vertices &vertices)
 {
    // edge
    // source node   -->   destination node

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -85,16 +85,16 @@ public:
    ///
    ///  @param  vertices           The vertex list to search from.
    ///  @param  edgeIndexMap   Pointer to EdgeIndexMap structure.
-   virtual void advanceEdges(AllVertices *vertices, EdgeIndexMap *edgeIndexMap);
+   virtual void advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap);
 
    ///  Advance one specific Edge.
    ///
    ///  @param  iEdg      Index of the Edge to connect to.
    ///  @param  vertices  The Neuron list to search from.
-   void advance911Edge(const BGSIZE iEdg, All911Vertices *vertices);
+   void advance911Edge(const BGSIZE iEdg, All911Vertices &vertices);
 
    /// unused virtual function placeholder
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *vertices) override {};
+   virtual void advanceEdge(const BGSIZE iEdg, AllVertices &vertices) override {};
 
 #endif
 };

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -259,7 +259,7 @@ void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVerte
 ///
 ///  @param  iEdg      Index of the Synapse to connect to.
 ///  @param  neurons   The Neuron list to search from.
-void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
+void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices &neurons)
 {
    // If the synapse is inhibitory or its weight is zero, update synapse state using AllSpikingSynapses::advanceEdge method
    //LOG4CPLUS_DEBUG(edgeLogger_, "iEdg : " << iEdg );
@@ -286,7 +286,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
       const int total_delay = totalDelay_[iEdg];
 
       BGFLOAT deltaT = Simulator::getInstance().getDeltaT();
-      AllSpikingNeurons *spNeurons = dynamic_cast<AllSpikingNeurons *>(neurons);
+      AllSpikingNeurons &spNeurons = dynamic_cast<AllSpikingNeurons &>(neurons);
 
       // pre and post neurons index
       int idxPre = sourceVertexIndex_[iEdg];
@@ -299,7 +299,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
          // spikeCount points to the next available position of spike_history,
          // so the getSpikeHistory w/offset = -2 will return the spike time
          // just one before the last spike.
-         spikeHistory = spNeurons->getSpikeHistory(idxPre, -2);
+         spikeHistory = spNeurons.getSpikeHistory(idxPre, -2);
 
          epre = 1.0;
          epost = 1.0;
@@ -307,7 +307,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
          // pre-post spikes
          int offIndex = -1;   // last spike
          while (true) {
-            spikeHistory = spNeurons->getSpikeHistory(idxPost, offIndex);
+            spikeHistory = spNeurons.getSpikeHistory(idxPost, offIndex);
             if (spikeHistory == numeric_limits<unsigned long>::max())
                break;
             // delta is the spike interval between pre-post spikes
@@ -339,7 +339,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
                      // spikeCount points to the next available position of spike_history,
                      // so the getSpikeHistory w/offset = -2 will return the spike time
                      // just one before the last spike.
-         spikeHistory = spNeurons->getSpikeHistory(idxPost, -2);
+         spikeHistory = spNeurons.getSpikeHistory(idxPost, -2);
          epost = 1.0;
          epre = 1;
 
@@ -348,7 +348,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
          // post-pre spikes
          int offIndex = -1;   // last spike
          while (true) {
-            spikeHistory = spNeurons->getSpikeHistory(idxPre, offIndex);
+            spikeHistory = spNeurons.getSpikeHistory(idxPre, offIndex);
             if (spikeHistory == numeric_limits<unsigned long>::max())
                break;
 

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -250,7 +250,7 @@ public:
    ///
    ///  @param  iEdg      Index of the Synapse to connect to.
    ///  @param  neurons   The Neuron list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *neurons) override;
+   virtual void advanceEdge(const BGSIZE iEdg, AllVertices &neurons) override;
 
    ///  Prepares Synapse for a spike hit (for back propagation).
    ///

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -271,7 +271,7 @@ void AllSpikingSynapses::postSpikeHit(const BGSIZE iEdg)
 ///
 ///  @param  iEdg      Index of the Synapse to connect to.
 ///  @param  neurons   The Neuron list to search from.
-void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices *neurons)
+void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices &neurons)
 {
    BGFLOAT &decay = decay_[iEdg];
    BGFLOAT &psr = psr_[iEdg];

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -231,7 +231,7 @@ public:
    ///
    ///  @param  iEdg      Index of the Synapse to connect to.
    ///  @param  neurons   The Neuron list to search from.
-   virtual void advanceEdge(const BGSIZE iEdg, AllVertices *neurons) override;
+   virtual void advanceEdge(const BGSIZE iEdg, AllVertices &neurons) override;
 
    ///  Prepares Synapse for a spike hit.
    ///

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -42,9 +42,9 @@ Layout::Layout() : numEndogenouslyActiveNeurons_(0)
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
-AllVertices *Layout::getVertices() const
+AllVertices &Layout::getVertices() const
 {
-   return vertices_.get();
+   return *vertices_;
 }
 
 int Layout::getNumVertices() const

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -32,6 +32,7 @@ public:
 
    virtual ~Layout() = default;
 
+   /// Returns reference to Vertices
    AllVertices &getVertices() const;
 
    /// Setup the internal structure of the class.

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -32,7 +32,7 @@ public:
 
    virtual ~Layout() = default;
 
-   AllVertices *getVertices() const;
+   AllVertices &getVertices() const;
 
    /// Setup the internal structure of the class.
    /// Allocate memories to store all layout state.
@@ -67,24 +67,24 @@ public:
    /// @return The number of vertices managed by the Layout
    virtual int getNumVertices() const;
 
-   VectorMatrix xloc_;   ///< Store neuron i's x location.
+   VectorMatrix xloc_;      ///< Store neuron i's x location.
 
-   VectorMatrix yloc_;   ///< Store neuron i's y location.
+   VectorMatrix yloc_;      ///< Store neuron i's y location.
 
    CompleteMatrix dist2_;   ///< Inter-neuron distance squared.
 
-   CompleteMatrix dist_;   ///< The true inter-neuron distance.
+   CompleteMatrix dist_;    ///< The true inter-neuron distance.
 
    vector<int>
       probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
 
-   vector<vertexType> vertexTypeMap_;   ///< The vertex type map (INH, EXC).
+   vector<vertexType> vertexTypeMap_;      ///< The vertex type map (INH, EXC).
 
-   vector<bool> starterMap_;   ///< The starter existence map (T/F).
+   vector<bool> starterMap_;               ///< The starter existence map (T/F).
 
    BGSIZE numEndogenouslyActiveNeurons_;   ///< Number of endogenously active neurons.
 
-   BGSIZE numCallerVertices_;   ///< Number of caller vertices.
+   BGSIZE numCallerVertices_;              ///< Number of caller vertices.
 
 
 protected:
@@ -92,7 +92,7 @@ protected:
 
    vector<int> endogenouslyActiveNeuronList_;   ///< Endogenously active neurons list.
 
-   vector<int> inhibitoryNeuronLayout_;   ///< Inhibitory neurons list.
+   vector<int> inhibitoryNeuronLayout_;         ///< Inhibitory neurons list.
 
    log4cplus::Logger fileLogger_;
 

--- a/Simulator/Layouts/Layout.h
+++ b/Simulator/Layouts/Layout.h
@@ -67,24 +67,24 @@ public:
    /// @return The number of vertices managed by the Layout
    virtual int getNumVertices() const;
 
-   VectorMatrix xloc_;      ///< Store neuron i's x location.
+   VectorMatrix xloc_;   ///< Store neuron i's x location.
 
-   VectorMatrix yloc_;      ///< Store neuron i's y location.
+   VectorMatrix yloc_;   ///< Store neuron i's y location.
 
    CompleteMatrix dist2_;   ///< Inter-neuron distance squared.
 
-   CompleteMatrix dist_;    ///< The true inter-neuron distance.
+   CompleteMatrix dist_;   ///< The true inter-neuron distance.
 
    vector<int>
       probedNeuronList_;   ///< Probed neurons list. // ToDo: Move this to Hdf5 recorder once its implemented in project -chris
 
-   vector<vertexType> vertexTypeMap_;      ///< The vertex type map (INH, EXC).
+   vector<vertexType> vertexTypeMap_;   ///< The vertex type map (INH, EXC).
 
-   vector<bool> starterMap_;               ///< The starter existence map (T/F).
+   vector<bool> starterMap_;   ///< The starter existence map (T/F).
 
    BGSIZE numEndogenouslyActiveNeurons_;   ///< Number of endogenously active neurons.
 
-   BGSIZE numCallerVertices_;              ///< Number of caller vertices.
+   BGSIZE numCallerVertices_;   ///< Number of caller vertices.
 
 
 protected:
@@ -92,7 +92,7 @@ protected:
 
    vector<int> endogenouslyActiveNeuronList_;   ///< Endogenously active neurons list.
 
-   vector<int> inhibitoryNeuronLayout_;         ///< Inhibitory neurons list.
+   vector<int> inhibitoryNeuronLayout_;   ///< Inhibitory neurons list.
 
    log4cplus::Logger fileLogger_;
 

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -133,9 +133,9 @@ void Hdf5Recorder::initDataSet()
    Model *model = simulator.getModel();
 
    // Set up probed neurons so that they can be written incrementally
-   if (model->getLayout()->probedNeuronList_.size() > 0) {
+   if (model->getLayout().probedNeuronList_.size() > 0) {
       // create the data space & dataset for probed neurons
-      dims[0] = static_cast<hsize_t>(model->getLayout()->probedNeuronList_.size());
+      dims[0] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
       DataSpace dsProbedNeurons(1, dims);
       dataSetProbedNeurons_
          = resultOut_.createDataSet(nameProbedNeurons, PredType::NATIVE_INT, dsProbedNeurons);
@@ -145,11 +145,11 @@ void Hdf5Recorder::initDataSet()
       // the data space with unlimited dimensions
       hsize_t maxdims[2];
       maxdims[0] = H5S_UNLIMITED;
-      maxdims[1] = static_cast<hsize_t>(model->getLayout()->probedNeuronList_.size());
+      maxdims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
 
       // dataset dimensions at creation
       dims[0] = static_cast<hsize_t>(1);
-      dims[1] = static_cast<hsize_t>(model->getLayout()->probedNeuronList_.size());
+      dims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
       DataSpace dsSpikesProbedNeurons(2, dims, maxdims);
 
       // set fill value for the dataset
@@ -160,7 +160,7 @@ void Hdf5Recorder::initDataSet()
       // modify dataset creation properties, enable chunking
       hsize_t chunk_dims[2];
       chunk_dims[0] = static_cast<hsize_t>(100);
-      chunk_dims[1] = static_cast<hsize_t>(model->getLayout()->probedNeuronList_.size());
+      chunk_dims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
       cparms.setChunk(2, chunk_dims);
 
       dataSetSpikesProbedNeurons_ = resultOut_.createDataSet(
@@ -172,13 +172,13 @@ void Hdf5Recorder::initDataSet()
    spikesHistory_.assign(static_cast<int>(simulator.getEpochDuration() * 100), 0);
 
    // create the data space & dataset for spikes history of probed neurons
-   if (model->getLayout()->probedNeuronList_.size() > 0) {
+   if (model->getLayout().probedNeuronList_.size() > 0) {
       // allocate data for spikesProbedNeurons
-      spikesProbedNeurons_.resize(model->getLayout()->probedNeuronList_.size());
+      spikesProbedNeurons_.resize(model->getLayout().probedNeuronList_.size());
 
       // allocate and initialize memory to save offsets of what's been written
-      offsetSpikesProbedNeurons_.resize(model->getLayout()->probedNeuronList_.size());
-      offsetSpikesProbedNeurons_.assign(model->getLayout()->probedNeuronList_.size(), 0);
+      offsetSpikesProbedNeurons_.resize(model->getLayout().probedNeuronList_.size());
+      offsetSpikesProbedNeurons_.assign(model->getLayout().probedNeuronList_.size(), 0);
    }
 }
 
@@ -221,8 +221,8 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
    // output spikes: iterate over each neuron
    for (int iVertex = 0; iVertex < spNeurons.vertexEvents_.size(); iVertex++) {
       // true if this is a probed neuron
-      fProbe = ((iProbe < model->getLayout()->probedNeuronList_.size())
-                && (iVertex == model->getLayout()->probedNeuronList_[iProbe]));
+      fProbe = ((iProbe < model->getLayout().probedNeuronList_.size())
+                && (iVertex == model->getLayout().probedNeuronList_[iProbe]));
 
       // iterate over each spike that neuron produced
       for (int eventIterator = 0;
@@ -276,24 +276,24 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
       spikesHistory_.assign(static_cast<int>(simulator.getEpochDuration() * 100), 0);
 
       // write spikes data of probed neurons
-      if (model->getLayout()->probedNeuronList_.size() > 0) {
+      if (model->getLayout().probedNeuronList_.size() > 0) {
          unsigned int max_size = 0;
          // iterate over each neuron to find the maximum number of spikes for
          // this epoch
-         for (unsigned int i = 0; i < model->getLayout()->probedNeuronList_.size(); i++) {
+         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
             unsigned int size = spikesProbedNeurons_[i].size() + offsetSpikesProbedNeurons_[i];
             max_size = (max_size > size) ? max_size : size;
          }
          // dataset dimensions
          dimsm[0] = static_cast<hsize_t>(max_size);
-         dimsm[1] = static_cast<hsize_t>(model->getLayout()->probedNeuronList_.size());
+         dimsm[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
 
          // extend the dataset
          dataSetSpikesProbedNeurons_.extend(dimsm);
          dataspace = dataSetSpikesProbedNeurons_.getSpace();
 
          // write it! Iterate over each neuron's spike data.
-         for (unsigned int i = 0; i < model->getLayout()->probedNeuronList_.size(); i++) {
+         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
             dimsm[0] = spikesProbedNeurons_[i].size();
             dimsm[1] = 1;
             DataSpace memspace_spike(2, dimsm, nullptr);
@@ -352,7 +352,7 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       // create Neuron Types matrix
       VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
       for (int i = 0; i < simulator.getTotalVertices(); i++) {
-         neuronTypes[i] = model->getLayout()->vertexTypeMap_[i];
+         neuronTypes[i] = model->getLayout().vertexTypeMap_[i];
       }
 
       // create neuron threshold matrix
@@ -366,8 +366,8 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       vector<int> iYloc(simulator.getTotalVertices());
       for (int i = 0; i < simulator.getTotalVertices(); i++) {
          // convert VectorMatrix to int array
-         iXloc[i] = (model->getLayout()->xloc_)[i];
-         iYloc[i] = (model->getLayout()->yloc_)[i];
+         iXloc[i] = (model->getLayout().xloc_)[i];
+         iYloc[i] = (model->getLayout().yloc_)[i];
       }
       dataSetXloc_.write(iXloc.data(), PredType::NATIVE_INT);
       dataSetYloc_.write(iYloc.data(), PredType::NATIVE_INT);
@@ -378,10 +378,10 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       }
       dataSetNeuronTypes_.write(iNeuronTypes, PredType::NATIVE_INT);
 
-      int num_starter_neurons = static_cast<int>(model->getLayout()->numEndogenouslyActiveNeurons_);
+      int num_starter_neurons = static_cast<int>(model->getLayout().numEndogenouslyActiveNeurons_);
       if (num_starter_neurons > 0) {
          VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-         getStarterNeuronMatrix(starterNeurons, model->getLayout()->starterMap_);
+         getStarterNeuronMatrix(starterNeurons, model->getLayout().starterMap_);
 
          // create the data space & dataset for starter neurons
          hsize_t dims[2];
@@ -398,13 +398,13 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       }
 
       // Finalize probed neurons' spikes dataset
-      if (model->getLayout()->probedNeuronList_.size() > 0) {
+      if (model->getLayout().probedNeuronList_.size() > 0) {
          // create the data space & dataset for probed neurons
          hsize_t dims[2];
 
-         vector<int> iProbedNeurons(model->getLayout()->probedNeuronList_.size());
-         for (unsigned int i = 0; i < model->getLayout()->probedNeuronList_.size(); i++) {
-            iProbedNeurons[i] = model->getLayout()->probedNeuronList_[i];
+         vector<int> iProbedNeurons(model->getLayout().probedNeuronList_.size());
+         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
+            iProbedNeurons[i] = model->getLayout().probedNeuronList_[i];
          }
          dataSetProbedNeurons_.write(iProbedNeurons.data(), PredType::NATIVE_INT);
 

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -186,7 +186,7 @@ void Hdf5Recorder::initDataSet()
       spikesProbedNeurons_.resize(model.getLayout().probedNeuronList_.size());
 
       // allocate and initialize memory to save offsets of what's been written
-      offsetSpikesProbedNeurons_.assign(model.getLayout()->probedNeuronList_.size(), 0);
+      offsetSpikesProbedNeurons_.assign(model.getLayout().probedNeuronList_.size(), 0);
    }
 }
 

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -130,12 +130,12 @@ void Hdf5Recorder::initDataSet()
       = resultOut_.createDataSet(nameSimulationEndTime, H5_FLOAT, dsSimulationEndTime);
 
    // Get model instance
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
    // Set up probed neurons so that they can be written incrementally
-   if (model->getLayout().probedNeuronList_.size() > 0) {
+   if (model.getLayout().probedNeuronList_.size() > 0) {
       // create the data space & dataset for probed neurons
-      dims[0] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
+      dims[0] = static_cast<hsize_t>(model.getLayout().probedNeuronList_.size());
       DataSpace dsProbedNeurons(1, dims);
       dataSetProbedNeurons_
          = resultOut_.createDataSet(nameProbedNeurons, PredType::NATIVE_INT, dsProbedNeurons);
@@ -145,11 +145,11 @@ void Hdf5Recorder::initDataSet()
       // the data space with unlimited dimensions
       hsize_t maxdims[2];
       maxdims[0] = H5S_UNLIMITED;
-      maxdims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
+      maxdims[1] = static_cast<hsize_t>(model.getLayout().probedNeuronList_.size());
 
       // dataset dimensions at creation
       dims[0] = static_cast<hsize_t>(1);
-      dims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
+      dims[1] = static_cast<hsize_t>(model.getLayout().probedNeuronList_.size());
       DataSpace dsSpikesProbedNeurons(2, dims, maxdims);
 
       // set fill value for the dataset
@@ -160,7 +160,7 @@ void Hdf5Recorder::initDataSet()
       // modify dataset creation properties, enable chunking
       hsize_t chunk_dims[2];
       chunk_dims[0] = static_cast<hsize_t>(100);
-      chunk_dims[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
+      chunk_dims[1] = static_cast<hsize_t>(model.getLayout().probedNeuronList_.size());
       cparms.setChunk(2, chunk_dims);
 
       dataSetSpikesProbedNeurons_ = resultOut_.createDataSet(
@@ -172,13 +172,13 @@ void Hdf5Recorder::initDataSet()
    spikesHistory_.assign(static_cast<int>(simulator.getEpochDuration() * 100), 0);
 
    // create the data space & dataset for spikes history of probed neurons
-   if (model->getLayout().probedNeuronList_.size() > 0) {
+   if (model.getLayout().probedNeuronList_.size() > 0) {
       // allocate data for spikesProbedNeurons
-      spikesProbedNeurons_.resize(model->getLayout().probedNeuronList_.size());
+      spikesProbedNeurons_.resize(model.getLayout().probedNeuronList_.size());
 
       // allocate and initialize memory to save offsets of what's been written
-      offsetSpikesProbedNeurons_.resize(model->getLayout().probedNeuronList_.size());
-      offsetSpikesProbedNeurons_.assign(model->getLayout().probedNeuronList_.size(), 0);
+      offsetSpikesProbedNeurons_.resize(model.getLayout().probedNeuronList_.size());
+      offsetSpikesProbedNeurons_.assign(model.getLayout().probedNeuronList_.size(), 0);
    }
 }
 
@@ -216,13 +216,13 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
    unsigned int iProbe = 0;   // index into the probedNeuronsLayout vector
    bool fProbe = false;
 
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
    // output spikes: iterate over each neuron
    for (int iVertex = 0; iVertex < spNeurons.vertexEvents_.size(); iVertex++) {
       // true if this is a probed neuron
-      fProbe = ((iProbe < model->getLayout().probedNeuronList_.size())
-                && (iVertex == model->getLayout().probedNeuronList_[iProbe]));
+      fProbe = ((iProbe < model.getLayout().probedNeuronList_.size())
+                && (iVertex == model.getLayout().probedNeuronList_[iProbe]));
 
       // iterate over each spike that neuron produced
       for (int eventIterator = 0;
@@ -276,24 +276,24 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
       spikesHistory_.assign(static_cast<int>(simulator.getEpochDuration() * 100), 0);
 
       // write spikes data of probed neurons
-      if (model->getLayout().probedNeuronList_.size() > 0) {
+      if (model.getLayout().probedNeuronList_.size() > 0) {
          unsigned int max_size = 0;
          // iterate over each neuron to find the maximum number of spikes for
          // this epoch
-         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
+         for (unsigned int i = 0; i < model.getLayout().probedNeuronList_.size(); i++) {
             unsigned int size = spikesProbedNeurons_[i].size() + offsetSpikesProbedNeurons_[i];
             max_size = (max_size > size) ? max_size : size;
          }
          // dataset dimensions
          dimsm[0] = static_cast<hsize_t>(max_size);
-         dimsm[1] = static_cast<hsize_t>(model->getLayout().probedNeuronList_.size());
+         dimsm[1] = static_cast<hsize_t>(model.getLayout().probedNeuronList_.size());
 
          // extend the dataset
          dataSetSpikesProbedNeurons_.extend(dimsm);
          dataspace = dataSetSpikesProbedNeurons_.getSpace();
 
          // write it! Iterate over each neuron's spike data.
-         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
+         for (unsigned int i = 0; i < model.getLayout().probedNeuronList_.size(); i++) {
             dimsm[0] = spikesProbedNeurons_[i].size();
             dimsm[1] = 1;
             DataSpace memspace_spike(2, dimsm, nullptr);
@@ -346,13 +346,13 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
 void Hdf5Recorder::saveSimData(const AllVertices &vertices)
 {
    Simulator &simulator = Simulator::getInstance();
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
    try {
       // create Neuron Types matrix
       VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
       for (int i = 0; i < simulator.getTotalVertices(); i++) {
-         neuronTypes[i] = model->getLayout().vertexTypeMap_[i];
+         neuronTypes[i] = model.getLayout().vertexTypeMap_[i];
       }
 
       // create neuron threshold matrix
@@ -366,8 +366,8 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       vector<int> iYloc(simulator.getTotalVertices());
       for (int i = 0; i < simulator.getTotalVertices(); i++) {
          // convert VectorMatrix to int array
-         iXloc[i] = (model->getLayout().xloc_)[i];
-         iYloc[i] = (model->getLayout().yloc_)[i];
+         iXloc[i] = (model.getLayout().xloc_)[i];
+         iYloc[i] = (model.getLayout().yloc_)[i];
       }
       dataSetXloc_.write(iXloc.data(), PredType::NATIVE_INT);
       dataSetYloc_.write(iYloc.data(), PredType::NATIVE_INT);
@@ -378,10 +378,10 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       }
       dataSetNeuronTypes_.write(iNeuronTypes, PredType::NATIVE_INT);
 
-      int num_starter_neurons = static_cast<int>(model->getLayout().numEndogenouslyActiveNeurons_);
+      int num_starter_neurons = static_cast<int>(model.getLayout().numEndogenouslyActiveNeurons_);
       if (num_starter_neurons > 0) {
          VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-         getStarterNeuronMatrix(starterNeurons, model->getLayout().starterMap_);
+         getStarterNeuronMatrix(starterNeurons, model.getLayout().starterMap_);
 
          // create the data space & dataset for starter neurons
          hsize_t dims[2];
@@ -398,13 +398,13 @@ void Hdf5Recorder::saveSimData(const AllVertices &vertices)
       }
 
       // Finalize probed neurons' spikes dataset
-      if (model->getLayout().probedNeuronList_.size() > 0) {
+      if (model.getLayout().probedNeuronList_.size() > 0) {
          // create the data space & dataset for probed neurons
          hsize_t dims[2];
 
-         vector<int> iProbedNeurons(model->getLayout().probedNeuronList_.size());
-         for (unsigned int i = 0; i < model->getLayout().probedNeuronList_.size(); i++) {
-            iProbedNeurons[i] = model->getLayout().probedNeuronList_[i];
+         vector<int> iProbedNeurons(model.getLayout().probedNeuronList_.size());
+         for (unsigned int i = 0; i < model.getLayout().probedNeuronList_.size(); i++) {
+            iProbedNeurons[i] = model.getLayout().probedNeuronList_[i];
          }
          dataSetProbedNeurons_.write(iProbedNeurons.data(), PredType::NATIVE_INT);
 

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -40,8 +40,8 @@ void Xml911Recorder::compileHistories(AllVertices &vertices)
 /// @param  vertices the Vertex list to search from.
 void Xml911Recorder::saveSimData(const AllVertices &vertices)
 {
-   auto conns = Simulator::getInstance().getModel()->getConnections();
-   Connections911 &conns911 = dynamic_cast<Connections911 &>(*conns);
+   auto &conns = Simulator::getInstance().getModel()->getConnections();
+   Connections911 &conns911 = dynamic_cast<Connections911 &>(conns);
 
    // create Vertex Types matrix
    VectorMatrix oldTypes(MATRIX_TYPE, MATRIX_INIT, 1, Simulator::getInstance().getTotalVertices(),

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -40,7 +40,7 @@ void Xml911Recorder::compileHistories(AllVertices &vertices)
 /// @param  vertices the Vertex list to search from.
 void Xml911Recorder::saveSimData(const AllVertices &vertices)
 {
-   auto &conns = Simulator::getInstance().getModel()->getConnections();
+   auto &conns = Simulator::getInstance().getModel().getConnections();
    Connections911 &conns911 = dynamic_cast<Connections911 &>(conns);
 
    // create Vertex Types matrix
@@ -49,7 +49,7 @@ void Xml911Recorder::saveSimData(const AllVertices &vertices)
    VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1,
                             Simulator::getInstance().getTotalVertices(), EXC);
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      vertexTypes[i] = Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[i];
+      vertexTypes[i] = Simulator::getInstance().getModel().getLayout().vertexTypeMap_[i];
       oldTypes[i] = conns911.oldTypeMap_[i];
    }
 
@@ -57,7 +57,7 @@ void Xml911Recorder::saveSimData(const AllVertices &vertices)
    resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
               << "<!-- State output file for the 911 systems modeling-->\n";
    //stateOut << version; TODO: version
-   auto &layout = Simulator::getInstance().getModel()->getLayout();
+   auto &layout = Simulator::getInstance().getModel().getLayout();
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -49,7 +49,7 @@ void Xml911Recorder::saveSimData(const AllVertices &vertices)
    VectorMatrix vertexTypes(MATRIX_TYPE, MATRIX_INIT, 1,
                             Simulator::getInstance().getTotalVertices(), EXC);
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      vertexTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
+      vertexTypes[i] = Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[i];
       oldTypes[i] = conns911.oldTypeMap_[i];
    }
 
@@ -57,12 +57,12 @@ void Xml911Recorder::saveSimData(const AllVertices &vertices)
    resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
               << "<!-- State output file for the 911 systems modeling-->\n";
    //stateOut << version; TODO: version
-   auto layout = Simulator::getInstance().getModel()->getLayout();
+   auto &layout = Simulator::getInstance().getModel()->getLayout();
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";
-   resultOut_ << "   " << layout->xloc_.toXML("xloc") << endl;
-   resultOut_ << "   " << layout->yloc_.toXML("yloc") << endl;
+   resultOut_ << "   " << layout.xloc_.toXML("xloc") << endl;
+   resultOut_ << "   " << layout.yloc_.toXML("yloc") << endl;
    resultOut_ << "   " << oldTypes.toXML("vertexTypesPreEvent") << endl;
    resultOut_ << "   " << vertexTypes.toXML("vertexTypesPostEvent") << endl;
 

--- a/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
@@ -44,9 +44,9 @@ void Hdf5GrowthRecorder::initDataSet()
 void Hdf5GrowthRecorder::initDefaultValues()
 {
    Simulator &simulator = Simulator::getInstance();
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
-   Connections &connections = model->getConnections();
+   Connections &connections = model.getConnections();
    BGFLOAT startRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.startRadius;
 
    radiiHistory_.assign(simulator.getTotalVertices(), startRadius);
@@ -61,9 +61,9 @@ void Hdf5GrowthRecorder::initDefaultValues()
 void Hdf5GrowthRecorder::initValues()
 {
    Simulator &simulator = Simulator::getInstance();
-   Model *model = simulator.getModel();
+   Model &model = simulator.getModel();
 
-   Connections &connections = model->getConnections();
+   Connections &connections = model.getConnections();
 
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
       radiiHistory_[i] = (dynamic_cast<ConnGrowth &>(connections).radii_)[i];
@@ -78,8 +78,8 @@ void Hdf5GrowthRecorder::initValues()
 /// Get the current radii and rates values
 void Hdf5GrowthRecorder::getValues()
 {
-   Model *model = Simulator::getInstance().getModel();
-   Connections &connections = model->getConnections();
+   Model &model = Simulator::getInstance().getModel();
+   Connections &connections = model.getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       (dynamic_cast<ConnGrowth &>(connections).radii_)[i] = radiiHistory_[i];
@@ -100,8 +100,8 @@ void Hdf5GrowthRecorder::compileHistories(AllVertices &neurons)
 {
    Hdf5Recorder::compileHistories(neurons);
 
-   Model *model = Simulator::getInstance().getModel();
-   Connections &connections = model->getConnections();
+   Model &model = Simulator::getInstance().getModel();
+   Connections &connections = model.getConnections();
 
    BGFLOAT minRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.minRadius;
    VectorMatrix &rates = (dynamic_cast<ConnGrowth &>(connections).rates_);

--- a/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/Hdf5GrowthRecorder.cpp
@@ -46,8 +46,8 @@ void Hdf5GrowthRecorder::initDefaultValues()
    Simulator &simulator = Simulator::getInstance();
    Model *model = simulator.getModel();
 
-   Connections *connections = model->getConnections();
-   BGFLOAT startRadius = dynamic_cast<ConnGrowth *>(connections)->growthParams_.startRadius;
+   Connections &connections = model->getConnections();
+   BGFLOAT startRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.startRadius;
 
    radiiHistory_.assign(simulator.getTotalVertices(), startRadius);
    ratesHistory_.assign(simulator.getTotalVertices(), 0);
@@ -63,11 +63,11 @@ void Hdf5GrowthRecorder::initValues()
    Simulator &simulator = Simulator::getInstance();
    Model *model = simulator.getModel();
 
-   Connections *connections = model->getConnections();
+   Connections &connections = model->getConnections();
 
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      radiiHistory_[i] = (dynamic_cast<ConnGrowth *>(connections)->radii_)[i];
-      ratesHistory_[i] = (dynamic_cast<ConnGrowth *>(connections)->rates_)[i];
+      radiiHistory_[i] = (dynamic_cast<ConnGrowth &>(connections).radii_)[i];
+      ratesHistory_[i] = (dynamic_cast<ConnGrowth &>(connections).rates_)[i];
    }
 
    // write initial radii and rate
@@ -79,11 +79,11 @@ void Hdf5GrowthRecorder::initValues()
 void Hdf5GrowthRecorder::getValues()
 {
    Model *model = Simulator::getInstance().getModel();
-   Connections *connections = model->getConnections();
+   Connections &connections = model->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      (dynamic_cast<ConnGrowth *>(connections)->radii_)[i] = radiiHistory_[i];
-      (dynamic_cast<ConnGrowth *>(connections)->rates_)[i] = ratesHistory_[i];
+      (dynamic_cast<ConnGrowth &>(connections).radii_)[i] = radiiHistory_[i];
+      (dynamic_cast<ConnGrowth &>(connections).rates_)[i] = ratesHistory_[i];
    }
 }
 
@@ -101,11 +101,11 @@ void Hdf5GrowthRecorder::compileHistories(AllVertices &neurons)
    Hdf5Recorder::compileHistories(neurons);
 
    Model *model = Simulator::getInstance().getModel();
-   Connections *connections = model->getConnections();
+   Connections &connections = model->getConnections();
 
-   BGFLOAT minRadius = dynamic_cast<ConnGrowth *>(connections)->growthParams_.minRadius;
-   VectorMatrix &rates = (dynamic_cast<ConnGrowth *>(connections)->rates_);
-   VectorMatrix &radii = (dynamic_cast<ConnGrowth *>(connections)->radii_);
+   BGFLOAT minRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.minRadius;
+   VectorMatrix &rates = (dynamic_cast<ConnGrowth &>(connections).rates_);
+   VectorMatrix &radii = (dynamic_cast<ConnGrowth &>(connections).radii_);
 
    // output spikes
    for (int iVertex = 0; iVertex < Simulator::getInstance().getTotalVertices(); iVertex++) {

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -30,8 +30,8 @@ void XmlGrowthRecorder::init()
 /// Init radii and rates history matrices with default values
 void XmlGrowthRecorder::initDefaultValues()
 {
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
-   BGFLOAT startRadius = dynamic_cast<ConnGrowth *>(connections)->growthParams_.startRadius;
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   BGFLOAT startRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.startRadius;
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       (*radiiHistory_)(0, i) = startRadius;
@@ -42,23 +42,23 @@ void XmlGrowthRecorder::initDefaultValues()
 /// Init radii and rates history matrices with current radii and rates
 void XmlGrowthRecorder::initValues()
 {
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      (*radiiHistory_)(0, i) = (dynamic_cast<ConnGrowth *>(connections)->radii_)[i];
-      (*ratesHistory_)(0, i) = (dynamic_cast<ConnGrowth *>(connections)->rates_)[i];
+      (*radiiHistory_)(0, i) = (dynamic_cast<ConnGrowth &>(connections).radii_)[i];
+      (*ratesHistory_)(0, i) = (dynamic_cast<ConnGrowth &>(connections).rates_)[i];
    }
 }
 
 /// Get the current radii and rates values
 void XmlGrowthRecorder::getValues()
 {
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      (dynamic_cast<ConnGrowth *>(connections)->radii_)[i]
+      (dynamic_cast<ConnGrowth &>(connections).radii_)[i]
          = (*radiiHistory_)(Simulator::getInstance().getCurrentStep(), i);
-      (dynamic_cast<ConnGrowth *>(connections)->rates_)[i]
+      (dynamic_cast<ConnGrowth &>(connections).rates_)[i]
          = (*ratesHistory_)(Simulator::getInstance().getCurrentStep(), i);
    }
 }
@@ -70,11 +70,11 @@ void XmlGrowthRecorder::compileHistories(AllVertices &neurons)
 {
    XmlRecorder::compileHistories(neurons);
 
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
 
-   BGFLOAT minRadius = dynamic_cast<ConnGrowth *>(connections)->growthParams_.minRadius;
-   VectorMatrix &rates = (dynamic_cast<ConnGrowth *>(connections)->rates_);
-   VectorMatrix &radii = (dynamic_cast<ConnGrowth *>(connections)->radii_);
+   BGFLOAT minRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.minRadius;
+   VectorMatrix &rates = (dynamic_cast<ConnGrowth &>(connections).rates_);
+   VectorMatrix &radii = (dynamic_cast<ConnGrowth &>(connections).radii_);
 
    for (int iVertex = 0; iVertex < Simulator::getInstance().getTotalVertices(); iVertex++) {
       // record firing rate to history matrix

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -101,7 +101,7 @@ void XmlGrowthRecorder::saveSimData(const AllVertices &neurons)
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1,
                             Simulator::getInstance().getTotalVertices(), EXC);
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      neuronTypes[i] = Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[i];
+      neuronTypes[i] = Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[i];
    }
 
    // create neuron threshold matrix
@@ -121,19 +121,19 @@ void XmlGrowthRecorder::saveSimData(const AllVertices &neurons)
    resultOut_ << "   " << radiiHistory_->toXML("radiiHistory") << endl;
    resultOut_ << "   " << ratesHistory_->toXML("ratesHistory") << endl;
    resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->xloc_.toXML("xloc")
+   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout().xloc_.toXML("xloc")
               << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout()->yloc_.toXML("yloc")
+   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout().yloc_.toXML("yloc")
               << endl;
    resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter neuron matrix
    int num_starter_neurons = static_cast<int>(
-      Simulator::getInstance().getModel()->getLayout()->numEndogenouslyActiveNeurons_);
+      Simulator::getInstance().getModel()->getLayout().numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons,
-                             Simulator::getInstance().getModel()->getLayout()->starterMap_);
+                             Simulator::getInstance().getModel()->getLayout().starterMap_);
       resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 

--- a/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlGrowthRecorder.cpp
@@ -30,7 +30,7 @@ void XmlGrowthRecorder::init()
 /// Init radii and rates history matrices with default values
 void XmlGrowthRecorder::initDefaultValues()
 {
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
    BGFLOAT startRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.startRadius;
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
@@ -42,7 +42,7 @@ void XmlGrowthRecorder::initDefaultValues()
 /// Init radii and rates history matrices with current radii and rates
 void XmlGrowthRecorder::initValues()
 {
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       (*radiiHistory_)(0, i) = (dynamic_cast<ConnGrowth &>(connections).radii_)[i];
@@ -53,7 +53,7 @@ void XmlGrowthRecorder::initValues()
 /// Get the current radii and rates values
 void XmlGrowthRecorder::getValues()
 {
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       (dynamic_cast<ConnGrowth &>(connections).radii_)[i]
@@ -70,7 +70,7 @@ void XmlGrowthRecorder::compileHistories(AllVertices &neurons)
 {
    XmlRecorder::compileHistories(neurons);
 
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
 
    BGFLOAT minRadius = dynamic_cast<ConnGrowth &>(connections).growthParams_.minRadius;
    VectorMatrix &rates = (dynamic_cast<ConnGrowth &>(connections).rates_);
@@ -101,7 +101,7 @@ void XmlGrowthRecorder::saveSimData(const AllVertices &neurons)
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1,
                             Simulator::getInstance().getTotalVertices(), EXC);
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
-      neuronTypes[i] = Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[i];
+      neuronTypes[i] = Simulator::getInstance().getModel().getLayout().vertexTypeMap_[i];
    }
 
    // create neuron threshold matrix
@@ -121,19 +121,19 @@ void XmlGrowthRecorder::saveSimData(const AllVertices &neurons)
    resultOut_ << "   " << radiiHistory_->toXML("radiiHistory") << endl;
    resultOut_ << "   " << ratesHistory_->toXML("ratesHistory") << endl;
    resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout().xloc_.toXML("xloc")
+   resultOut_ << "   " << Simulator::getInstance().getModel().getLayout().xloc_.toXML("xloc")
               << endl;
-   resultOut_ << "   " << Simulator::getInstance().getModel()->getLayout().yloc_.toXML("yloc")
+   resultOut_ << "   " << Simulator::getInstance().getModel().getLayout().yloc_.toXML("yloc")
               << endl;
    resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter neuron matrix
    int num_starter_neurons = static_cast<int>(
-      Simulator::getInstance().getModel()->getLayout().numEndogenouslyActiveNeurons_);
+      Simulator::getInstance().getModel().getLayout().numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
       getStarterNeuronMatrix(starterNeurons,
-                             Simulator::getInstance().getModel()->getLayout().starterMap_);
+                             Simulator::getInstance().getModel().getLayout().starterMap_);
       resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -30,24 +30,24 @@ void XmlSTDPRecorder::init()
 ///Init radii and rates history matrices with default values
 void XmlSTDPRecorder::initDefaultValues()
 {
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
    //AllNeuroEdges *synapses synapses)->W_[iSyn]
-   BGFLOAT startRadius = dynamic_cast<ConnStatic *>(connections)->getConnsRadiusThresh();
+   BGFLOAT startRadius = dynamic_cast<ConnStatic &>(connections).getConnsRadiusThresh();
 }
 
 ///InitValues gets the values for weights, source index and dest index at the time of simulation start
 void XmlSTDPRecorder::initValues()
 {
-   Connections *connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel()->getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices()
                           * Simulator::getInstance().getMaxEdgesPerVertex();
         i++) {
-      weightsHistory_[0][i] = (dynamic_cast<ConnStatic *>(connections)->getWCurrentEpoch())[i];
+      weightsHistory_[0][i] = (dynamic_cast<ConnStatic &>(connections).getWCurrentEpoch())[i];
       sourceNeuronIndexHistory_[0][i]
-         = (dynamic_cast<ConnStatic *>(connections)->getSourceVertexIndexCurrentEpoch())[i];
+         = (dynamic_cast<ConnStatic &>(connections).getSourceVertexIndexCurrentEpoch())[i];
       destNeuronIndexHistory_[0][i]
-         = (dynamic_cast<ConnStatic *>(connections)->getDestVertexIndexCurrentEpoch())[i];
+         = (dynamic_cast<ConnStatic &>(connections).getDestVertexIndexCurrentEpoch())[i];
    }
 }
 
@@ -55,8 +55,8 @@ void XmlSTDPRecorder::initValues()
 void XmlSTDPRecorder::getValues()
 {
    Simulator &simulator = Simulator::getInstance();
-   Connections *connections = simulator.getModel()->getConnections();
-   AllEdges &synapses = connections->getEdges();
+   Connections &connections = simulator.getModel()->getConnections();
+   AllEdges &synapses = connections.getEdges();
    const int currentStep = simulator.getCurrentStep();
 
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
@@ -74,8 +74,8 @@ void XmlSTDPRecorder::compileHistories(AllVertices &neurons)
    LOG4CPLUS_INFO(fileLogger_, "Compiling STDP HISTORY");
    XmlRecorder::compileHistories(neurons);
    Simulator &simulator = Simulator::getInstance();
-   Connections *connections = simulator.getModel()->getConnections();
-   AllEdges &synapses = connections->getEdges();
+   Connections &connections = simulator.getModel()->getConnections();
+   AllEdges &synapses = connections.getEdges();
    const int currentStep = simulator.getCurrentStep();
 
    for (int iNeuron = 0; iNeuron < simulator.getTotalVertices() * simulator.getMaxEdgesPerVertex();

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -142,7 +142,7 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
    // create Neuron Types matrix
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout()->vertexTypeMap_[i];
+      neuronTypes[i] = simulator.getModel()->getLayout().vertexTypeMap_[i];
    }
 
    // create neuron threshold matrix
@@ -162,16 +162,16 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
    resultOut_ << "   " << toXML("destNeuronIndexHistory", destNeuronIndexHistory_) << endl;
    resultOut_ << "   " << toXML("weightsHistory", weightsHistory_) << endl;
    resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->xloc_.toXML("xloc") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout()->yloc_.toXML("yloc") << endl;
+   resultOut_ << "   " << simulator.getModel()->getLayout().xloc_.toXML("xloc") << endl;
+   resultOut_ << "   " << simulator.getModel()->getLayout().yloc_.toXML("yloc") << endl;
    resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter neuron matrix
    int num_starter_neurons
-      = static_cast<int>(simulator.getModel()->getLayout()->numEndogenouslyActiveNeurons_);
+      = static_cast<int>(simulator.getModel()->getLayout().numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout()->starterMap_);
+      getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout().starterMap_);
       resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -30,7 +30,7 @@ void XmlSTDPRecorder::init()
 ///Init radii and rates history matrices with default values
 void XmlSTDPRecorder::initDefaultValues()
 {
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
    //AllNeuroEdges *synapses synapses)->W_[iSyn]
    BGFLOAT startRadius = dynamic_cast<ConnStatic &>(connections).getConnsRadiusThresh();
 }
@@ -38,7 +38,7 @@ void XmlSTDPRecorder::initDefaultValues()
 ///InitValues gets the values for weights, source index and dest index at the time of simulation start
 void XmlSTDPRecorder::initValues()
 {
-   Connections &connections = Simulator::getInstance().getModel()->getConnections();
+   Connections &connections = Simulator::getInstance().getModel().getConnections();
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices()
                           * Simulator::getInstance().getMaxEdgesPerVertex();
@@ -55,7 +55,7 @@ void XmlSTDPRecorder::initValues()
 void XmlSTDPRecorder::getValues()
 {
    Simulator &simulator = Simulator::getInstance();
-   Connections &connections = simulator.getModel()->getConnections();
+   Connections &connections = simulator.getModel().getConnections();
    AllEdges &synapses = connections.getEdges();
    const int currentStep = simulator.getCurrentStep();
 
@@ -74,7 +74,7 @@ void XmlSTDPRecorder::compileHistories(AllVertices &neurons)
    LOG4CPLUS_INFO(fileLogger_, "Compiling STDP HISTORY");
    XmlRecorder::compileHistories(neurons);
    Simulator &simulator = Simulator::getInstance();
-   Connections &connections = simulator.getModel()->getConnections();
+   Connections &connections = simulator.getModel().getConnections();
    AllEdges &synapses = connections.getEdges();
    const int currentStep = simulator.getCurrentStep();
 
@@ -142,7 +142,7 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
    // create Neuron Types matrix
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout().vertexTypeMap_[i];
+      neuronTypes[i] = simulator.getModel().getLayout().vertexTypeMap_[i];
    }
 
    // create neuron threshold matrix
@@ -162,16 +162,16 @@ void XmlSTDPRecorder::saveSimData(const AllVertices &neurons)
    resultOut_ << "   " << toXML("destNeuronIndexHistory", destNeuronIndexHistory_) << endl;
    resultOut_ << "   " << toXML("weightsHistory", weightsHistory_) << endl;
    resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout().xloc_.toXML("xloc") << endl;
-   resultOut_ << "   " << simulator.getModel()->getLayout().yloc_.toXML("yloc") << endl;
+   resultOut_ << "   " << simulator.getModel().getLayout().xloc_.toXML("xloc") << endl;
+   resultOut_ << "   " << simulator.getModel().getLayout().yloc_.toXML("yloc") << endl;
    resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter neuron matrix
    int num_starter_neurons
-      = static_cast<int>(simulator.getModel()->getLayout().numEndogenouslyActiveNeurons_);
+      = static_cast<int>(simulator.getModel().getLayout().numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, simulator.getModel()->getLayout().starterMap_);
+      getStarterNeuronMatrix(starterNeurons, simulator.getModel().getLayout().starterMap_);
       resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 

--- a/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
+++ b/Simulator/Recorders/Neuro/XmlSTDPRecorder.cpp
@@ -56,7 +56,7 @@ void XmlSTDPRecorder::getValues()
 {
    Simulator &simulator = Simulator::getInstance();
    Connections *connections = simulator.getModel()->getConnections();
-   AllEdges &synapses = (*connections->getEdges());
+   AllEdges &synapses = connections->getEdges();
    const int currentStep = simulator.getCurrentStep();
 
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
@@ -75,7 +75,7 @@ void XmlSTDPRecorder::compileHistories(AllVertices &neurons)
    XmlRecorder::compileHistories(neurons);
    Simulator &simulator = Simulator::getInstance();
    Connections *connections = simulator.getModel()->getConnections();
-   AllEdges &synapses = (*connections->getEdges());
+   AllEdges &synapses = connections->getEdges();
    const int currentStep = simulator.getCurrentStep();
 
    for (int iNeuron = 0; iNeuron < simulator.getTotalVertices() * simulator.getMaxEdgesPerVertex();

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -98,7 +98,7 @@ void XmlRecorder::saveSimData(const AllVertices &vertices)
    // create Neuron Types matrix
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout().vertexTypeMap_[i];
+      neuronTypes[i] = simulator.getModel().getLayout().vertexTypeMap_[i];
    }
    // create neuron threshold matrix
    VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
@@ -110,7 +110,7 @@ void XmlRecorder::saveSimData(const AllVertices &vertices)
    resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
               << "<!-- State output file for the DCT growth modeling-->\n";
    // stateOut << version; TODO: version
-   auto &layout = simulator.getModel()->getLayout();
+   auto &layout = simulator.getModel().getLayout();
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -98,7 +98,7 @@ void XmlRecorder::saveSimData(const AllVertices &vertices)
    // create Neuron Types matrix
    VectorMatrix neuronTypes(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), EXC);
    for (int i = 0; i < simulator.getTotalVertices(); i++) {
-      neuronTypes[i] = simulator.getModel()->getLayout()->vertexTypeMap_[i];
+      neuronTypes[i] = simulator.getModel()->getLayout().vertexTypeMap_[i];
    }
    // create neuron threshold matrix
    VectorMatrix neuronThresh(MATRIX_TYPE, MATRIX_INIT, 1, simulator.getTotalVertices(), 0);
@@ -110,20 +110,20 @@ void XmlRecorder::saveSimData(const AllVertices &vertices)
    resultOut_ << "<?xml version=\"1.0\" standalone=\"no\"?>\n"
               << "<!-- State output file for the DCT growth modeling-->\n";
    // stateOut << version; TODO: version
-   auto layout = simulator.getModel()->getLayout();
+   auto &layout = simulator.getModel()->getLayout();
 
    // Write the core state information:
    resultOut_ << "<SimState>\n";
    resultOut_ << "   " << spikesHistory_.toXML("spikesHistory") << endl;
-   resultOut_ << "   " << layout->xloc_.toXML("xloc") << endl;
-   resultOut_ << "   " << layout->yloc_.toXML("yloc") << endl;
+   resultOut_ << "   " << layout.xloc_.toXML("xloc") << endl;
+   resultOut_ << "   " << layout.yloc_.toXML("yloc") << endl;
    resultOut_ << "   " << neuronTypes.toXML("neuronTypes") << endl;
 
    // create starter neurons matrix
-   int num_starter_neurons = static_cast<int>(layout->numEndogenouslyActiveNeurons_);
+   int num_starter_neurons = static_cast<int>(layout.numEndogenouslyActiveNeurons_);
    if (num_starter_neurons > 0) {
       VectorMatrix starterNeurons(MATRIX_TYPE, MATRIX_INIT, 1, num_starter_neurons);
-      getStarterNeuronMatrix(starterNeurons, layout->starterMap_);
+      getStarterNeuronMatrix(starterNeurons, layout.starterMap_);
       resultOut_ << "   " << starterNeurons.toXML("starterNeurons") << endl;
    }
 

--- a/Simulator/Utils/Inputs/SInputPoisson.cpp
+++ b/Simulator/Utils/Inputs/SInputPoisson.cpp
@@ -108,7 +108,7 @@ void SInputPoisson::init()
    for (int neuronIndex = 0; neuronIndex < Simulator::getInstance().getTotalVertices();
         neuronIndex++) {
       edgeType type;
-      if (Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[neuronIndex] == INH)
+      if (Simulator::getInstance().getModel().getLayout().vertexTypeMap_[neuronIndex] == INH)
          type = EI;
       else
          type = EE;

--- a/Simulator/Utils/Inputs/SInputPoisson.cpp
+++ b/Simulator/Utils/Inputs/SInputPoisson.cpp
@@ -108,7 +108,7 @@ void SInputPoisson::init()
    for (int neuronIndex = 0; neuronIndex < Simulator::getInstance().getTotalVertices();
         neuronIndex++) {
       edgeType type;
-      if (Simulator::getInstance().getModel()->getLayout()->vertexTypeMap_[neuronIndex] == INH)
+      if (Simulator::getInstance().getModel()->getLayout().vertexTypeMap_[neuronIndex] == INH)
          type = EI;
       else
          type = EE;

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -110,14 +110,14 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice)
+                                float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice)
       = 0;
 
    ///  Set some parameters used for advanceVerticesDevice.
    ///
    ///  @param  edges               Reference to the allEdges struct on host memory.
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
-#else   // !defined(USE_GPU)
+#else    // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Neuron (called by every simulation step).
    ///  Notify outgoing synapses if vertex has fired.

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -117,7 +117,7 @@ public:
    ///
    ///  @param  edges               Reference to the allEdges struct on host memory.
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
-#else    // !defined(USE_GPU)
+#else   // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Neuron (called by every simulation step).
    ///  Notify outgoing synapses if vertex has fired.

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -55,7 +55,7 @@ public:
    ///  Creates all the Vertices and assigns initial data for them.
    ///
    ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout) = 0;
+   virtual void createAllVertices(Layout &layout) = 0;
 
    ///  Outputs state of the vertex chosen as a string.
    ///
@@ -110,7 +110,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice *edgeIndexMapDevice)
+                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice)
       = 0;
 
    ///  Set some parameters used for advanceVerticesDevice.
@@ -124,7 +124,7 @@ public:
    ///
    ///  @param  edges         The Synapse list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) = 0;
+   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap) = 0;
 
 #endif   // defined(USE_GPU)
 };

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -22,7 +22,7 @@ void All911Vertices::setupVertices()
 }
 
 // Generate callNum_ and dispNum_ for all caller and psap nodes
-void All911Vertices::createAllVertices(Layout *layout)
+void All911Vertices::createAllVertices(Layout &layout)
 {
    vector<int> psapList;
    vector<int> respList;
@@ -32,31 +32,31 @@ void All911Vertices::createAllVertices(Layout *layout)
    int callersPerZone[] = {0, 0, 0, 0};
    int respPerZone[] = {0, 0, 0, 0};
 
-   Layout911 *layout911 = dynamic_cast<Layout911 *>(layout);
+   Layout911 &layout911 = dynamic_cast<Layout911 &>(layout);
 
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
       // Create all callers
-      if (layout->vertexTypeMap_[i] == CALR) {
+      if (layout.vertexTypeMap_[i] == CALR) {
          callNum_[i] = initRNG.inRange(callNumRange_[0], callNumRange_[1]);
-         callersPerZone[layout911->zone(i)] += callNum_[i];
+         callersPerZone[layout911.zone(i)] += callNum_[i];
       }
 
       // Find all PSAPs
-      if (layout->vertexTypeMap_[i] == PSAP) {
+      if (layout.vertexTypeMap_[i] == PSAP) {
          psapList.push_back(i);
       }
 
       // Find all resps
-      if (layout->vertexTypeMap_[i] == RESP) {
+      if (layout.vertexTypeMap_[i] == RESP) {
          respList.push_back(i);
-         respPerZone[layout911->zone(i)] += 1;
+         respPerZone[layout911.zone(i)] += 1;
       }
    }
 
    // Create all psaps
    // Dispatchers in a psap = [callers in the zone * k] + some randomness
    for (int i = 0; i < psapList.size(); i++) {
-      int psapQ = layout911->zone(i);
+      int psapQ = layout911.zone(i);
       int dispCount = (callersPerZone[psapQ] * dispNumScale_) + initRNG.inRange(-5, 5);
       if (dispCount < 1) {
          dispCount = 1;
@@ -67,7 +67,7 @@ void All911Vertices::createAllVertices(Layout *layout)
    // Create all responders
    // Responders in a node = [callers in the zone * k]/[number of responder nodes] + some randomness
    for (int i = 0; i < respList.size(); i++) {
-      int respQ = layout911->zone(respList[i]);
+      int respQ = layout911.zone(respList[i]);
       int respCount
          = (callersPerZone[respQ] * respNumScale_) / respPerZone[respQ] + initRNG.inRange(-5, 5);
       if (respCount < 1) {
@@ -102,7 +102,7 @@ string All911Vertices::toString(const int index) const
 ///
 ///  @param  edges         The edge list to search from.
 ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap)
+void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap)
 {
    //    // casting all911Edges for this method to use & modify
    //    All911Edges &allEdges = dynamic_cast<All911Edges &>(edges);
@@ -121,12 +121,12 @@ void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIn
    //          BGSIZE edgeCounts;
 
    //          if (edgeIndexMap != nullptr) {
-   //             edgeCounts = edgeIndexMap->outgoingEdgeCount_[idx];
+   //             edgeCounts = edgeIndexMap.outgoingEdgeCount_[idx];
    //             if (edgeCounts != 0) {
-   //                int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
+   //                int beginIndex = edgeIndexMap.outgoingEdgeBegin_[idx];
    //                BGSIZE iEdg;
    //                for (BGSIZE i = 0; i < edgeCounts; i++) {
-   //                   iEdg = edgeIndexMap->outgoingEdgeBegin_[beginIndex + i];
+   //                   iEdg = edgeIndexMap.outgoingEdgeBegin_[beginIndex + i];
    //                   allEdges.preSpikeHit(iEdg);
    //                }
    //             }

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -86,7 +86,7 @@ public:
    virtual void copyToDevice(void *allVerticesDevice) {};
    virtual void copyFromDevice(void *allVerticesDevice) {};
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) {};
+                                float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) {};
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) {};
 #else   // !defined(USE_GPU)
 public:

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -42,7 +42,7 @@ public:
    ///  Creates all the Vertices and assigns initial data for them.
    ///
    ///  @param  layout      Layout information of the network.
-   virtual void createAllVertices(Layout *layout);
+   virtual void createAllVertices(Layout &layout);
 
    ///  Load member variables from configuration file.
    ///  Registered to OperationManager as Operation::loadParameters
@@ -86,7 +86,7 @@ public:
    virtual void copyToDevice(void *allVerticesDevice) {};
    virtual void copyFromDevice(void *allVerticesDevice) {};
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice *edgeIndexMapDevice) {};
+                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) {};
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) {};
 #else   // !defined(USE_GPU)
 public:
@@ -95,7 +95,7 @@ public:
    ///
    ///  @param  edges         The Edge list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap *edgeIndexMap) override;
+   virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap) override;
 
 protected:
    void advanceVertex(const int index);

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -99,7 +99,7 @@ void AllIFNeurons::printParameters() const
 ///  Creates all the Neurons and generates data for them.
 ///
 ///  @param  layout      Layout information of the neural network.
-void AllIFNeurons::createAllVertices(Layout *layout)
+void AllIFNeurons::createAllVertices(Layout &layout)
 {
    /* set their specific types */
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
@@ -114,7 +114,7 @@ void AllIFNeurons::createAllVertices(Layout *layout)
 ///
 ///  @param  i Index of the neuron to create.
 ///  @param  layout       Layout information of the neural network.
-void AllIFNeurons::createNeuron(int i, Layout *layout)
+void AllIFNeurons::createNeuron(int i, Layout &layout)
 {
    // set the neuron info for neurons
    Iinject_[i] = initRNG.inRange(IinjectRange_[0], IinjectRange_[1]);
@@ -127,7 +127,7 @@ void AllIFNeurons::createNeuron(int i, Layout *layout)
 
    initNeuronConstsFromParamValues(i, Simulator::getInstance().getDeltaT());
 
-   switch (layout->vertexTypeMap_[i]) {
+   switch (layout.vertexTypeMap_[i]) {
       case INH:
          LOG4CPLUS_DEBUG(vertexLogger_, "Setting inhibitory neuron: " << i);
          // set inhibitory absolute refractory period
@@ -142,12 +142,12 @@ void AllIFNeurons::createNeuron(int i, Layout *layout)
 
       default:
          LOG4CPLUS_DEBUG(vertexLogger_,
-                         "ERROR: unknown neuron type: " << layout->vertexTypeMap_[i] << "@" << i);
+                         "ERROR: unknown neuron type: " << layout.vertexTypeMap_[i] << "@" << i);
          assert(false);
          break;
    }
    // endogenously_active_neuron_map -> Model State
-   if (layout->starterMap_[i]) {
+   if (layout.starterMap_[i]) {
       // set endogenously active threshold voltage, reset voltage, and refractory period
       Vthresh_[i] = initRNG.inRange(starterVthreshRange_[0], starterVthreshRange_[1]);
       Vreset_[i] = initRNG.inRange(starterVresetRange_[0], starterVresetRange_[1]);

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -78,7 +78,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice);
+                                float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice);
 
    ///  Allocate GPU memories to store all neurons' states,
    ///  and copy them from host to GPU memory.

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -49,7 +49,7 @@ public:
    ///  Creates all the Neurons and assigns initial data for them.
    ///
    ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout);
+   virtual void createAllVertices(Layout &layout);
 
    ///  Outputs state of the neuron chosen as a string.
    ///
@@ -78,7 +78,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice *edgeIndexMapDevice);
+                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice);
 
    ///  Allocate GPU memories to store all neurons' states,
    ///  and copy them from host to GPU memory.
@@ -133,7 +133,7 @@ protected:
    ///
    ///  @param  neuronIndex Index of the neuron to create.
    ///  @param  layout       Layout information of the neural network.
-   void createNeuron(int neuronIndex, Layout *layout);
+   void createNeuron(int neuronIndex, Layout &layout);
 
    ///  Set the Neuron at the indexed location to default values.
    ///

--- a/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
@@ -223,7 +223,7 @@ void AllIFNeurons::clearNeuronSpikeCounts(void *allVerticesDevice)
 ///  @param  randNoise              Reference to the random noise array.
 ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
 void AllIFNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
-                                   void *allEdgesDevice, float *randNoise,
-                                   EdgeIndexMapDevice &edgeIndexMapDevice)
+                                   void *allEdgesDevice, float randNoise[],
+                                   EdgeIndexMapDevice *edgeIndexMapDevice)
 {
 }

--- a/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
@@ -224,6 +224,6 @@ void AllIFNeurons::clearNeuronSpikeCounts(void *allVerticesDevice)
 ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
 void AllIFNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
                                    void *allEdgesDevice, float *randNoise,
-                                   EdgeIndexMapDevice *edgeIndexMapDevice)
+                                   EdgeIndexMapDevice &edgeIndexMapDevice)
 {
 }

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -51,7 +51,7 @@ void AllIZHNeurons::printParameters() const
 ///  Creates all the Neurons and generates data for them.
 ///
 ///  @param  layout      Layout information of the neural network.
-void AllIZHNeurons::createAllVertices(Layout *layout)
+void AllIZHNeurons::createAllVertices(Layout &layout)
 {
    /* set their specific types */
    for (int i = 0; i < Simulator::getInstance().getTotalVertices(); i++) {
@@ -66,13 +66,13 @@ void AllIZHNeurons::createAllVertices(Layout *layout)
 ///
 ///  @param  i Index of the neuron to create.
 ///  @param  layout       Layout information of the neural network.
-void AllIZHNeurons::createNeuron(int i, Layout *layout)
+void AllIZHNeurons::createNeuron(int i, Layout &layout)
 {
    // set the neuron info for neurons
    AllIFNeurons::createNeuron(i, layout);
 
    // TODO: we may need another distribution mode besides flat distribution
-   if (layout->vertexTypeMap_[i] == EXC) {
+   if (layout.vertexTypeMap_[i] == EXC) {
       // excitatory neuron
       Aconst_[i] = initRNG.inRange(excAconst_[0], excAconst_[1]);
       Bconst_[i] = initRNG.inRange(excBconst_[0], excBconst_[1]);

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -128,7 +128,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  Reference to the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) override;
+                                float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) override;
 
    ///  Allocate GPU memories to store all neurons' states,
    ///  and copy them from host to GPU memory.
@@ -192,7 +192,7 @@ protected:
    ///  @param  allVerticesDevice         Reference to the AllIZHNeuronsDeviceProperties struct.
    void copyDeviceToHost(AllIZHNeuronsDeviceProperties &allVerticesDevice);
 
-#else   // !defined(USE_GPU)
+#else    // !defined(USE_GPU)
 
 protected:
    ///  Helper for #advanceNeuron. Updates state of a single neuron.

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -99,7 +99,7 @@ public:
    ///  Creates all the Neurons and assigns initial data for them.
    ///
    ///  @param  layout      Layout information of the neural network.
-   virtual void createAllVertices(Layout *layout) override;
+   virtual void createAllVertices(Layout &layout) override;
 
    ///  Outputs state of the neuron chosen as a string.
    ///
@@ -128,7 +128,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  Reference to the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice *edgeIndexMapDevice) override;
+                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) override;
 
    ///  Allocate GPU memories to store all neurons' states,
    ///  and copy them from host to GPU memory.
@@ -212,7 +212,7 @@ protected:
    ///
    ///  @param  neuronIndex Index of the neuron to create.
    ///  @param  layout       Layout information of the neural network.
-   void createNeuron(int neuronIndex, Layout *layout);
+   void createNeuron(int neuronIndex, Layout &layout);
 
    ///  Set the Neuron at the indexed location to default values.
    ///

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -192,7 +192,7 @@ protected:
    ///  @param  allVerticesDevice         Reference to the AllIZHNeuronsDeviceProperties struct.
    void copyDeviceToHost(AllIZHNeuronsDeviceProperties &allVerticesDevice);
 
-#else    // !defined(USE_GPU)
+#else   // !defined(USE_GPU)
 
 protected:
    ///  Helper for #advanceNeuron. Updates state of a single neuron.

--- a/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
@@ -30,7 +30,7 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
                                         float *randNoise,
                                         AllIZHNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice *edgeIndexMapDevice,
+                                        EdgeIndexMapDevice &edgeIndexMapDevice,
                                         bool fAllowBackPropagation);
 
 
@@ -185,7 +185,7 @@ void AllIZHNeurons::clearNeuronSpikeCounts(void *allVerticesDevice)
 ///  Notify outgoing synapses if neuron has fired.
 void AllIZHNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
                                     void *allEdgesDevice, float *randNoise,
-                                    EdgeIndexMapDevice *edgeIndexMapDevice)
+                                    EdgeIndexMapDevice &edgeIndexMapDevice)
 {
    int vertex_count = Simulator::getInstance().getTotalVertices();
    int maxSpikes = (int)((Simulator::getInstance().getEpochDuration()
@@ -222,7 +222,7 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
                                         float *randNoise,
                                         AllIZHNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice *edgeIndexMapDevice,
+                                        EdgeIndexMapDevice &edgeIndexMapDevice,
                                         bool fAllowBackPropagation)
 {
    // determine which neuron this thread is processing
@@ -264,12 +264,12 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
       u = r_u + allVerticesDevice->Dconst_[idx];
 
       // notify outgoing synapses of spike
-      BGSIZE synapseCounts = edgeIndexMapDevice->outgoingEdgeCount_[idx];
+      BGSIZE synapseCounts = edgeIndexMapDevice.outgoingEdgeCount_[idx];
       if (synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice->outgoingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice.outgoingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice->outgoingEdgeIndexMap_[beginIndex]);
+         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice.outgoingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          for (BGSIZE i = 0; i < synapseCounts; i++) {
@@ -278,12 +278,12 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
       }
 
       // notify incomming synapses of spike
-      synapseCounts = edgeIndexMapDevice->incomingEdgeCount_[idx];
+      synapseCounts = edgeIndexMapDevice.incomingEdgeCount_[idx];
       if (fAllowBackPropagation && synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice->incomingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice.incomingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice->incomingEdgeIndexMap_[beginIndex]);
+         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice.incomingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          switch (classSynapses_d) {

--- a/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
@@ -27,10 +27,10 @@
 
 __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int maxSpikes,
                                         const BGFLOAT deltaT, uint64_t simulationStep,
-                                        float *randNoise,
+                                        float randNoise[],
                                         AllIZHNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice &edgeIndexMapDevice,
+                                        EdgeIndexMapDevice *edgeIndexMapDevice,
                                         bool fAllowBackPropagation);
 
 
@@ -184,8 +184,8 @@ void AllIZHNeurons::clearNeuronSpikeCounts(void *allVerticesDevice)
 
 ///  Notify outgoing synapses if neuron has fired.
 void AllIZHNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
-                                    void *allEdgesDevice, float *randNoise,
-                                    EdgeIndexMapDevice &edgeIndexMapDevice)
+                                    void *allEdgesDevice, float randNoise[],
+                                    EdgeIndexMapDevice *edgeIndexMapDevice)
 {
    int vertex_count = Simulator::getInstance().getTotalVertices();
    int maxSpikes = (int)((Simulator::getInstance().getEpochDuration()
@@ -219,10 +219,10 @@ void AllIZHNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
 ///  @param[in] fAllowBackPropagation True if back propagaion is allowed.
 __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int maxSpikes,
                                         const BGFLOAT deltaT, uint64_t simulationStep,
-                                        float *randNoise,
+                                        float randNoise[],
                                         AllIZHNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice &edgeIndexMapDevice,
+                                        EdgeIndexMapDevice *edgeIndexMapDevice,
                                         bool fAllowBackPropagation)
 {
    // determine which neuron this thread is processing
@@ -244,7 +244,7 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
 
    if (allVerticesDevice->numStepsInRefractoryPeriod_[idx] > 0) {   // is neuron refractory?
       --allVerticesDevice->numStepsInRefractoryPeriod_[idx];
-   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {   // should it fire?
+   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {           // should it fire?
       int &spikeCount = allVerticesDevice->numEventsInEpoch_[idx];
       // Note that the neuron has fired!
       allVerticesDevice->hasFired_[idx] = true;
@@ -264,12 +264,12 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
       u = r_u + allVerticesDevice->Dconst_[idx];
 
       // notify outgoing synapses of spike
-      BGSIZE synapseCounts = edgeIndexMapDevice.outgoingEdgeCount_[idx];
+      BGSIZE synapseCounts = edgeIndexMapDevice->outgoingEdgeCount_[idx];
       if (synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice.outgoingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice->outgoingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice.outgoingEdgeIndexMap_[beginIndex]);
+         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice->outgoingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          for (BGSIZE i = 0; i < synapseCounts; i++) {
@@ -278,12 +278,12 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
       }
 
       // notify incomming synapses of spike
-      synapseCounts = edgeIndexMapDevice.incomingEdgeCount_[idx];
+      synapseCounts = edgeIndexMapDevice->incomingEdgeCount_[idx];
       if (fAllowBackPropagation && synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice.incomingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice->incomingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice.incomingEdgeIndexMap_[beginIndex]);
+         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice->incomingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          switch (classSynapses_d) {

--- a/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
@@ -244,7 +244,7 @@ __global__ void advanceIZHNeuronsDevice(int totalVertices, int maxEdges, int max
 
    if (allVerticesDevice->numStepsInRefractoryPeriod_[idx] > 0) {   // is neuron refractory?
       --allVerticesDevice->numStepsInRefractoryPeriod_[idx];
-   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {           // should it fire?
+   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {   // should it fire?
       int &spikeCount = allVerticesDevice->numEventsInEpoch_[idx];
       // Note that the neuron has fired!
       allVerticesDevice->hasFired_[idx] = true;

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -108,8 +108,8 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) override;
-#else   // !defined(USE_GPU)
+                                float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) override;
+#else    // !defined(USE_GPU)
 protected:
    ///  Helper for #advanceNeuron. Updates state of a single neuron.
    ///

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -108,7 +108,7 @@ public:
    ///  @param  randNoise              Reference to the random noise array.
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
-                                float *randNoise, EdgeIndexMapDevice *edgeIndexMapDevice) override;
+                                float *randNoise, EdgeIndexMapDevice &edgeIndexMapDevice) override;
 #else   // !defined(USE_GPU)
 protected:
    ///  Helper for #advanceNeuron. Updates state of a single neuron.

--- a/Simulator/Vertices/Neuro/AllLIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons.h
@@ -109,7 +109,7 @@ public:
    ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
    virtual void advanceVertices(AllEdges &synapses, void *allVerticesDevice, void *allEdgesDevice,
                                 float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) override;
-#else    // !defined(USE_GPU)
+#else   // !defined(USE_GPU)
 protected:
    ///  Helper for #advanceNeuron. Updates state of a single neuron.
    ///

--- a/Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp
@@ -29,7 +29,7 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
                                         float *randNoise,
                                         AllIFNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice *edgeIndexMapDevice,
+                                        EdgeIndexMapDevice &edgeIndexMapDevice,
                                         bool fAllowBackPropagation);
 
 
@@ -45,7 +45,7 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
 ///  @param  edgeIndexMapDevice  GPU address of the EdgeIndexMap on device memory.
 void AllLIFNeurons::advanceVertices(AllEdges &synapses, void *allVerticesDevice,
                                     void *allEdgesDevice, float *randNoise,
-                                    EdgeIndexMapDevice *edgeIndexMapDevice)
+                                    EdgeIndexMapDevice &edgeIndexMapDevice)
 {
    int vertex_count = Simulator::getInstance().getTotalVertices();
    int maxSpikes = (int)((Simulator::getInstance().getEpochDuration()
@@ -88,7 +88,7 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
                                         float *randNoise,
                                         AllIFNeuronsDeviceProperties *allVerticesDevice,
                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice,
-                                        EdgeIndexMapDevice *edgeIndexMapDevice,
+                                        EdgeIndexMapDevice &edgeIndexMapDevice,
                                         bool fAllowBackPropagation)
 {
    // determine which neuron this thread is processing
@@ -132,12 +132,12 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
       vm = allVerticesDevice->Vreset_[idx];
 
       // notify outgoing synapses of spike
-      BGSIZE synapseCounts = edgeIndexMapDevice->outgoingEdgeCount_[idx];
+      BGSIZE synapseCounts = edgeIndexMapDevice.outgoingEdgeCount_[idx];
       if (synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice->outgoingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice.outgoingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice->outgoingEdgeIndexMap_[beginIndex]);
+         BGSIZE *outgoingMapBegin = &(edgeIndexMapDevice.outgoingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          for (BGSIZE i = 0; i < synapseCounts; i++) {
@@ -146,12 +146,12 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
       }
 
       // notify incomming synapses of spike
-      synapseCounts = edgeIndexMapDevice->incomingEdgeCount_[idx];
+      synapseCounts = edgeIndexMapDevice.incomingEdgeCount_[idx];
       if (fAllowBackPropagation && synapseCounts != 0) {
          // get the index of where this neuron's list of synapses are
-         BGSIZE beginIndex = edgeIndexMapDevice->incomingEdgeBegin_[idx];
+         BGSIZE beginIndex = edgeIndexMapDevice.incomingEdgeBegin_[idx];
          // get the memory location of where that list begins
-         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice->incomingEdgeIndexMap_[beginIndex]);
+         BGSIZE *incomingMapBegin = &(edgeIndexMapDevice.incomingEdgeIndexMap_[beginIndex]);
 
          // for each synapse, let them know we have fired
          switch (classSynapses_d) {

--- a/Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp
@@ -104,7 +104,7 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
 
    if (allVerticesDevice->numStepsInRefractoryPeriod_[idx] > 0) {   // is neuron refractory?
       --allVerticesDevice->numStepsInRefractoryPeriod_[idx];
-   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {           // should it fire?
+   } else if (r_vm >= allVerticesDevice->Vthresh_[idx]) {   // should it fire?
       int &spikeCount = allVerticesDevice->numEventsInEpoch_[idx];
 
       // Note that the neuron has fired!
@@ -181,7 +181,7 @@ __global__ void advanceLIFNeuronsDevice(int totalVertices, int maxEdges, int max
       // Random number alg. goes here
       r_sp += (randNoise[idx] * allVerticesDevice->Inoise_[idx]);   // add cheap noise
       vm = allVerticesDevice->C1_[idx] * r_vm
-           + allVerticesDevice->C2_[idx] * (r_sp);                  // decay Vm and add inputs
+           + allVerticesDevice->C2_[idx] * (r_sp);   // decay Vm and add inputs
    }
 
    // clear synaptic input for next time step

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -39,7 +39,7 @@ void AllSpikingNeurons::clearSpikeCounts()
 ///
 ///  @param  synapses         The Synapse list to search from.
 ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap *edgeIndexMap)
+void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap &edgeIndexMap)
 {
    int maxSpikes = (int)((Simulator::getInstance().getEpochDuration()
                           * Simulator::getInstance().getMaxFiringRate()));
@@ -61,17 +61,17 @@ void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap *
          // notify outgoing synapses
          BGSIZE synapseCounts;
 
-         if (edgeIndexMap != nullptr) {
-            synapseCounts = edgeIndexMap->outgoingEdgeCount_[idx];
-            if (synapseCounts != 0) {
-               int beginIndex = edgeIndexMap->outgoingEdgeBegin_[idx];
-               BGSIZE iEdg;
-               for (BGSIZE i = 0; i < synapseCounts; i++) {
-                  iEdg = edgeIndexMap->outgoingEdgeIndexMap_[beginIndex + i];
-                  spSynapses.preSpikeHit(iEdg);
-               }
+
+         synapseCounts = edgeIndexMap.outgoingEdgeCount_[idx];
+         if (synapseCounts != 0) {
+            int beginIndex = edgeIndexMap.outgoingEdgeBegin_[idx];
+            BGSIZE iEdg;
+            for (BGSIZE i = 0; i < synapseCounts; i++) {
+               iEdg = edgeIndexMap.outgoingEdgeIndexMap_[beginIndex + i];
+               spSynapses.preSpikeHit(iEdg);
             }
          }
+
 
          // notify incoming synapses
          synapseCounts = spSynapses.edgeCounts_[idx];

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -71,7 +71,7 @@ public:
    ///
    ///  @param  synapses         The Synapse list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void advanceVertices(AllEdges &synapses, const EdgeIndexMap *edgeIndexMap);
+   virtual void advanceVertices(AllEdges &synapses, const EdgeIndexMap &edgeIndexMap);
 
    /// Get the spike history of neuron[index] at the location offIndex.
    /// More specifically, retrieves the global simulation time step for the spike


### PR DESCRIPTION
Fixes Issue #423 

Change the getter methods of AllVertices, AllEdges, Model, Layout, Connections, and Recorder to return a reference of the object than a raw pointer.