### PR TITLE
[ISSUE-458] Changed summationPoint_ into a vector of indexes

### DIFF
--- a/Simulator/Connections/Connections.cpp
+++ b/Simulator/Connections/Connections.cpp
@@ -121,7 +121,7 @@ void Connections::createSynapsesFromWeights()
          // if the synapse weight is not zero (which means there is a connection), create the synapse
          if (edges_->W_[iEdg] != 0.0) {
             BGFLOAT theW = edges_->W_[iEdg];
-            BGFLOAT *sumPoint = &(vertices.summationMap_[i]);
+            const int sumPoint = i;
             int srcVertex = edges_->sourceVertexIndex_[iEdg];
             int destVertex = edges_->destVertexIndex_[iEdg];
             edgeType type = layout.edgType(srcVertex, destVertex);

--- a/Simulator/Connections/NG911/Connections911.cpp
+++ b/Simulator/Connections/NG911/Connections911.cpp
@@ -31,7 +31,7 @@ void Connections911::setup()
       size_t srcV = gm.source(*it);
       size_t destV = gm.target(*it);
       edgeType type = layout.edgType(srcV, destV);
-      BGFLOAT *sumPoint = &vertices.summationMap_[destV];
+      const int sumPoint = destV;
 
       BGFLOAT dist = layout.dist_(srcV, destV);
       LOG4CPLUS_DEBUG(edgeLogger_, "Source: " << srcV << " Dest: " << destV << " Dist: " << dist);
@@ -191,7 +191,7 @@ bool Connections911::erasePSAP(AllVertices &vertices, Layout &layout)
       }
 
       // Insert Caller to PSAP edge
-      BGFLOAT *sumPoint = &vertices.summationMap_[closestPSAP];
+      const int sumPoint = closestPSAP;
       BGSIZE iEdg;
       edges_->addEdge(iEdg, CP, srcVertex, closestPSAP, sumPoint,
                       Simulator::getInstance().getDeltaT());
@@ -221,7 +221,7 @@ bool Connections911::erasePSAP(AllVertices &vertices, Layout &layout)
       }
 
       // Insert PSAP to Responder edge
-      BGFLOAT *sumPoint = &vertices.summationMap_[destVertex];
+      const int sumPoint = destVertex;
       BGSIZE iEdg;
       edges_->addEdge(iEdg, PR, closestPSAP, destVertex, sumPoint,
                       Simulator::getInstance().getDeltaT());

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -278,7 +278,7 @@ void ConnGrowth::updateSynapsesWeights()
          // if not connected and weight(a,b) > 0, add a new synapse from a to b
          if (!connected && (W_(srcVertex, destVertex) > 0)) {
             // locate summation point
-            BGFLOAT *sumPoint = &(vertices.summationMap_[destVertex]);
+            const int sumPoint = destVertex;
             added++;
 
             BGSIZE iEdg;

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -74,7 +74,7 @@ void ConnStatic::setup()
       for (BGSIZE i = 0; i < distDestVertices[srcVertex].size() && (int)i < connsPerVertex_; i++) {
          int destVertex = distDestVertices[srcVertex][i].destVertex;
          edgeType type = layout.edgType(srcVertex, destVertex);
-         BGFLOAT *sumPoint = &vertices.summationMap_[destVertex];
+         const int sumPoint = destVertex;
 
          LOG4CPLUS_DEBUG(fileLogger_,
                          "Source: " << srcVertex << " Dest: " << destVertex

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -145,11 +145,11 @@ private:
 
    // TODO
    void addEdge(AllEdges &synapses, edgeType type, const int srcVertex, const int destVertex,
-                Coordinate &source, Coordinate &dest, BGFLOAT *sumPoint, BGFLOAT deltaT);
+                Coordinate &source, Coordinate &dest, const int sumPoint, BGFLOAT deltaT);
 
    // TODO
    void createEdge(AllEdges &synapses, const int neuronIndex, const int synapseIndex,
-                   Coordinate source, Coordinate dest, BGFLOAT *sp, BGFLOAT deltaT, edgeType type);
+                   Coordinate source, Coordinate dest, const int sp, BGFLOAT deltaT, edgeType type);
 };
 
 #if defined(__CUDACC__)

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -78,7 +78,7 @@ void AllEdges::setupEdges(const int numVertices, const int maxEdges)
       W_.assign(maxTotalEdges, 0);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
       edgeCounts_.assign(numVertices, 0);
-      summationPoint_.assign(maxTotalEdges, nullptr);
+      summationPoint_.assign(maxTotalEdges, -1);
       destVertexIndex_.assign(maxTotalEdges, 0);
       sourceVertexIndex_.assign(maxTotalEdges, 0);
 
