### PR TITLE
[ISSUE-446] Refactor vector initialization to use assign instead of resize and assign

### DIFF
--- a/Simulator/Core/EdgeIndexMap.h
+++ b/Simulator/Core/EdgeIndexMap.h
@@ -54,11 +54,6 @@ struct EdgeIndexMap {
       numOfVertices_(vertexCount), numOfEdges_(edgeCount)
    {
       if (numOfVertices_ > 0) {
-         outgoingEdgeBegin_.resize(numOfVertices_);
-         outgoingEdgeCount_.resize(numOfVertices_);
-         incomingEdgeBegin_.resize(numOfVertices_);
-         incomingEdgeCount_.resize(numOfVertices_);
-
          outgoingEdgeBegin_.assign(numOfVertices_, 0);
          outgoingEdgeCount_.assign(numOfVertices_, 0);
          incomingEdgeBegin_.assign(numOfVertices_, 0);
@@ -66,9 +61,6 @@ struct EdgeIndexMap {
       }
 
       if (numOfEdges_ > 0) {
-         outgoingEdgeIndexMap_.resize(numOfEdges_);
-         incomingEdgeIndexMap_.resize(numOfEdges_);
-
          outgoingEdgeIndexMap_.assign(numOfEdges_, 0);
          incomingEdgeIndexMap_.assign(numOfEdges_, 0);
       }

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -75,23 +75,12 @@ void AllEdges::setupEdges(const int numVertices, const int maxEdges)
    countVertices_ = numVertices;
 
    if (maxTotalEdges != 0) {
-      sourceVertexIndex_.resize(maxTotalEdges);
-      sourceVertexIndex_.assign(maxTotalEdges, 0);
-
-      destVertexIndex_.resize(maxTotalEdges, 0);
-      destVertexIndex_.assign(maxTotalEdges, 0);
-
-      summationPoint_.resize(maxTotalEdges, nullptr);
-      summationPoint_.assign(maxTotalEdges, nullptr);
-
-      W_.resize(maxTotalEdges, 0);
       W_.assign(maxTotalEdges, 0);
-
-      type_.resize(maxTotalEdges);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
-
-      edgeCounts_.resize(numVertices, 0);
       edgeCounts_.assign(numVertices, 0);
+      summationPoint_.assign(maxTotalEdges, nullptr);
+      destVertexIndex_.assign(maxTotalEdges, 0);
+      sourceVertexIndex_.assign(maxTotalEdges, 0);
 
       inUse_ = make_unique<bool[]>(maxTotalEdges);
       fill_n(inUse_.get(), maxTotalEdges, false);

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -25,26 +25,13 @@ void All911Edges::setupEdges()
 
    // To do: Figure out whether we need all of these
    if (maxTotalEdges != 0) {
-      // psr_.resize(maxTotalEdges);
       // psr_.assign(maxTotalEdges, 0.0);
-      sourceVertexIndex_.resize(maxTotalEdges);
-      sourceVertexIndex_.assign(maxTotalEdges, 0);
-
-      destVertexIndex_.resize(maxTotalEdges, 0);
-      destVertexIndex_.assign(maxTotalEdges, 0);
-
-      summationPoint_.resize(maxTotalEdges, nullptr);
-      summationPoint_.assign(maxTotalEdges, nullptr);
-
-      W_.resize(maxTotalEdges, 0);
       W_.assign(maxTotalEdges, 0);
-
-      type_.resize(maxTotalEdges);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
-
-      edgeCounts_.resize(numVertices, 0);
       edgeCounts_.assign(numVertices, 0);
-
+      summationPoint_.assign(maxTotalEdges, nullptr);
+      destVertexIndex_.assign(maxTotalEdges, 0);
+      sourceVertexIndex_.assign(maxTotalEdges, 0);
       inUse_ = make_unique<bool[]>(maxTotalEdges);
       fill_n(inUse_.get(), maxTotalEdges, false);
    }

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -32,22 +32,11 @@ void AllDSSynapses::setupEdges(const int numVertices, const int maxEdges)
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
    if (maxTotalSynapses != 0) {
-      lastSpike_.resize(maxTotalSynapses);
       lastSpike_.assign(maxTotalSynapses, 0);
-
-      r_.resize(maxTotalSynapses);
       r_.assign(maxTotalSynapses, 0);
-
-      u_.resize(maxTotalSynapses);
       u_.assign(maxTotalSynapses, 0);
-
-      D_.resize(maxTotalSynapses);
       D_.assign(maxTotalSynapses, 0);
-
-      U_.resize(maxTotalSynapses);
       U_.assign(maxTotalSynapses, 0);
-
-      F_.resize(maxTotalSynapses);
       F_.assign(maxTotalSynapses, 0);
    }
 }

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -32,22 +32,11 @@ void AllDynamicSTDPSynapses::setupEdges(const int numVertices, const int maxEdge
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
    if (maxTotalSynapses != 0) {
-      lastSpike_.resize(maxTotalSynapses);
       lastSpike_.assign(maxTotalSynapses, 0);
-
-      r_.resize(maxTotalSynapses);
       r_.assign(maxTotalSynapses, 0);
-
-      u_.resize(maxTotalSynapses);
       u_.assign(maxTotalSynapses, 0);
-
-      D_.resize(maxTotalSynapses);
       D_.assign(maxTotalSynapses, 0);
-
-      U_.resize(maxTotalSynapses);
       U_.assign(maxTotalSynapses, 0);
-
-      F_.resize(maxTotalSynapses);
       F_.assign(maxTotalSynapses, 0);
    }
 }

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -24,7 +24,6 @@ void AllNeuroEdges::setupEdges(const int numVertices, const int maxEdges)
    BGSIZE maxTotalEdges = maxEdges * numVertices;
 
    if (maxTotalEdges != 0) {
-      psr_.resize(maxTotalEdges);
       psr_.assign(maxTotalEdges, 0.0);
    }
 }

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -54,47 +54,20 @@ void AllSTDPSynapses::setupEdges(const int numVertices, const int maxEdges)
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
    if (maxTotalSynapses != 0) {
-      totalDelayPost_.resize(maxTotalSynapses);
-      totalDelayPost_.assign(maxTotalSynapses, 0);
-
-      delayQueuePost_.resize(maxTotalSynapses);
-      delayQueuePost_.assign(maxTotalSynapses, 0);
-
-      delayIndexPost_.resize(maxTotalSynapses);
-      delayIndexPost_.assign(maxTotalSynapses, 0);
-
-      delayQueuePostLength_.resize(maxTotalSynapses);
-      delayQueuePostLength_.assign(maxTotalSynapses, 0);
-
-      tauspost_.resize(maxTotalSynapses);
-      tauspost_.assign(maxTotalSynapses, 0);
-
-      tauspre_.resize(maxTotalSynapses);
-      tauspre_.assign(maxTotalSynapses, 0);
-
-      taupos_.resize(maxTotalSynapses);
-      taupos_.assign(maxTotalSynapses, 0);
-
-      tauneg_.resize(maxTotalSynapses);
-      tauneg_.assign(maxTotalSynapses, 0);
-
-      STDPgap_.resize(maxTotalSynapses);
-      STDPgap_.assign(maxTotalSynapses, 0);
-
-      Wex_.resize(maxTotalSynapses);
       Wex_.assign(maxTotalSynapses, 0);
-
-      Aneg_.resize(maxTotalSynapses);
       Aneg_.assign(maxTotalSynapses, 0);
-
-      Apos_.resize(maxTotalSynapses);
       Apos_.assign(maxTotalSynapses, 0);
-
-      mupos_.resize(maxTotalSynapses);
       mupos_.assign(maxTotalSynapses, 0);
-
-      muneg_.resize(maxTotalSynapses);
       muneg_.assign(maxTotalSynapses, 0);
+      taupos_.assign(maxTotalSynapses, 0);
+      tauneg_.assign(maxTotalSynapses, 0);
+      tauspre_.assign(maxTotalSynapses, 0);
+      STDPgap_.assign(maxTotalSynapses, 0);
+      tauspost_.assign(maxTotalSynapses, 0);
+      totalDelayPost_.assign(maxTotalSynapses, 0);
+      delayQueuePost_.assign(maxTotalSynapses, 0);
+      delayIndexPost_.assign(maxTotalSynapses, 0);
+      delayQueuePostLength_.assign(maxTotalSynapses, 0);
    }
 }
 

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -47,23 +47,12 @@ void AllSpikingSynapses::setupEdges(const int numVertices, const int maxEdges)
    BGSIZE maxTotalSynapses = maxEdges * numVertices;
 
    if (maxTotalSynapses != 0) {
-      decay_.resize(maxTotalSynapses);
-      decay_.assign(maxTotalSynapses, 0);
-
-      totalDelay_.resize(maxTotalSynapses);
-      totalDelay_.assign(maxTotalSynapses, 0);
-
-      delayQueue_.resize(maxTotalSynapses);
-      delayQueue_.assign(maxTotalSynapses, 0);
-
-      delayIndex_.resize(maxTotalSynapses);
-      delayIndex_.assign(maxTotalSynapses, 0);
-
-      delayQueueLength_.resize(maxTotalSynapses);
-      delayQueueLength_.assign(maxTotalSynapses, 0);
-
-      tau_.resize(maxTotalSynapses);
       tau_.assign(maxTotalSynapses, 0);
+      decay_.assign(maxTotalSynapses, 0);
+      totalDelay_.assign(maxTotalSynapses, 0);
+      delayQueue_.assign(maxTotalSynapses, 0);
+      delayIndex_.assign(maxTotalSynapses, 0);
+      delayQueueLength_.assign(maxTotalSynapses, 0);
    }
 }
 

