### PR TITLE
[ISSUE 529] Implemented call redials in the NG911 models

### DIFF
--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -21,6 +21,9 @@ void All911Edges::setupEdges()
    isAvailable_ = make_unique<bool[]>(maxTotalEdges);
    fill_n(isAvailable_.get(), maxTotalEdges, true);
 
+   isRedial_ = make_unique<bool[]>(maxTotalEdges);
+   fill_n(isRedial_.get(), maxTotalEdges, false);
+
    call_.resize(maxTotalEdges);
 
    maxEdgesPerVertex_ = maxEdges;
@@ -84,20 +87,26 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
          }   // Edge doesn't have a call
 
          int dst = destVertexIndex_[edgeIdx];
-         // Record that we received a call
-         all911Vertices.receivedCalls_[dst]++;
 
          // The destination vertex should be the one pulling the information
          assert(dst == vertex);
          if (all911Vertices.vertexQueues_[dst].isFull()) {
             // Call is dropped because there is no space in the waiting queue
-            all911Vertices.droppedCalls_[dst]++;
-            LOG4CPLUS_DEBUG(edgeLogger_, "Call dropped: " << all911Vertices.droppedCalls_[dst]
-                                                          << ", time: " << call_[edgeIdx].time
-                                                          << ", eIdx: " << edgeIdx);
+            if (!isRedial_[edgeIdx]) {
+               // Only count the dropped call if its is not a redial
+               all911Vertices.droppedCalls_[dst]++;
+               // Record that we received a call
+               all911Vertices.receivedCalls_[dst]++;
+               LOG4CPLUS_DEBUG(edgeLogger_, "Call dropped: " << all911Vertices.droppedCalls_[dst]
+                                                            << ", time: " << call_[edgeIdx].time
+                                                            << ", eIdx: " << edgeIdx);
+            }
          } else {
             all911Vertices.vertexQueues_[dst].put(call_[edgeIdx]);
+            // Record that we received a call
+            all911Vertices.receivedCalls_[dst]++;
             isAvailable_[edgeIdx] = true;
+            isRedial_[edgeIdx] = false;
          }
       }
    }

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -98,8 +98,8 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
                // Record that we received a call
                all911Vertices.receivedCalls_[dst]++;
                LOG4CPLUS_DEBUG(edgeLogger_, "Call dropped: " << all911Vertices.droppedCalls_[dst]
-                                                            << ", time: " << call_[edgeIdx].time
-                                                            << ", eIdx: " << edgeIdx);
+                                                             << ", time: " << call_[edgeIdx].time
+                                                             << ", eIdx: " << edgeIdx);
             }
          } else {
             all911Vertices.vertexQueues_[dst].put(call_[edgeIdx]);

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -93,7 +93,7 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
          if (all911Vertices.vertexQueues_[dst].isFull()) {
             // Call is dropped because there is no space in the waiting queue
             if (!isRedial_[edgeIdx]) {
-               // Only count the dropped call if its is not a redial
+               // Only count the dropped call if it's not a redial
                all911Vertices.droppedCalls_[dst]++;
                // Record that we received a call
                all911Vertices.receivedCalls_[dst]++;

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -101,6 +101,9 @@ public:
    /// If edge has a call or not
    unique_ptr<bool[]> isAvailable_;
 
+   /// If the call in the edge is a redial
+   unique_ptr<bool[]> isRedial_;
+
    /// The call information per edge
    vector<Call> call_;
 };

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -144,6 +144,7 @@ void All911Vertices::loadParameters()
    ParameterManager::getInstance().getIntByXpath("//CallNum/max/text()", callNumRange_[1]);
    ParameterManager::getInstance().getBGFloatByXpath("//DispNumScale/text()", dispNumScale_);
    ParameterManager::getInstance().getBGFloatByXpath("//RespNumScale/text()", respNumScale_);
+   ParameterManager::getInstance().getBGFloatByXpath("//RedialP/text()", redialP_);
 }
 
 
@@ -202,14 +203,20 @@ void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIn
          if (!edges911.isAvailable_[edgeIdx]) {
             // If the call is still there, it means that there was no space in the PSAP's waiting
             // queue. Therefore, this is a dropped call.
-            // TODO: Decide if it needs to be redialed
-            // Make the edge availabe after taking care of the dropped call
-            edges911.isAvailable_[edgeIdx] = true;
+            // If readialing, we assume that it happens immediately and the caller tries until
+            // getting through. Otherwise, just mark it as a redial.
+            if (!edges911.isRedial_[edgeIdx] && initRNG.randDblExc() >= redialP_) {
+               // We only make the edge available if no readialing occurs.
+               edges911.isAvailable_[edgeIdx] = true;
+               LOG4CPLUS_DEBUG(vertexLogger_, "Did not redial at time: " << edges911.call_[edgeIdx].time);
+            } else {
+               edges911.isRedial_[edgeIdx] = true;
+            }
          }
 
          // peek at the next call in the queue
          optional<Call> nextCall = vertexQueues_[vertex].peek();
-         if (nextCall && nextCall->time <= g_simulationStep) {
+         if (edges911.isAvailable_[edgeIdx] && nextCall && nextCall->time <= g_simulationStep) {
             // Calls that start at the same time are process in the order they appear.
             // The call starts at the current time step so we need to pop it and process it
             vertexQueues_[vertex].get();   // pop from the queue

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -208,7 +208,8 @@ void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIn
             if (!edges911.isRedial_[edgeIdx] && initRNG.randDblExc() >= redialP_) {
                // We only make the edge available if no readialing occurs.
                edges911.isAvailable_[edgeIdx] = true;
-               LOG4CPLUS_DEBUG(vertexLogger_, "Did not redial at time: " << edges911.call_[edgeIdx].time);
+               LOG4CPLUS_DEBUG(vertexLogger_,
+                               "Did not redial at time: " << edges911.call_[edgeIdx].time);
             } else {
                edges911.isRedial_[edgeIdx] = true;
             }

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -204,13 +204,14 @@ void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIn
             // If the call is still there, it means that there was no space in the PSAP's waiting
             // queue. Therefore, this is a dropped call.
             // If readialing, we assume that it happens immediately and the caller tries until
-            // getting through. Otherwise, just mark it as a redial.
+            // getting through.
             if (!edges911.isRedial_[edgeIdx] && initRNG.randDblExc() >= redialP_) {
                // We only make the edge available if no readialing occurs.
                edges911.isAvailable_[edgeIdx] = true;
                LOG4CPLUS_DEBUG(vertexLogger_,
                                "Did not redial at time: " << edges911.call_[edgeIdx].time);
             } else {
+               // Keep the edge unavailable but mark it as a redial
                edges911.isRedial_[edgeIdx] = true;
             }
          }

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -90,6 +90,9 @@ private:
    /// Number of phone lines available. Only valid for PSAPs and Responders
    vector<int> numTrunks_;
 
+   /// The probability that a caller will redial after receiving the busy signal
+   BGFLOAT redialP_;
+
    /// Holds the calls being served by each agent
    vector<vector<Call>> servingCall_;
 

--- a/configfiles/test-spd-911.xml
+++ b/configfiles/test-spd-911.xml
@@ -28,6 +28,7 @@
       </CallNum>
       <DispNumScale name="DispNumScale">0.3</DispNumScale>
       <RespNumScale name="RespNumScale">0.3</RespNumScale>
+      <RedialP name="RedialProbability">0.85</RedialP>
     </VerticesParams>
 
     <EdgesParams class="All911Edges" name="EdgesParams">


### PR DESCRIPTION
Closes #529 

This PR implements call redials using a redial probability parameter provided through the config file.

The implementation assumes that once the caller decides to redial, he will do so immediately and will try until the call is answered by the PSAP.

