### PR TITLE
[ISSUE-410] Check switches on edgeType and make sure they have default cases

### DIFF
--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -94,8 +94,8 @@ int AllNeuroEdges::edgSign(const edgeType type)
       default:
          return 0;
    }
-   // if return 0 -> throw exception.
-   // TODO Throw exception if 0 (error).
+   // if return 0 throw exception.
+   // TODO Throw exception.
    return 0; 
 }
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -95,7 +95,8 @@ int AllNeuroEdges::edgSign(const edgeType type)
          return 0;
    }
    // if return 0 -> throw exception
-   return 0; // TODO Throw exception if 0 (error)
+   return 0; 
+   // TODO Throw exception if 0 (error)
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -95,7 +95,8 @@ int AllNeuroEdges::edgSign(const edgeType type)
          return 0;
    }
    // if return 0 -> throw exception.
-   return 0; // TODO Throw exception if 0 (error).
+   // TODO Throw exception if 0 (error).
+   return 0; 
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -91,6 +91,7 @@ int AllNeuroEdges::edgSign(const edgeType type)
          return 1;
       case ETYPE_UNDEF:
          return 0;
+         break;
       default:
          return 0;
    }

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -92,11 +92,9 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case ETYPE_UNDEF:
          // TODO error.
          return 0;
-      default:
-         return 0;
    }
 
-   return 0;
+   return 0; // default.
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,12 +90,12 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
-         return 0; // cannot add default case without code style violation
+         return 0;
+      default:
+         return 0;
    }
-   
-   return 0; 
-   // if return 0 -> throw exception
-   // TODO Throw exception if 0 (error)
+   // if return 0 -> throw exception.
+   return 0; // TODO Throw exception if 0 (error).
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,13 +90,13 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
+         // TODO error.
          return 0;
       default:
          return 0;
    }
-   // if return 0 throw exception.
-   // TODO Throw exception.
-   return 0; 
+
+   return 0;
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -94,8 +94,9 @@ int AllNeuroEdges::edgSign(const edgeType type)
       default:
          return 0;
    }
-   // if return 0 -> throw exception
+   
    return 0; 
+   // if return 0 -> throw exception
    // TODO Throw exception if 0 (error)
 }
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,11 +90,12 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
-         // TODO error.
+         return 0;
+      default:
          return 0;
    }
-
-   return 0;
+   // if return 0 -> throw exception
+   return 0; // TODO Throw exception if 0 (error)
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -91,10 +91,10 @@ int AllNeuroEdges::edgSign(const edgeType type)
          return 1;
       case ETYPE_UNDEF:
          return 0;
-      default:
-         return 0;
+      //default:
+        // return 0;
    }
-   
+
    return 0; 
    // if return 0 -> throw exception
    // TODO Throw exception if 0 (error)

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,14 +90,11 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
+         // TODO error.
          return 0;
-      //default:
-        // return 0;
    }
 
-   return 0; 
-   // if return 0 -> throw exception
-   // TODO Throw exception if 0 (error)
+   return 0;
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,15 +90,12 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
-         return 0;
-         break;
-      default:
-         return 0;
+         return 0; // cannot add default case without code style violation
    }
    
    return 0; 
-   /// if return 0 -> throw exception
-   /// TODO Throw exception if 0 (error)
+   // if return 0 -> throw exception
+   // TODO Throw exception if 0 (error)
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,10 +90,11 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
-         // TODO error.
+         return 0;
+      default:
          return 0;
    }
-
+   // TODO: exception throw.
    return 0;   // default.
 }
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -90,11 +90,14 @@ int AllNeuroEdges::edgSign(const edgeType type)
       case EE:
          return 1;
       case ETYPE_UNDEF:
-         // TODO error.
+         return 0;
+      default:
          return 0;
    }
-
-   return 0;
+   
+   return 0; 
+   /// if return 0 -> throw exception
+   /// TODO Throw exception if 0 (error)
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -94,7 +94,7 @@ int AllNeuroEdges::edgSign(const edgeType type)
          return 0;
    }
 
-   return 0; // default.
+   return 0;   // default.
 }
 
 ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -36,8 +36,8 @@ CUDA_CALLABLE int edgSign(edgeType t)
       case EE:
          return 1;
    }
-    // Add throw exception.
-   return 0;
+
+   return 0; // TODO exception.
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -36,8 +36,8 @@ CUDA_CALLABLE int edgSign(edgeType t)
       case EE:
          return 1;
    }
-
-   return 0; // TODO Potentially add throw exception for easier diagnosis.
+    // TODO Potentially add throw exception for easier diagnosis.
+   return 0;
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -37,7 +37,7 @@ CUDA_CALLABLE int edgSign(edgeType t)
          return 1;
    }
 
-   return 0;
+   return 0; // TODO Potentially add throw exception for easier diagnosis 
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -37,7 +37,7 @@ CUDA_CALLABLE int edgSign(edgeType t)
          return 1;
    }
 
-   return 0;   // TODO: exception.
+   return 0;   // TODO: exception throw.
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -37,7 +37,7 @@ CUDA_CALLABLE int edgSign(edgeType t)
          return 1;
    }
 
-   return 0; // TODO Potentially add throw exception for easier diagnosis 
+   return 0; // TODO Potentially add throw exception for easier diagnosis.
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -37,7 +37,7 @@ CUDA_CALLABLE int edgSign(edgeType t)
          return 1;
    }
 
-   return 0; // TODO exception.
+   return 0;   // TODO: exception.
 }
 
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -36,7 +36,7 @@ CUDA_CALLABLE int edgSign(edgeType t)
       case EE:
          return 1;
    }
-    // TODO Potentially add throw exception for easier diagnosis.
+    // Add throw exception.
    return 0;
 }
 


### PR DESCRIPTION
Closes #410 
This PR checks to make sure switches on edgeType and makes sure they have default cases, with the ability to expand with throwing exceptions in the future if the switches return 0. In principle, return 0 in switch case if error. 