--- a/Simulator/Layouts/Layout.cpp
+++ b/Simulator/Layouts/Layout.cpp
@@ -69,11 +69,8 @@ void Layout::setup()
    dist_ = CompleteMatrix(MATRIX_TYPE, MATRIX_INIT, numVertices_, numVertices_);
 
    // more allocation of internal memory
-   vertexTypeMap_.resize(numVertices_);
-   vertexTypeMap_.assign(numVertices_, VTYPE_UNDEF);
-
-   starterMap_.resize(numVertices_);
    starterMap_.assign(numVertices_, false);
+   vertexTypeMap_.assign(numVertices_, VTYPE_UNDEF);
 }
 
 

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -177,7 +177,7 @@ void Hdf5Recorder::initDataSet()
    }
 
    // allocate and initialize data memories
-   spikesHistory_.resize(static_cast<int>(simulator.getEpochDuration() * 100));
+
    spikesHistory_.assign(static_cast<int>(simulator.getEpochDuration() * 100), 0);
 
    // create the data space & dataset for spikes history of probed neurons
@@ -186,7 +186,6 @@ void Hdf5Recorder::initDataSet()
       spikesProbedNeurons_.resize(model->getLayout()->probedNeuronList_.size());
 
       // allocate and initialize memory to save offsets of what's been written
