### PR TITLE
[ISSUE 557] Made all class members of All911Vertices private

### DIFF
--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -72,16 +72,16 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
          // The destination vertex should be the one pulling the information
          assert(dst == vertex);
 
-         CircularBuffer<Call> &dstQueue = all911Vertices.vertexQueues_[dst];
-         if (dstQueue.size() == (dstQueue.capacity() - all911Vertices.busyServers_[dst])) {
+         CircularBuffer<Call> &dstQueue = all911Vertices.getQueue(dst);
+         if (dstQueue.size() == (dstQueue.capacity() - all911Vertices.busyServers(dst))) {
             // Call is dropped because there is no space in the waiting queue
             if (!isRedial_[edgeIdx]) {
                // Only count the dropped call if it's not a redial
-               all911Vertices.droppedCalls_[dst]++;
+               all911Vertices.droppedCalls(dst)++;
                // Record that we received a call
-               all911Vertices.receivedCalls_[dst]++;
+               all911Vertices.receivedCalls(dst)++;
                LOG4CPLUS_DEBUG(edgeLogger_,
-                               "Call dropped: " << all911Vertices.droppedCalls_[dst] << ", time: "
+                               "Call dropped: " << all911Vertices.droppedCalls(dst) << ", time: "
                                                 << call_[edgeIdx].time << ", vertex: " << dst
                                                 << ", queue size: " << dstQueue.size());
             }
@@ -89,7 +89,7 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
             // Transfer call to destination
             dstQueue.put(call_[edgeIdx]);
             // Record that we received a call
-            all911Vertices.receivedCalls_[dst]++;
+            all911Vertices.receivedCalls(dst)++;
             isAvailable_[edgeIdx] = true;
             isRedial_[edgeIdx] = false;
          }

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -149,7 +149,7 @@ int &All911Vertices::receivedCalls(int vIdx)
    return receivedCalls_[vIdx];
 }
 
-int All911Vertices::busyServers(int vIdx)
+int All911Vertices::busyServers(int vIdx) const
 {
    return busyServers_[vIdx];
 }

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -134,6 +134,26 @@ void All911Vertices::loadEpochInputs(uint64_t currentStep, uint64_t endStep)
    }
 }
 
+CircularBuffer<Call> &All911Vertices::getQueue(int vIdx)
+{
+   return vertexQueues_[vIdx];
+}
+
+int &All911Vertices::droppedCalls(int vIdx)
+{
+   return droppedCalls_[vIdx];
+}
+
+int &All911Vertices::receivedCalls(int vIdx)
+{
+   return receivedCalls_[vIdx];
+}
+
+int All911Vertices::busyServers(int vIdx)
+{
+   return busyServers_[vIdx];
+}
+
 #if !defined(USE_GPU)
 
 

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -134,21 +134,25 @@ void All911Vertices::loadEpochInputs(uint64_t currentStep, uint64_t endStep)
    }
 }
 
+// Accessor for the waiting queue of a vertex
 CircularBuffer<Call> &All911Vertices::getQueue(int vIdx)
 {
    return vertexQueues_[vIdx];
 }
 
+// Accessor for the droppedCalls counter of a vertex
 int &All911Vertices::droppedCalls(int vIdx)
 {
    return droppedCalls_[vIdx];
 }
 
+// Accessor for the receivedCalls counter of a vertex
 int &All911Vertices::receivedCalls(int vIdx)
 {
    return receivedCalls_[vIdx];
 }
 