@@ -243,7 +243,7 @@ void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg)
 {
    edgeCounts_[iVert]--;
    inUse_[iEdg] = false;
-   summationPoint_[iEdg] = nullptr;
+   summationPoint_[iEdg] = -1;
    W_[iEdg] = 0;
 }
 
@@ -259,7 +259,7 @@ void AllEdges::eraseEdge(const int iVert, const BGSIZE iEdg)
 ///  @param  sumPoint   Summation point address.
 ///  @param  deltaT      Inner simulation step duration
 void AllEdges::addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex,
-                       BGFLOAT *sumPoint, const BGFLOAT deltaT)
+                       const int sumPoint, const BGFLOAT deltaT)
 {
    if (edgeCounts_[destVertex] >= maxEdgesPerVertex_) {
       LOG4CPLUS_FATAL(edgeLogger_, "Vertex : " << destVertex << " ran out of space for new edges.");

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -11,6 +11,7 @@
 #include "EdgeIndexMap.h"
 #include "Global.h"
 #include "Simulator.h"
+#include "boost/container/vector.hpp"
 #include "cereal/types/vector.hpp"
 #include "log4cplus/loggingmacros.h"
 #include <vector>
@@ -43,7 +44,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration
    virtual void addEdge(BGSIZE &iEdg, edgeType type, const int srcVertex, const int destVertex,
-                        BGFLOAT *sumPoint, const BGFLOAT deltaT);
+                        const int sumPoint, const BGFLOAT deltaT);
 
    ///  Create a Edge and connect it to the model.
    ///
@@ -53,7 +54,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Edge to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type)
       = 0;
 
@@ -206,8 +207,9 @@ public:
    ///   The weight (scaling factor, strength, maximal amplitude) of the edge.
    vector<BGFLOAT> W_;
 
-   ///  This edge's summation point's address.
-   vector<BGFLOAT *> summationPoint_;
+   ///  This edge's summation point's index.
+   // This was changed from storing the address to index to help serialization
+   vector<int> summationPoint_;
 
    ///   Synapse type
    vector<edgeType> type_;

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -34,7 +34,7 @@ void All911Edges::setupEdges()
       W_.assign(maxTotalEdges, 0);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
       edgeCounts_.assign(numVertices, 0);
-      summationPoint_.assign(maxTotalEdges, nullptr);
+      summationPoint_.assign(maxTotalEdges, -1);
       destVertexIndex_.assign(maxTotalEdges, 0);
       sourceVertexIndex_.assign(maxTotalEdges, 0);
       inUse_ = make_unique<bool[]>(maxTotalEdges);
@@ -42,7 +42,7 @@ void All911Edges::setupEdges()
    }
 }
 
-void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+void All911Edges::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                              const BGFLOAT deltaT, edgeType type)
 {
    inUse_[iEdg] = true;

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -55,7 +55,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Edge to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type) override;
 
 protected:

--- a/Simulator/Edges/Neuro/AllDSSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses.cpp
@@ -113,7 +113,7 @@ void AllDSSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT)
 ///  @param  sumPoint   Summation point address.
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
-void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+void AllDSSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                                const BGFLOAT deltaT, edgeType type)
 {
    AllSpikingSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -85,7 +85,7 @@ public:
    ///  @param  sumPoint   Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type) override;
 
    ///  Prints SynapsesProps data to console.

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.cpp
@@ -114,7 +114,7 @@ void AllDynamicSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT)
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
 void AllDynamicSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
-                                        BGFLOAT *sumPoint, const BGFLOAT deltaT, edgeType type)
+                                        const int sumPoint, const BGFLOAT deltaT, edgeType type)
 {
    AllSTDPSynapses::createEdge(iEdg, srcVertex, destVertex, sumPoint, deltaT, type);
 

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -90,7 +90,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type) override;
 
    ///  Prints SynapsesProps data.

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -109,7 +109,7 @@ void AllNeuroEdges::printSynapsesProps() const
          cout << " type: " << type_[i];
          cout << " psr: " << psr_[i];
          cout << " in_use:" << inUse_[i];