-      offsetSpikesProbedNeurons_.resize(model->getLayout()->probedNeuronList_.size());
       offsetSpikesProbedNeurons_.assign(model->getLayout()->probedNeuronList_.size(), 0);
    }
 }

--- a/Simulator/Utils/Inputs/SInputPoisson.cpp
+++ b/Simulator/Utils/Inputs/SInputPoisson.cpp
@@ -42,8 +42,8 @@ SInputPoisson::SInputPoisson(TiXmlElement *parms) :
    lambda = 1 / fr_mean;       // inverse firing rate
 
    // allocate memory for interval counter
-   nISIs.resize(Simulator::getInstance().getTotalVertices());
-   memset(nISIs.data(), 0, sizeof(int) * Simulator::getInstance().getTotalVertices());
+
+   nISIs.assign(Simulator::getInstance().getTotalVertices(), 0);
 
    // allocate memory for input masks
    masks = make_unique<bool[]>(Simulator::getInstance().getTotalVertices());

--- a/Simulator/Utils/Inputs/SInputRegular.cpp
+++ b/Simulator/Utils/Inputs/SInputRegular.cpp
@@ -77,11 +77,8 @@ SInputRegular::SInputRegular(TiXmlElement *parms) : values(nullptr)
 
    initValues.clear();
 
