### PR TITLE
[issue #406] Removed the unnecessary Connections parameter level from XML config file

### DIFF
--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -46,7 +46,6 @@ void Connections911::setup()
 
 void Connections911::loadParameters()
 {
-   ParameterManager::getInstance().getIntByXpath("//connsPerVertex/text()", connsPerVertex_);
    ParameterManager::getInstance().getIntByXpath("//psapsToErase/text()", psapsToErase_);
    ParameterManager::getInstance().getIntByXpath("//respsToErase/text()", respsToErase_);
 }
@@ -58,7 +57,7 @@ void Connections911::printParameters() const
    LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS"
                                    << endl
                                    << "\tConnections Type: Connections911" << endl
-                                   << "\tConnections per vertex: " << connsPerVertex_ << endl
+                                   << "\tMaximum Connections per vertex: " << edges_->maxEdgesPerVertex_ << endl
                                    << "\tPSAPs to erase: " << psapsToErase_ << endl
                                    << "\tRESPs to erase: " << respsToErase_ << endl
                                    << endl);

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -54,13 +54,14 @@ void Connections911::loadParameters()
 ///  Registered to OperationManager as Operation::printParameters
 void Connections911::printParameters() const
 {
-   LOG4CPLUS_DEBUG(fileLogger_, "CONNECTIONS PARAMETERS"
-                                   << endl
-                                   << "\tConnections Type: Connections911" << endl
-                                   << "\tMaximum Connections per vertex: " << edges_->maxEdgesPerVertex_ << endl
-                                   << "\tPSAPs to erase: " << psapsToErase_ << endl
-                                   << "\tRESPs to erase: " << respsToErase_ << endl
-                                   << endl);
+   LOG4CPLUS_DEBUG(fileLogger_,
+                   "CONNECTIONS PARAMETERS"
+                      << endl
+                      << "\tConnections Type: Connections911" << endl
+                      << "\tMaximum Connections per vertex: " << edges_->maxEdgesPerVertex_ << endl
+                      << "\tPSAPs to erase: " << psapsToErase_ << endl
+                      << "\tRESPs to erase: " << respsToErase_ << endl
+                      << endl);
 }
 
 #if !defined(USE_GPU)

--- a/Simulator/Connections/NG911/Connections911.h
+++ b/Simulator/Connections/NG911/Connections911.h
@@ -46,9 +46,6 @@ public:
    virtual void printParameters() const override;
 
 private:
-   /// number of maximum connections per vertex
-   int connsPerVertex_;
-
    /// number of psaps to erase at the end of 1 epoch
    int psapsToErase_;
 

--- a/configfiles/test-king-county-911.xml
+++ b/configfiles/test-king-county-911.xml
@@ -31,13 +31,11 @@
     </EdgesParams>
 
     <ConnectionsParams class="Connections911" name="ConnectionsParams">
-      <Connections911Params name="Connections911Params">
-        <graphmlFile name="graphmlFile">../configfiles/graphs/King_county_NG911.graphml</graphmlFile>
-            <!-- Max ConnsPerVertex = 87 RC + 1 PR -->
-        <connsPerVertex name="connsPerVertex">100</connsPerVertex>
-        <psapsToErase name="psapsToErase">1</psapsToErase>
-        <respsToErase name="respsToErase">2</respsToErase>
-      </Connections911Params>
+      <graphmlFile name="graphmlFile">../configfiles/graphs/King_county_NG911.graphml</graphmlFile>
+          <!-- Max ConnsPerVertex = 87 RC + 1 PR -->
+      <connsPerVertex name="connsPerVertex">100</connsPerVertex>
+      <psapsToErase name="psapsToErase">1</psapsToErase>
+      <respsToErase name="respsToErase">2</respsToErase>
     </ConnectionsParams>
 
 

--- a/configfiles/test-king-county-911.xml
+++ b/configfiles/test-king-county-911.xml
@@ -32,8 +32,6 @@
 
     <ConnectionsParams class="Connections911" name="ConnectionsParams">
       <graphmlFile name="graphmlFile">../configfiles/graphs/King_county_NG911.graphml</graphmlFile>
-          <!-- Max ConnsPerVertex = 87 RC + 1 PR -->
-      <connsPerVertex name="connsPerVertex">100</connsPerVertex>
       <psapsToErase name="psapsToErase">1</psapsToErase>
       <respsToErase name="respsToErase">2</respsToErase>
     </ConnectionsParams>

--- a/configfiles/test-small-911.xml
+++ b/configfiles/test-small-911.xml
@@ -36,8 +36,6 @@
     <ConnectionsParams class="Connections911" name="ConnectionsParams">
       <Connections911Params name="Connections911Params">
         <graphmlFile name="graphmlFile">../configfiles/graphs/small_911.graphml</graphmlFile>
-            <!-- Max ConnsPerVertex = 87 RC + 1 PR -->
-        <connsPerVertex name="maxConnsPerVertex">88</connsPerVertex>
         <psapsToErase name="psapsToErase">1</psapsToErase>
         <respsToErase name="respsToErase">2</respsToErase>
       </Connections911Params>

--- a/configfiles/test-small-911.xml
+++ b/configfiles/test-small-911.xml
@@ -37,7 +37,7 @@
       <Connections911Params name="Connections911Params">
         <graphmlFile name="graphmlFile">../configfiles/graphs/small_911.graphml</graphmlFile>
             <!-- Max ConnsPerVertex = 87 RC + 1 PR -->
-        <connsPerVertex name="connsPerVertex">88</connsPerVertex>
+        <connsPerVertex name="maxConnsPerVertex">88</connsPerVertex>
         <psapsToErase name="psapsToErase">1</psapsToErase>
         <respsToErase name="respsToErase">2</respsToErase>
       </Connections911Params>


### PR DESCRIPTION
Closes #406 

Removes the extra level in the Connections parameter node from the XML config file because it is not needed.