### PR TITLE
[ISSUE 376] Rename command line options for stimulusfile (-s), deserializefile(-r) and serializefile(-w)

### DIFF
--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,7 +55,8 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") // changed from 'd' to 'g'.
+         // changed from 'd' to 'g'.
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") 
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,7 +55,7 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")   // d to g option change 
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")   // d to g option change.
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,8 +55,7 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-         // changed from 'd' to 'g'.
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") 
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")    // changed from 'd' to 'g'.
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,15 +55,15 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'd', ParamContainer::regular, "CUDA device id")
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") // changed from 'd' to 'g' since deserialize took 'd'
            != ParamContainer::errOk)
 #endif   // USE_GPU
-       || (cl.addParam("stimulusfile", 's', ParamContainer::filename, "stimulus input filepath")
+       || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")
            != ParamContainer::errOk)
-       || (cl.addParam("deserializefile", 'r', ParamContainer::filename,
+       || (cl.addParam("deserializefile", 'd', ParamContainer::filename,
                        "simulation deserialization filepath (enables deserialization)")
            != ParamContainer::errOk)
-       || (cl.addParam("serializefile", 'w', ParamContainer::filename,
+       || (cl.addParam("serializefile", 's', ParamContainer::filename,
                        "simulation serialization filepath (enables serialization)")
            != ParamContainer::errOk)
        || (cl.addParam("version", 'v', ParamContainer::novalue,

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,7 +55,7 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") // changed from 'd' to 'g'.
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,7 +55,7 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id") // changed from 'd' to 'g' since deserialize took 'd'
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,9 +55,9 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")   // d to g option change.
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")
            != ParamContainer::errOk)
-#endif   // USE_GPU
+#endif   // USE_GPU changed 'd' to 'g' option
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")
            != ParamContainer::errOk)
        || (cl.addParam("deserializefile", 'd', ParamContainer::filename,

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,9 +55,9 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA GPU device ID")
            != ParamContainer::errOk)
-#endif   // USE_GPU changed 'd' to 'g' option
+#endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")
            != ParamContainer::errOk)
        || (cl.addParam("deserializefile", 'd', ParamContainer::filename,

--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -55,7 +55,7 @@ bool Core::parseCommandLine(string executableName, string cmdLineArguments)
    if ((cl.addParam("configfile", 'c', ParamContainer::filename, "parameter configuration filepath")
         != ParamContainer::errOk)
 #if defined(USE_GPU)
-       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")    // changed from 'd' to 'g'.
+       || (cl.addParam("device", 'g', ParamContainer::regular, "CUDA device id")   // d to g option change 
            != ParamContainer::errOk)
 #endif   // USE_GPU
        || (cl.addParam("inputfile", 'i', ParamContainer::filename, "input file path")

--- a/docs/Developer/StudentSetup.md
+++ b/docs/Developer/StudentSetup.md
@@ -86,9 +86,9 @@ Other external guides for remote VS Code development:
 The following options are available:
 
 - `-c, --configfile=<configfile>`: Specifies the filepath for the parameter configuration file. This file is required.
-- `-s, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
-- `-r, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
-- `-w, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
+- `-i, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
+- `-d, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
+- `-s, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
 - `-v, --version`: Outputs the current git commit ID and exits.
 
 ## Using Visual Studio Code 

--- a/docs/Developer/StudentSetup.md
+++ b/docs/Developer/StudentSetup.md
@@ -86,9 +86,11 @@ Other external guides for remote VS Code development:
 The following options are available:
 
 - `-c, --configfile=<configfile>`: Specifies the filepath for the parameter configuration file. This file is required.
-- `-i, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
+- `-i, --inputfile=<stimulusfile>`: Specifies the filepath for the input file. This file is required.
 - `-d, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
 - `-s, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
+- `-g, --device=<GPU device ID>`: Specifies the ID of the GPU device to be used. Available only when the
+high-performance GPU version has been compiled (`ggraphitti`).
 - `-v, --version`: Outputs the current git commit ID and exits.
 
 ## Using Visual Studio Code 

--- a/docs/User/quickstart.md
+++ b/docs/User/quickstart.md
@@ -59,7 +59,7 @@ As a quick start and sanity test, let's run a small, prepackaged simulation to m
 The following options are available:
 
 - `-c, --configfile=<configfile>`: Specifies the filepath for the parameter configuration file. This file is required.
-- `-i, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
+- `-i, --inputfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
 - `-d, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
 - `-s, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
 - `-g, --device=<GPU device ID>`: Specifies the ID of the GPU device to be used. Available only when the

--- a/docs/User/quickstart.md
+++ b/docs/User/quickstart.md
@@ -50,7 +50,22 @@ As a quick start and sanity test, let's run a small, prepackaged simulation to m
    $ ./cgraphitti -c ../configfiles/test-small.xml
    ```
 
-5. The program will then run and display the current step and epoch of the simulation. The output of the simulation (after the end of the simulation) will be saved in the ```Output/Results``` folder.
+5. To access the command line options of Graphitti, use the `-help` flag with its CPU or GPU executable. Here's an example of how to run it:
+
+    ```
+    $ ./cgraphitti -help
+    ```
+
+The following options are available:
+
+- `-c, --configfile=<configfile>`: Specifies the filepath for the parameter configuration file. This file is required.
+- `-i, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
+- `-d, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
+- `-s, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
+- `-v, --version`: Outputs the current git commit ID and exits.
+
+
+6. The program will then run and display the current step and epoch of the simulation. The output of the simulation (after the end of the simulation) will be saved in the ```Output/Results``` folder.
 
 The run time of this test is small-ish on a fast computer (maybe a couple minutes), but this particular test also doesn't do much. The output will be mostly nothing - but it shouldn't crash or give you anything weird. 
 

--- a/docs/User/quickstart.md
+++ b/docs/User/quickstart.md
@@ -62,6 +62,8 @@ The following options are available:
 - `-i, --stimulusfile=<stimulusfile>`: Specifies the filepath for the stimulus input file. This file is required.
 - `-d, --deserializefile=<deserializefile>`: Specifies the filepath for simulation deserialization. Enabling this option allows you to deserialize a previous simulation.
 - `-s, --serializefile=<serializefile>`: Specifies the filepath for simulation serialization. Enabling this option allows you to serialize the simulation.
+- `-g, --device=<GPU device ID>`: Specifies the ID of the GPU device to be used. Available only when the
+high-performance GPU version has been compiled (`ggraphitti`).
 - `-v, --version`: Outputs the current git commit ID and exits.
 
 


### PR DESCRIPTION
- Renames command line options for stimulusfile (-s), deserializefile(-r) and serializefile(-w)
- Updates the command line option in the documentation under Student Quickstart
- Adds command line option in the documentation under Quickstart