### PR TITLE
[ISSUE-473] Write up GitFlow documentation; add to or link to contributing guide 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ For more information on pull requests, you can read the following guide: [pull r
 
 ***Please write unit tests.*** Every time you touch a file, you should review the existing unit tests and think of at least one new one to add.
 
-
+testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,40 +12,42 @@ For UW Bothell students interested in working in the BCL, we use a [shared repos
 
 ## Workflow
 
-- Please read up on Github basics (including [GitHub Issues](https://help.github.com/categories/managing-your-work-on-github/)).
+- Please read up on Github basics (including [GitHub Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues)).
 - Seek the guidance of more senior lab members regarding how to get started. 
 - Please ***DO NOT WORK DIRECTLY ON THE MASTER BRANCH***.
 - Instead, please follow the lab workflow that follows.
 
-0. Review our [Code Formatting Etiquette](https://uwb-biocomputing.github.io/Graphitti/Developer/codingConventions.html) and [C++ design and Coding standards](https://uwb-biocomputing.github.io/Graphitti/Developer/cppStyleGuide.html). Your work will be rejected if it doesn't conform (in fact, your pull requests will fail our code style check in many cases).
+1. Review our [Code Formatting Etiquette](https://uwb-biocomputing.github.io/Graphitti/Developer/codingConventions.html) and [C++ design and Coding standards](https://uwb-biocomputing.github.io/Graphitti/Developer/cppStyleGuide.html). Your work will be rejected if it doesn't conform (in fact, your pull requests will fail our code style check in many cases).
 
-1. Your work should be in response to one or more _issues_. If you are planning to work on something that is a small part of an existing issue, then likely that issue is a placeholder "umbrella" that was generated in lieu of thinking through all related details. In that case, now is the time for you to think it through and break that issue down into actionable items — new issues that partially or completely replace the umbrella.
+2. Your work should be in response to one or more _issues_. If you are planning to work on something that is a small part of an existing issue, then likely that issue is a placeholder "umbrella" that was generated in lieu of thinking through all related details. In that case, now is the time for you to think it through and break that issue down into actionable items — new issues that partially or completely replace the umbrella.
 
-2. When creating an issue, ensure that it is not a duplicate of an existing one. At Graphitti, we value proper etiquette for issue management. The issue title should be concise and descriptive, starting with action verbs. The issue body should provide all the necessary details, including a description section and tasks section.
+3. When creating an issue, ensure that it is not a duplicate of an existing one. At Graphitti, we value proper etiquette for issue management. The issue title should be concise and descriptive, starting with action verbs. The issue body should provide all the necessary details, including a description section and tasks section.
 
-3. Assign yourself to those issue(s).
+4. Assign yourself to those issue(s).
 
-4. Create a new feature branch for your work. The branch name should be prefixed with issue number followed by a short description of the issue i.e., **issue-3141-add-documentation-cereal**. 
+For more information on our GitFlow, please review our [GitFlow Documentation](docs/Developer/GitFlowDiagram.md) to better understand our modifications regarding merging the development branch.
+
+5. Create a new feature branch for your work. The branch name should be prefixed with issue number followed by a short description of the issue i.e., **issue-3141-add-documentation-cereal**. 
 Use lowercase letters & hyphens to separate words. Additionally, you can add a comment to the issue(s) including a link to the feature branch (unless you are going to create a pull request right away).
 
-5. Make changes to the feature branch (commit/push).
+6. Make changes to the feature branch (commit/push).
 
-6. Create a pull request for your branch, whether early or later in your work, to merge into the development branch (not master). Start the pull request title with the issue number, such as **[ISSUE-3141] Add documentation on cereal**. 
+7. Create a pull request for your branch, whether early or later in your work, to merge into the development branch (not master). Start the pull request title with the issue number, such as **[ISSUE-3141] Add documentation on cereal**. 
 In the pull request description, tag your issue and provide a brief overview of the changes for the reviewer. Additionally, ensure to perform the following actions in the right-hand column of the pull request page:
 
   - Assign the pull request to yourself.
   - Attach appropriate labels to the pull request.
   - Link the issue(s) you're working on to this pull request (under "Development", for some reason).
 
-For more information on pull requests, you can read the following guide: [pull requests](http://help.github.com/pull-requests/)
+For more information on pull requests, you can read the following guide: [pull requests](https://docs.github.com/en/pull-requests)
 
-6. Before requesting a review of your pull request, *check that your haven't broken anything*. This means checking that all of our automated GitHub actions have passed their tests (this will show directly in the pull request) and that any required manual tests have passed. Some of our tests take a while to run, so rather than do them for every commit to a pull request, we just run them manually when such requests are close to done. Also, GitHub can only test the CPU version of the simulator, so you need to run GPU tests manually. If in doubt, ask someone.
+8. Before requesting a review of your pull request, *check that your haven't broken anything*. This means checking that all of our automated GitHub actions have passed their tests (this will show directly in the pull request) and that any required manual tests have passed. Some of our tests take a while to run, so rather than do them for every commit to a pull request, we just run them manually when such requests are close to done. Also, GitHub can only test the CPU version of the simulator, so you need to run GPU tests manually. If in doubt, ask someone.
 
-7. Request a review of your pull request. If you have a designated reviewer, ask that person; otherwise, ask Prof. Stiber or ask during a lab meeting who should review your pull request.
+9. Request a review of your pull request. If you have a designated reviewer, ask that person; otherwise, ask Prof. Stiber or ask during a lab meeting who should review your pull request.
 
-8. When your pull request is approved, you can merge it.
+10. When your pull request is approved, you can merge it.
 
-9. Once you've verified that the merge is done, you can delete your feature branch.
+11. Once you've verified that the merge is done, you can delete your feature branch.
 
 ***Please document what you've done***, not only in your commit messages but also with useful comments in code and via changes to the github pages content in the docs directory.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,5 +50,3 @@ For more information on pull requests, you can read the following guide: [pull r
 ***Please document what you've done***, not only in your commit messages but also with useful comments in code and via changes to the github pages content in the docs directory.
 
 ***Please write unit tests.*** Every time you touch a file, you should review the existing unit tests and think of at least one new one to add.
-
-testing

--- a/docs/Developer/GitFlowDiagram.md
+++ b/docs/Developer/GitFlowDiagram.md
@@ -82,3 +82,7 @@ Merging to the Master branch is kind of tricky for our workflow. Our master and 
       checkout main
       cherry-pick id: "fixed broken links"
 ```
+---------
+[<< Go back to the Graphitti home page](../index.md)
+
+[<< Go back to the CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/Developer/GitFlowDiagram.md
+++ b/docs/Developer/GitFlowDiagram.md
@@ -20,7 +20,7 @@ As new development is completed, it gets merged back into the development brach,
 ## How it Works
 New development (new features, non-emergency bug fixes) are built in feature branches. These feature branches are branched off of the development branch, and finished features are merged back into the development branch when they're ready to be reviewed & merged.
 
-### Main Branche
+### Main Branch
 ```mermaid
 %%{init: { 'logLevel': 'debug', 'theme': 'base', 'themeVariables': {
     'git0': '#2E9AFE',

--- a/docs/Developer/GitFlowDiagram.md
+++ b/docs/Developer/GitFlowDiagram.md
@@ -1,0 +1,84 @@
+# Introducing GitFlow
+
+## What is GitFlow?
+
+GitFlow is a branching model for Git, created by [Vincent Driessen.](https://nvie.com/posts/a-successful-git-branching-model/) 
+
+## Key Benefits
+
+### Parallel Development
+One of the great things about GitFlow is that it makes parallel devleopment very easy, by isolating new development from finished work. New development (such as features and non-emergency bug fixes) is done in feature branches, and is only merged back into development branch after going through extensive unit/regressional testing + review through the pull request.
+
+Another great thing about GitFlow is that if you are asked to switched from one task to another, all you need to do is commit your changes and create a new branch for your new task. When that task is done, just checkout your original feature branch and you can continue where you left off.
+
+### Collaboration
+Feature branches also make it easier for developers to collaborate on the same feature, because each feature branch is essentially a sandbox where you isolate + test the changes that are only necessary to get a new feature working, making it crystal clear to follow what each collaborator is working on. 
+
+### Release Staging Area
+As new development is completed, it gets merged back into the development brach, which is a staging area for all completed features that haven't yet been released. So when the next release is branched off of development, it will automatically contain all of the new tasks that have been finished.
+
+## How it Works
+New development (new features, non-emergency bug fixes) are built in feature branches. These feature branches are branched off of the development branch, and finished features are merged back into the development branch when they're ready to be reviewed & merged.
+
+### Main Branche
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'themeVariables': {
+    'git0': '#2E9AFE',
+    'git1': '#FFBF00'
+},'gitGraph': {'rotateCommitLabel': true, 'showBranches': true, 'showCommitLabel':true}} }%%
+   gitGraph TB:
+      commit id: "Version 1.0"
+      commit id: "Version 1.1"
+      branch Development
+      checkout main
+      checkout Development
+      commit id: "initial commit NG911"
+      commit id: "fixed broken links"
+      checkout main
+      commit id: "Version 1.2"
+      checkout Development
+      commit id: "a"
+```
+### Supporting branches
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'themeVariables': {
+    'git0': '#FFBF00',
+    'git1': '#A4A4A4',
+    'git2': '#A4A4A4'
+},'gitGraph': {'rotateCommitLabel': true, 'showBranches': true, 'showCommitLabel':true}} }%%
+   gitGraph TB:
+      commit id: "initial commit NG911"
+      commit id: "adding comments to function"
+      branch FeatureA
+      commit id: "[ISSUE-412] Name Of Issue" tag:"pull-request"
+      commit id: "commit1"
+      commit id: "commit2:" tag: "GitHub Actions"
+      commit type: HIGHLIGHT id:"Review "
+      checkout main
+      merge FeatureA
+```
+
+### Merging to Master Branch
+Merging to the Master branch is kind of tricky for our workflow. Our master and development branch are parallel, meaning, that our development is technically the master branch. The feature branches that are created and destroyed branch off of the Development branch and once the changes are made it is not quite pushed to the Master branch.
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'themeVariables': {
+    'git0': '#2E9AFE',
+    'git1': '#FFBF00'
+},'gitGraph': {'rotateCommitLabel': true, 'showBranches': true, 'showCommitLabel':true}} }%%
+   gitGraph TB:
+      commit id: "Version 1.0"
+      commit id: "Version 1.1"
+      branch Development
+      checkout main
+      checkout Development
+      commit id: "initial commit NG911"
+      commit id: "fixed broken links"
+      checkout main
+      commit id: "Version 1.2"
+      checkout Development
+      commit id: "init commit"
+      checkout main
+      cherry-pick id: "fixed broken links"
+```

--- a/docs/Developer/GitFlowDiagram.md
+++ b/docs/Developer/GitFlowDiagram.md
@@ -32,31 +32,9 @@ Our development branch is considered to be the main branch, where features are b
 ### Merging to Master Branch
 The master and development branches exist parallel to one another. We consider the development branch to be the main branch where the source code always reflects a state with the latest delivered development changes. Once the development branch is ready to merge back to the master, we create a release branch (not supported in our document). Our version can either cherry-pick the developments we want into the master or revert the changes and merge to the master and re-revert the changes (not supported in the document). 
 
-<<<<<<< HEAD
-```mermaid
-%%{init: { 'logLevel': 'debug', 'theme': 'base', 'themeVariables': {
-    'git0': '#2E9AFE',
-    'git1': '#FFBF00'
-},'gitGraph': {'rotateCommitLabel': true, 'showBranches': true, 'showCommitLabel':true}} }%%
-   gitGraph TB:
-      commit id: "Version 1.0"
-      commit id: "Version 1.1"
-      branch Development
-      checkout main
-      checkout Development
-      commit id: "initial commit NG911"
-      commit id: "fixed broken links"
-      checkout main
-      commit id: "Version 1.2"
-      checkout Development
-      commit id: "init commit"
-      checkout main
-      cherry-pick id: "fixed broken links"
-```
+[![](https://mermaid.ink/img/pako:eNqNVNFumzAU_RXLU8QLjQIhAfyWrEkaKe2kpevDxh4cuCFWACNj2tGIf58xZSNr1xTEg8-99_ici69POOQRYIIHgxPLmCTohIyExxt4hMQgyIhgV8aGiQx5gBQaZEcL-AM8UMHoLoFCRU5BhtRjxEyOmsRP9sKfLReG-Re3NL5czpejUR-3NT5zmrePj_-DO308yGoVauCVoPmhUWIILqmEzzxNmdzQnfYiRQlKd3HgT3NBs_CgVffQs_Q9TQowjZSyrM2-o63_W1pIEEZdo3owCLJuW3Q_J1pgqFkQiwgK8AOIgvEMWUMrwDq802Toumkwz1PIZFt1gPDIS_k60KdrfhGjSQferXzrH94lUFkKmL2u_bHebr8trhzL_okaL-jLHq2LooQXgrPkFEQMSACNqgAjWeVA0M16dbNR3z2SNCYB_gqPDJ666g_p14RIcsWcgDpHb2qfv0_YSut89vVGaN-5vySqC5xv2Up9yy3q7KJL1Gfy5h-U0Z6pnoguLER1lbPw-H7_LjQfm01_1EmO1KDrKQ2wnt4AN6QRFceGqFZ5tJR8W2UhJnoucJlHao6uGY0FTfHLUGCImOTitr059AVi4pxm3zlPu0K1xOSEf2EynQxdb2pPHNf3PGti-yauMBk7Q8udup5l-QqaeHZt4mddPxr6jj9yXcd2x55rj91J_Rvb4n0O?type=png)](https://mermaid.live/edit#pako:eNqNVNFumzAU_RXLU8QLjQIhAfyWrEkaKe2kpevDxh4cuCFWACNj2tGIf58xZSNr1xTEg8-99_ici69POOQRYIIHgxPLmCTohIyExxt4hMQgyIhgV8aGiQx5gBQaZEcL-AM8UMHoLoFCRU5BhtRjxEyOmsRP9sKfLReG-Re3NL5czpejUR-3NT5zmrePj_-DO308yGoVauCVoPmhUWIILqmEzzxNmdzQnfYiRQlKd3HgT3NBs_CgVffQs_Q9TQowjZSyrM2-o63_W1pIEEZdo3owCLJuW3Q_J1pgqFkQiwgK8AOIgvEMWUMrwDq802Toumkwz1PIZFt1gPDIS_k60KdrfhGjSQferXzrH94lUFkKmL2u_bHebr8trhzL_okaL-jLHq2LooQXgrPkFEQMSACNqgAjWeVA0M16dbNR3z2SNCYB_gqPDJ666g_p14RIcsWcgDpHb2qfv0_YSut89vVGaN-5vySqC5xv2Up9yy3q7KJL1Gfy5h-U0Z6pnoguLER1lbPw-H7_LjQfm01_1EmO1KDrKQ2wnt4AN6QRFceGqFZ5tJR8W2UhJnoucJlHao6uGY0FTfHLUGCImOTitr059AVi4pxm3zlPu0K1xOSEf2EynQxdb2pPHNf3PGti-yauMBk7Q8udup5l-QqaeHZt4mddPxr6jj9yXcd2x55rj91J_Rvb4n0O)
+
 ---------
 [<< Go back to the Graphitti home page](../index.md)
 
 [<< Go back to the CONTRIBUTING.md](../../CONTRIBUTING.md)
-=======
-[![](https://mermaid.ink/img/pako:eNqNVNFumzAU_RXLU8QLjQIhAfyWrEkaKe2kpevDxh4cuCFWACNj2tGIf58xZSNr1xTEg8-99_ici69POOQRYIIHgxPLmCTohIyExxt4hMQgyIhgV8aGiQx5gBQaZEcL-AM8UMHoLoFCRU5BhtRjxEyOmsRP9sKfLReG-Re3NL5czpejUR-3NT5zmrePj_-DO308yGoVauCVoPmhUWIILqmEzzxNmdzQnfYiRQlKd3HgT3NBs_CgVffQs_Q9TQowjZSyrM2-o63_W1pIEEZdo3owCLJuW3Q_J1pgqFkQiwgK8AOIgvEMWUMrwDq802Toumkwz1PIZFt1gPDIS_k60KdrfhGjSQferXzrH94lUFkKmL2u_bHebr8trhzL_okaL-jLHq2LooQXgrPkFEQMSACNqgAjWeVA0M16dbNR3z2SNCYB_gqPDJ666g_p14RIcsWcgDpHb2qfv0_YSut89vVGaN-5vySqC5xv2Up9yy3q7KJL1Gfy5h-U0Z6pnoguLER1lbPw-H7_LjQfm01_1EmO1KDrKQ2wnt4AN6QRFceGqFZ5tJR8W2UhJnoucJlHao6uGY0FTfHLUGCImOTitr059AVi4pxm3zlPu0K1xOSEf2EynQxdb2pPHNf3PGti-yauMBk7Q8udup5l-QqaeHZt4mddPxr6jj9yXcd2x55rj91J_Rvb4n0O?type=png)](https://mermaid.live/edit#pako:eNqNVNFumzAU_RXLU8QLjQIhAfyWrEkaKe2kpevDxh4cuCFWACNj2tGIf58xZSNr1xTEg8-99_ici69POOQRYIIHgxPLmCTohIyExxt4hMQgyIhgV8aGiQx5gBQaZEcL-AM8UMHoLoFCRU5BhtRjxEyOmsRP9sKfLReG-Re3NL5czpejUR-3NT5zmrePj_-DO308yGoVauCVoPmhUWIILqmEzzxNmdzQnfYiRQlKd3HgT3NBs_CgVffQs_Q9TQowjZSyrM2-o63_W1pIEEZdo3owCLJuW3Q_J1pgqFkQiwgK8AOIgvEMWUMrwDq802Toumkwz1PIZFt1gPDIS_k60KdrfhGjSQferXzrH94lUFkKmL2u_bHebr8trhzL_okaL-jLHq2LooQXgrPkFEQMSACNqgAjWeVA0M16dbNR3z2SNCYB_gqPDJ666g_p14RIcsWcgDpHb2qfv0_YSut89vVGaN-5vySqC5xv2Up9yy3q7KJL1Gfy5h-U0Z6pnoguLER1lbPw-H7_LjQfm01_1EmO1KDrKQ2wnt4AN6QRFceGqFZ5tJR8W2UhJnoucJlHao6uGY0FTfHLUGCImOTitr059AVi4pxm3zlPu0K1xOSEf2EynQxdb2pPHNf3PGti-yauMBk7Q8udup5l-QqaeHZt4mddPxr6jj9yXcd2x55rj91J_Rvb4n0O)
->>>>>>> 34b9d9c59f50adbae5192b907d419e02d9b4f510

--- a/docs/Developer/index.md
+++ b/docs/Developer/index.md
@@ -8,11 +8,13 @@ Reading code that isn't obvious? When you figure out how it works, then *documen
 
 ## Student Quick Start
 
-Students, use this [Quickstart guide](StudentSetup.md) to help setup, use, and develop with Graphitti.
+Students, use this [quickstart guide](StudentSetup.md) to help setup, use, and develop with Graphitti.
 
-## Coding Conventions
+## Software Development Process
 
-Please adhere to our [coding conventions](codingConventions.md). Your pull requests will not be approved if you don't.
+- To further understand our development process, please check out our [gitflow documentation](GitFlowDiagram.md).
+
+- Your pull requests will not be approved if you do not adhere to our [coding conventions](codingConventions.md).
 
 ## Graphitti Repository Tools and Workflows
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,17 +18,19 @@
    
    2.1 [Student Quick Start](Developer/StudentSetup.md)
    
-   2.2 [Code Formatting Etiquettes](Developer/codingConventions.md)
+   2.2 [GitFlow Documentation](Developer/GitFlowDiagram.md)
 
-   2.3 [C++ design and Coding standards](Developer/cppStyleGuide.md)
+   2.3 [Code Formatting Etiquettes](Developer/codingConventions.md)
 
-   2.4 [Graphitti Repository Tools and Workflows](Developer/index.md) 
+   2.4 [C++ design and Coding standards](Developer/cppStyleGuide.md)
 
-   2.5 [Graphitti System Documentation](Developer/index.md)
+   2.5 [Graphitti Repository Tools and Workflows](Developer/index.md) 
+
+   2.6 [Graphitti System Documentation](Developer/index.md)
   
-   2.6 [Unit Tests](Developer/UnitTests.md)
+   2.7 [Unit Tests](Developer/UnitTests.md)
 
-3. [Testing](Testing/index.md)
+4. [Testing](Testing/index.md)
 
    3.1 Array Performance Testing
 
@@ -36,7 +38,7 @@
 
    3.3 Test Config Files
 
-4. Notes
+5. Notes
 
    4.1 [General Notes](RebuildNotes/GeneralNotes.md)
 
@@ -50,7 +52,7 @@
 
    4.6 [Recorder Notes](RebuildNotes/RecordersNotes.md)
 
-5. [Glossary](Glossary.md)
+6. [Glossary](Glossary.md)
 
    5.1 Graph Vocabulary
 


### PR DESCRIPTION
closes #473 

- Added gitflowdiagram.md file under docs/Developer
- Updated CONTRIBUTING.md to support new file (gitflowdiagram.md)
- Updated CONTRIBUTING.md's broken links and numbering (pull requests, github issues, duplicate steps #s)
- Updated index.md in docs/Developer to support new file (gitflowdiagram.md)
- Updated index.md docs to support new file (gitflowdiagram.md)