+// Accessor for the number of busy servers in a given vertex
 int All911Vertices::busyServers(int vIdx) const
 {
    return busyServers_[vIdx];

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -120,7 +120,7 @@ public:
    /// endStep (exclusive)
    virtual void loadEpochInputs(uint64_t currentStep, uint64_t endStep) override;
 
-   /// Accessor for a given vertex waiting queue
+   /// Accessor for the waiting queue of a vertex
    ///
    /// @param vIdx   The index of the vertex
    /// @return    The waiting queue for the given vertex
@@ -139,6 +139,7 @@ public:
    int &receivedCalls(int vIdx);
 
    /// Accessor for the number of busy servers in a given vertex
+   ///
    /// @param vIdx   The index of the vertex
    /// @return    The number of busy servers in the given vertex
    int busyServers(int vIdx) const;

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -77,6 +77,9 @@ class All911Edges;
 // Class to hold all data necessary for all the Vertices.
 class All911Vertices : public AllVertices {
 public:
+   // Xml911Recorder needs to access some of this class private members
+   friend class Xml911Recorder;
+
    All911Vertices() = default;
 
    virtual ~All911Vertices() = default;
@@ -117,18 +120,30 @@ public:
    /// endStep (exclusive)
    virtual void loadEpochInputs(uint64_t currentStep, uint64_t endStep) override;
 
-   /// These are the queues where calls will wait to be served
-   vector<CircularBuffer<Call>> vertexQueues_;
+   /// Accessor for a given vertex waiting queue
+   ///
+   /// @param vIdx   The index of the vertex
+   /// @return    The waiting queue for the given vertex
+   CircularBuffer<Call> &getQueue(int vIdx);
 
-   /// Number of servers currently serving calls
-   vector<int> busyServers_;
+   /// Accessor for the droppedCalls counter of a vertex
+   ///
+   /// @param vIdx   The index of the vertex
+   /// @return    A reference to the droppedCalls counter of the vertex
+   int &droppedCalls(int vIdx);
 
-   /// The number of calls that have been dropped (got a busy signal)
-   vector<int> droppedCalls_;
+   /// Accessor for the receivedCalls counter of a vertex
+   ///
+   /// @param vIdx   The index of the vertex
+   /// @return    A reference to the receivedCalls counter of the vertex
+   int &receivedCalls(int vIdx);
 
-   /// The number of received calls
-   vector<int> receivedCalls_;
+   /// Accessor for the number of busy servers in a given vertex
+   /// @param vIdx   The index of the vertex
+   /// @return    The number of busy servers in the given vertex
+   int busyServers(int vIdx);
 
+private:
    /// The starting time for every call
    vector<vector<uint64_t>> beginTimeHistory_;
    /// The answer time for every call
@@ -137,11 +152,22 @@ public:
    vector<vector<uint64_t>> endTimeHistory_;
    /// True if the call was abandoned
    vector<vector<unsigned char>> wasAbandonedHistory_;
-
    /// The length of the waiting queue at every time-step
    vector<vector<int>> queueLengthHistory_;
    /// The portion of servers that are busy at every time-step
    vector<vector<double>> utilizationHistory_;
+
+   /// These are the queues where calls will wait to be served
+   vector<CircularBuffer<Call>> vertexQueues_;
+
+   /// The number of calls that have been dropped (got a busy signal)
+   vector<int> droppedCalls_;
+
+   /// The number of received calls
+   vector<int> receivedCalls_;
+
+   /// Number of servers currently serving calls
+   vector<int> busyServers_;
 
    /// Number of servers. In a PSAP these are the call takers, in Responder nodes
    /// they are responder units
@@ -150,7 +176,6 @@ public:
    /// Number of phone lines available. Only valid for PSAPs and Responders
    vector<int> numTrunks_;
 
-private:
    /// The probability that a caller will redial after receiving the busy signal
    BGFLOAT redialP_;
 

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -141,7 +141,7 @@ public:
    /// Accessor for the number of busy servers in a given vertex
    /// @param vIdx   The index of the vertex
    /// @return    The number of busy servers in the given vertex
-   int busyServers(int vIdx);
+   int busyServers(int vIdx) const;
 
 private:
    /// The starting time for every call


### PR DESCRIPTION
Closes #557 

Made all the class members of All911Vertices private. The Xml911Recorder class was made a friend of All911Vertices because it needs access to some of its internal data structures. Some accessors were also implemented for values needed by the All911Edges class.