-   // allocate memory for shift values
-   nShiftValues.resize(Simulator::getInstance().getTotalVertices());
-
-   // initialize shift values
-   memset(nShiftValues.data(), 0, sizeof(int) * Simulator::getInstance().getTotalVertices());
+   // allocate memory and initialize shift values
+   nShiftValues.assign(Simulator::getInstance().getTotalVertices(), 0);
 
    if (sync == "no") {
       // asynchronous stimuli - fill nShiftValues array with values between 0 - nStepsCycle

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -37,7 +37,6 @@ void AllVertices::setupVertices()
    // summationMap_ = nullptr;
 
 #else
-   summationMap_.resize(size_);
    summationMap_.assign(size_, 0);
 
 #endif

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -15,11 +15,6 @@
 void All911Vertices::setupVertices()
 {
    AllVertices::setupVertices();
-
-   callNum_.resize(size_);
-   dispNum_.resize(size_);
-   respNum_.resize(size_);
-
    // Populate arrays with 0
    callNum_.assign(size_, 0);
    dispNum_.assign(size_, 0);

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -20,23 +20,6 @@ void AllIFNeurons::setupVertices()
    AllSpikingNeurons::setupVertices();
 
    // TODO: Rename variables for easier identification
-   C1_.resize(size_);
-   C2_.resize(size_);
-   Cm_.resize(size_);
-   I0_.resize(size_);
-   Iinject_.resize(size_);
-   Inoise_.resize(size_);
-   Isyn_.resize(size_);
-   Rm_.resize(size_);
-   Tau_.resize(size_);
-   Trefract_.resize(size_);
-   Vinit_.resize(size_);
-   Vm_.resize(size_);
-   Vreset_.resize(size_);
-   Vrest_.resize(size_);
-   Vthresh_.resize(size_);
-   numStepsInRefractoryPeriod_.resize(size_);
-
    C1_.assign(size_, 0);
    C2_.assign(size_, 0);
    Cm_.assign(size_, 0);
@@ -246,7 +229,7 @@ string AllIFNeurons::toString(const int index) const
    ss << "Trefract: " << Trefract_[index] << " ";   // the number of steps in the refractory period
    ss << "Inoise: " << Inoise_[index] << " ";   // the stdev of the noise to be added each delta_t
    ss << "Iinject: " << Iinject_[index]
-      << " ";   // A constant current to be injected into the LIF neuron
+      << " ";                           // A constant current to be injected into the LIF neuron
    ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
       << endl;                          // the number of steps left in the refractory period
    ss << "Vm: " << Vm_[index] << " ";   // the membrane voltage

--- a/Simulator/Vertices/Neuro/AllIFNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.cpp
@@ -229,7 +229,7 @@ string AllIFNeurons::toString(const int index) const
    ss << "Trefract: " << Trefract_[index] << " ";   // the number of steps in the refractory period
    ss << "Inoise: " << Inoise_[index] << " ";   // the stdev of the noise to be added each delta_t
    ss << "Iinject: " << Iinject_[index]
-      << " ";                           // A constant current to be injected into the LIF neuron
+      << " ";   // A constant current to be injected into the LIF neuron
    ss << "nStepsInRefr: " << numStepsInRefractoryPeriod_[index]
       << endl;                          // the number of steps left in the refractory period
    ss << "Vm: " << Vm_[index] << " ";   // the membrane voltage

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.cpp
@@ -13,14 +13,6 @@
 void AllIZHNeurons::setupVertices()
 {
    AllIFNeurons::setupVertices();
-
-   Aconst_.resize(size_);
-   Bconst_.resize(size_);
-   Cconst_.resize(size_);
-   Dconst_.resize(size_);
-   u_.resize(size_);
-   C3_.resize(size_);
-
    Aconst_.assign(size_, 0);
    Bconst_.assign(size_, 0);
    Cconst_.assign(size_, 0);

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -17,8 +17,8 @@ void AllSpikingNeurons::setupVertices()
    int maxSpikes = static_cast<int>(Simulator::getInstance().getEpochDuration()
                                     * Simulator::getInstance().getMaxFiringRate());
 
-   hasFired_.resize(size_, false);
-   vertexEvents_.resize(size_, maxSpikes);
+   hasFired_.assign(size_, false);
+   vertexEvents_.assign(size_, maxSpikes);
 }
 
 ///  Clear the spike counts out of all Neurons.


### PR DESCRIPTION
Closes #446 

This PR replaces the usage of `resize` followed by `assign` with a single call to `assign` to initialize a vector with default values. This simplifies the code and makes it more efficient by eliminating the need to resize the vector and then fill in the default values separately.

The changes have been tested on the CPU and GPU with the medium config file.

Thanks @jardiamj for raising this issue