### PR TITLE
[ISSUE 460] Enhancing build efficiency with the -j option in the make command 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: cmake ..
     - id: build
       name: build
-      run: make
+      run: make -j
     - name: run unit tests
       run: ./tests    
 

--- a/build/README.md
+++ b/build/README.md
@@ -15,7 +15,7 @@ NOTE: If you're making a clean build (No CMakeCache.txt) of the GPU version, you
 
 This will generate a Makefile using the instructions in the CMakeLists.txt. Once the Makefile is created input the following  command.
 
-`make`
+`make -j`
 
 This will create the executables `graphitti` and `tests`. `graphitti` is the simulator and `tests` are the unit tests.
 To run the simulation input the following command with a path to a configuration file.


### PR DESCRIPTION
Closes #460 

This PR adds:
Added "make -j" to line 18 on README.md
Added line 28 on tests.yml "run: make -j" for GitHub Actions Workflow file, noticed a 2ms time difference on raiju ./tests run with -j option enabled on GPU. 