-         if (summationPoint_[i] != nullptr) {
+         if (summationPoint_[i] != -1) {
             cout << " summationPoint: is created!" << endl;
          } else {
             cout << " summationPoint: is EMPTY!!!!!" << endl;

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -67,7 +67,7 @@ public:
    // ///  @param  sumPoint    Summation point address.
    // ///  @param  deltaT      Inner simulation step duration.
    // ///  @param  type        Type of the Synapse to create.
-   // virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint, const BGFLOAT deltaT,
+   // virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint, const BGFLOAT deltaT,
    //                            edgeType type) override;
 
    ///  Get the sign of the edgeType.

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.cpp
@@ -229,7 +229,7 @@ void AllSTDPSynapses::resetEdge(const BGSIZE iEdg, const BGFLOAT deltaT)
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
 void AllSTDPSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
-                                 BGFLOAT *sumPoint, const BGFLOAT deltaT, edgeType type)
+                                 const int sumPoint, const BGFLOAT deltaT, edgeType type)
 {
    totalDelayPost_[iEdg]
       = 0;   // Apr 12th 2020 move this line so that when AllSpikingSynapses::createEdge() is called, inside this method the initSpikeQueue() method can be called successfully
@@ -274,7 +274,7 @@ void AllSTDPSynapses::advanceEdge(const BGSIZE iEdg, AllVertices &neurons)
 
    BGFLOAT &decay = decay_[iEdg];
    BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &summationPoint = *(summationPoint_[iEdg]);
+   int summationPoint = summationPoint_[iEdg];
 
    // is an input in the queue?
    bool fPre = isSpikeQueue(iEdg);

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -115,7 +115,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type) override;
 
    ///  Prints SynapsesProps data.

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -168,7 +168,7 @@ void AllSpikingSynapses::writeEdge(ostream &output, const BGSIZE iEdg) const
 ///  @param  deltaT      Inner simulation step duration.
 ///  @param  type        Type of the Synapse to create.
 void AllSpikingSynapses::createEdge(const BGSIZE iEdg, int srcVertex, int destVertex,
-                                    BGFLOAT *sumPoint, const BGFLOAT deltaT, edgeType type)
+                                    const int sumPoint, const BGFLOAT deltaT, edgeType type)
 {
    BGFLOAT delay;
 
@@ -275,7 +275,7 @@ void AllSpikingSynapses::advanceEdge(const BGSIZE iEdg, AllVertices &neurons)
 {
    BGFLOAT &decay = decay_[iEdg];
    BGFLOAT &psr = psr_[iEdg];
-   BGFLOAT &summationPoint = *(summationPoint_[iEdg]);
+   int summationPoint = summationPoint_[iEdg];
 
    // is an input in the queue?
    if (isSpikeQueue(iEdg)) {

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -70,7 +70,7 @@ public:
    ///  @param  sumPoint    Summation point address.
    ///  @param  deltaT      Inner simulation step duration.
    ///  @param  type        Type of the Synapse to create.
-   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT *sumPoint,
+   virtual void createEdge(const BGSIZE iEdg, int srcVertex, int destVertex, const int sumPoint,
                            const BGFLOAT deltaT, edgeType type) override;
 
    ///  Check if the back propagation (notify a spike event to the pre neuron)

--- a/Simulator/Utils/Inputs/GpuSInputPoisson.h
+++ b/Simulator/Utils/Inputs/GpuSInputPoisson.h
@@ -58,7 +58,7 @@ private:
 extern __global__ void inputStimulusDevice(int n, int *deviceInteralCounter_, bool *deviceMasks_,
                                            BGFLOAT deltaT, BGFLOAT lambda, curandState *devStates_d,
                                            AllDSSynapsesDeviceProperties *allEdgesDevice);
-extern __global__ void applyI2SummationMap(int n, BGFLOAT *summationPoint_d,
+extern __global__ void applyI2SummationMap(int n, int summationPoint_d,
                                            AllDSSynapsesDeviceProperties *allEdgesDevice);
 extern __global__ void setupSeeds(int n, curandState *devStates_d, unsigned long seed);
 #endif

--- a/Simulator/Utils/Inputs/GpuSInputRegular.h
+++ b/Simulator/Utils/Inputs/GpuSInputRegular.h
@@ -33,7 +33,7 @@ public:
 
 //! Device function that processes input stimulus for each time step.
 #if defined(__CUDACC__)
-extern __global__ void inputStimulusDevice(int n, BGFLOAT *summationPoint_d, BGFLOAT *initValues_d,
+extern __global__ void inputStimulusDevice(int n, int summationPoint_d, BGFLOAT *initValues_d,
                                            int *nShiftValues_d, int nStepsInCycle, int nStepsCycle,
                                            int nStepsDuration);
 #endif

--- a/Simulator/Utils/Inputs/SInputPoisson.cpp
+++ b/Simulator/Utils/Inputs/SInputPoisson.cpp
@@ -113,8 +113,7 @@ void SInputPoisson::init()
       else
          type = EE;
 
-      BGFLOAT *sumPoint
-         = &(Simulator::getInstance().getLayout().getVertices().summationMap_[neuronIndex]);
+      const int sumPoint = neuronIndex;
       BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * neuronIndex;
 
       edges_->createEdge(iEdg, 0, neuronIndex, sumPoint, Simulator::getInstance().getDeltaT(),


### PR DESCRIPTION
Closes #458 

This PR transforms `summationPoint_` into a vector of indexes, which can then be serialized and deserialized using the standard serialization methods provided by the Cereal Library.

