### PR TITLE
[ISSUE-459] Change vector of bool to vector of unsigned char

### DIFF
--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -254,7 +254,7 @@ void ConnGrowth::updateSynapsesWeights()
          BGSIZE synapse_adjusted = 0;
          BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * destVertex;
          for (BGSIZE synapseIndex = 0; synapse_adjusted < synapseCounts; synapseIndex++, iEdg++) {
-            if (synapses.inUse_[iEdg] == 1) {
+            if (synapses.inUse_[iEdg]) {
                // if there is a synapse between a and b
                if (synapses.sourceVertexIndex_[iEdg] == srcVertex) {
                   connected = true;

--- a/Simulator/Connections/Neuro/ConnGrowth.cpp
+++ b/Simulator/Connections/Neuro/ConnGrowth.cpp
@@ -254,7 +254,7 @@ void ConnGrowth::updateSynapsesWeights()
          BGSIZE synapse_adjusted = 0;
          BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * destVertex;
          for (BGSIZE synapseIndex = 0; synapse_adjusted < synapseCounts; synapseIndex++, iEdg++) {
-            if (synapses.inUse_[iEdg] == true) {
+            if (synapses.inUse_[iEdg] == 1) {
                // if there is a synapse between a and b
                if (synapses.sourceVertexIndex_[iEdg] == srcVertex) {
                   connected = true;

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -77,7 +77,7 @@ void AllEdges::setupEdges(int numVertices, int maxEdges)
    if (maxTotalEdges != 0) {
       W_.assign(maxTotalEdges, 0);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
-      inUse_.assign(maxTotalEdges, 0);
+      inUse_.assign(maxTotalEdges, false);
       edgeCounts_.assign(numVertices, 0);
       destVertexIndex_.assign(maxTotalEdges, 0);
       sourceVertexIndex_.assign(maxTotalEdges, 0);
@@ -101,9 +101,7 @@ void AllEdges::readEdge(istream &input, BGSIZE iEdg)
    input.ignore();
    input >> synapse_type;
    input.ignore();
-   bool inUseValue = false;
-   input >> inUseValue;
-   inUse_[iEdg] = (inUseValue ? 1 : 0);
+   input >> inUse_[iEdg];
    input.ignore();
 
    type_[iEdg] = edgeOrdinalToType(synapse_type);
@@ -241,7 +239,7 @@ void AllEdges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap)
 void AllEdges::eraseEdge(int iVert, BGSIZE iEdg)
 {
    edgeCounts_[iVert]--;
-   inUse_[iEdg] = 0;   // True:1, False:0
+   inUse_[iEdg] = false;   // True:1, False:0
    W_[iEdg] = 0;
 }
 

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -77,12 +77,10 @@ void AllEdges::setupEdges(int numVertices, int maxEdges)
    if (maxTotalEdges != 0) {
       W_.assign(maxTotalEdges, 0);
       type_.assign(maxTotalEdges, ETYPE_UNDEF);
+      inUse_.assign(maxTotalEdges, 0);
       edgeCounts_.assign(numVertices, 0);
       destVertexIndex_.assign(maxTotalEdges, 0);
       sourceVertexIndex_.assign(maxTotalEdges, 0);
-
-      inUse_ = make_unique<bool[]>(maxTotalEdges);
-      fill_n(inUse_.get(), maxTotalEdges, false);
    }
 }
 
@@ -103,7 +101,9 @@ void AllEdges::readEdge(istream &input, BGSIZE iEdg)
    input.ignore();
    input >> synapse_type;
    input.ignore();
-   input >> inUse_[iEdg];
+   bool inUseValue = false;
+   input >> inUseValue;
+   inUse_[iEdg] = (inUseValue ? 1 : 0);
    input.ignore();
 
    type_[iEdg] = edgeOrdinalToType(synapse_type);
@@ -119,7 +119,7 @@ void AllEdges::writeEdge(ostream &output, BGSIZE iEdg) const
    output << destVertexIndex_[iEdg] << ends;
    output << W_[iEdg] << ends;
    output << type_[iEdg] << ends;
-   output << inUse_[iEdg] << ends;
+   output << (inUse_[iEdg] == 1 ? "true" : "false") << ends;
 }
 
 ///  Returns an appropriate edgeType object for the given integer.
@@ -241,7 +241,7 @@ void AllEdges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap)
 void AllEdges::eraseEdge(int iVert, BGSIZE iEdg)
 {
    edgeCounts_[iVert]--;
-   inUse_[iEdg] = false;
+   inUse_[iEdg] = 0;   // True:1, False:0
    W_[iEdg] = 0;
 }
 

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -206,8 +206,10 @@ public:
    ///   Synapse type
    vector<edgeType> type_;
 
-   ///  The boolean value indicating the entry in the array is in use.
-   unique_ptr<bool[]> inUse_;
+   ///  The value indicating the entry in the array is in use.
+   // The representation of inUse has been updated from bool to unsigned char
+   // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
+   vector<unsigned char> inUse_;
 
    ///  The number of (incoming) edges for each vertex.
    ///  Note: Likely under a different name in GpuSim_struct, see edge_count. -Aaron

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -34,7 +34,7 @@ void All911Edges::setupEdges()
 void All911Edges::createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT deltaT,
                              edgeType type)
 {
-   inUse_[iEdg] = 1;   // True : 1 , False : 0
+   inUse_[iEdg] = true;   // True : 1 , False : 0
    destVertexIndex_[iEdg] = destVertex;
    sourceVertexIndex_[iEdg] = srcVertex;
    W_[iEdg] = 10;   // Figure this out

--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -34,7 +34,7 @@ void All911Edges::setupEdges()
 void All911Edges::createEdge(BGSIZE iEdg, int srcVertex, int destVertex, BGFLOAT deltaT,
                              edgeType type)
 {
-   inUse_[iEdg] = true;
+   inUse_[iEdg] = 1;   // True : 1 , False : 0
    destVertexIndex_[iEdg] = destVertex;
    sourceVertexIndex_[iEdg] = srcVertex;
    W_[iEdg] = 10;   // Figure this out

--- a/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
@@ -232,10 +232,12 @@ void AllDSSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
 
       edgeType *typePrint = new edgeType[size];
       BGFLOAT *psrPrint = new BGFLOAT[size];
-      bool *inUsePrint = new bool[size];
+      // The representation of inUse has been updated from bool to unsigned char
+      // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
+      unsigned char *inUsePrint = new unsigned char[size];
 
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = false;
+         inUsePrint[i] = 0;
       }
 
       for (int i = 0; i < countVertices_; i++) {
@@ -277,7 +279,7 @@ void AllDSSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
                               cudaMemcpyDeviceToHost));
       HANDLE_ERROR(cudaMemcpy(psrPrint, allSynapsesProps.psr_, size * sizeof(BGFLOAT),
                               cudaMemcpyDeviceToHost));
-      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(bool),
+      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(unsigned char),
                               cudaMemcpyDeviceToHost));
 
 
@@ -310,7 +312,7 @@ void AllDSSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
             cout << " GPU desNeuron: " << destNeuronIndexPrint[i];
             cout << " GPU type: " << typePrint[i];
             cout << " GPU psr: " << psrPrint[i];
-            cout << " GPU in_use:" << inUsePrint[i];
+            cout << " GPU in_use:" << (inUsePrint[i] == 1 ? "true" : "false");
 
             cout << " GPU decay: " << decayPrint[i];
             cout << " GPU tau: " << tauPrint[i];

--- a/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
@@ -237,7 +237,7 @@ void AllDSSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
       unsigned char *inUsePrint = new unsigned char[size];
 
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = 0;
+         inUsePrint[i] = false;
       }
 
       for (int i = 0; i < countVertices_; i++) {

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
@@ -236,10 +236,12 @@ void AllDynamicSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
 
       edgeType *typePrint = new edgeType[size];
       BGFLOAT *psrPrint = new BGFLOAT[size];
-      bool *inUsePrint = new bool[size];
+      // The representation of inUsePrint has been updated from bool to unsigned char
+      // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
+      unsigned char *inUsePrint = new unsigned char[size];
 
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = false;
+         inUsePrint[i] = 0;
       }
 
       for (int i = 0; i < countVertices_; i++) {
@@ -294,7 +296,7 @@ void AllDynamicSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
                               cudaMemcpyDeviceToHost));
       HANDLE_ERROR(cudaMemcpy(psrPrint, allSynapsesProps.psr_, size * sizeof(BGFLOAT),
                               cudaMemcpyDeviceToHost));
-      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(bool),
+      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(unsigned char),
                               cudaMemcpyDeviceToHost));
 
       HANDLE_ERROR(cudaMemcpy(decayPrint, allSynapsesProps.decay_, size * sizeof(BGFLOAT),
@@ -349,7 +351,7 @@ void AllDynamicSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
             cout << " GPU desNeuron: " << destNeuronIndexPrint[i];
             cout << " GPU type: " << typePrint[i];
             cout << " GPU psr: " << psrPrint[i];
-            cout << " GPU in_use:" << inUsePrint[i];
+            cout << " GPU in_use:" << (inUsePrint[i] == 1 ? "true" : "false");
 
             cout << " GPU decay: " << decayPrint[i];
             cout << " GPU tau: " << tauPrint[i];

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
@@ -241,7 +241,7 @@ void AllDynamicSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
       unsigned char *inUsePrint = new unsigned char[size];
 
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = 0;
+         inUsePrint[i] = false;
       }
 
       for (int i = 0; i < countVertices_; i++) {

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -56,7 +56,9 @@ void AllNeuroEdges::readEdge(istream &input, BGSIZE iEdg)
    input.ignore();
    input >> synapse_type;
    input.ignore();
-   input >> inUse_[iEdg];
+   bool inUseValue = false;
+   input >> inUseValue;
+   inUse_[iEdg] = (inUseValue ? 1 : 0);
    input.ignore();
 
    type_[iEdg] = edgeOrdinalToType(synapse_type);
@@ -73,7 +75,7 @@ void AllNeuroEdges::writeEdge(ostream &output, BGSIZE iEdg) const
    output << W_[iEdg] << ends;
    output << psr_[iEdg] << ends;
    output << type_[iEdg] << ends;
-   output << inUse_[iEdg] << ends;
+   output << (inUse_[iEdg] == 1 ? "true" : "false") << ends;
 }
 
 ///  Get the sign of the edgeType.
@@ -109,7 +111,7 @@ void AllNeuroEdges::printSynapsesProps() const
          cout << " desNeuron: " << destVertexIndex_[i];
          cout << " type: " << type_[i];
          cout << " psr: " << psr_[i];
-         cout << " in_use:" << inUse_[i];
+         cout << " in_use:" << ((inUse_[i] == 1) ? "true" : "false");
       }
    }
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.cpp
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.cpp
@@ -56,9 +56,7 @@ void AllNeuroEdges::readEdge(istream &input, BGSIZE iEdg)
    input.ignore();
    input >> synapse_type;
    input.ignore();
-   bool inUseValue = false;
-   input >> inUseValue;
-   inUse_[iEdg] = (inUseValue ? 1 : 0);
+   input >> inUse_[iEdg];
    input.ignore();
 
    type_[iEdg] = edgeOrdinalToType(synapse_type);
@@ -111,7 +109,7 @@ void AllNeuroEdges::printSynapsesProps() const
          cout << " desNeuron: " << destVertexIndex_[i];
          cout << " type: " << type_[i];
          cout << " psr: " << psr_[i];
-         cout << " in_use:" << ((inUse_[i] == 1) ? "true" : "false");
+         cout << " in_use:" << (inUse_[i] == 1 ? "true" : "false");
       }
    }
 

--- a/Simulator/Edges/Neuro/AllNeuroEdges.h
+++ b/Simulator/Edges/Neuro/AllNeuroEdges.h
@@ -123,8 +123,10 @@ struct AllEdgesDeviceProperties {
    ///  is going on in the edge.
    BGFLOAT *psr_;
 
-   ///  The boolean value indicating the entry in the array is in use.
-   bool *inUse_;
+   ///  The value indicating the entry in the array is in use.
+   // The representation of inUse has been updated from bool to unsigned char
+   // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
+   unsigned char *inUse_;
 
    ///  The number of edges for each vertex.
    ///  Note: Likely under a different name in GpuSim_struct, see edge_count. -Aaron

--- a/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
@@ -310,7 +310,7 @@ void AllSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
       // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
       unsigned char *inUsePrint = new unsigned char[size];
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = 0;
+         inUsePrint[i] = false;
       }
       for (int i = 0; i < countVertices_; i++) {
          synapseCountsPrint[i] = 0;

--- a/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
@@ -306,9 +306,11 @@ void AllSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
       BGFLOAT *WPrint = new BGFLOAT[size];
       edgeType *typePrint = new edgeType[size];
       BGFLOAT *psrPrint = new BGFLOAT[size];
-      bool *inUsePrint = new bool[size];
+      // The representation of inUsePrint has been updated from bool to unsigned char
+      // to store 1 (true) or 0 (false) for the support of serialization operations. See ISSUE-459
+      unsigned char *inUsePrint = new unsigned char[size];
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = false;
+         inUsePrint[i] = 0;
       }
       for (int i = 0; i < countVertices_; i++) {
          synapseCountsPrint[i] = 0;
@@ -349,7 +351,7 @@ void AllSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
                               cudaMemcpyDeviceToHost));
       HANDLE_ERROR(cudaMemcpy(psrPrint, allSynapsesProps.psr_, size * sizeof(BGFLOAT),
                               cudaMemcpyDeviceToHost));
-      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(bool),
+      HANDLE_ERROR(cudaMemcpy(inUsePrint, allSynapsesProps.inUse_, size * sizeof(unsigned char),
                               cudaMemcpyDeviceToHost));
 
       HANDLE_ERROR(cudaMemcpy(decayPrint, allSynapsesProps.decay_, size * sizeof(BGFLOAT),
@@ -387,7 +389,7 @@ void AllSTDPSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
             cout << " GPU desNeuron: " << destNeuronIndexPrint[i];
             cout << " GPU type: " << typePrint[i];
             cout << " GPU psr: " << psrPrint[i];
-            cout << " GPU in_use:" << inUsePrint[i];
+            cout << " GPU in_use:" << (inUsePrint[i] == 1 ? "true" : "false");
 
             cout << " GPU decay: " << decayPrint[i];
             cout << " GPU tau: " << tauPrint[i];

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -171,7 +171,7 @@ void AllSpikingSynapses::createEdge(BGSIZE iEdg, int srcVertex, int destVertex, 
 {
    BGFLOAT delay;
 
-   inUse_[iEdg] = 1;   // True: 1, False: 0
+   inUse_[iEdg] = true;   // True: 1, False: 0
    destVertexIndex_[iEdg] = destVertex;
    sourceVertexIndex_[iEdg] = srcVertex;
    W_[iEdg] = edgSign(type) * 10.0e-9;

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -171,7 +171,7 @@ void AllSpikingSynapses::createEdge(BGSIZE iEdg, int srcVertex, int destVertex, 
 {
    BGFLOAT delay;
 
-   inUse_[iEdg] = true;
+   inUse_[iEdg] = 1;   // True: 1, False: 0
    destVertexIndex_[iEdg] = destVertex;
    sourceVertexIndex_[iEdg] = srcVertex;
    W_[iEdg] = edgSign(type) * 10.0e-9;

--- a/Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp
@@ -358,7 +358,7 @@ void AllSpikingSynapses::printGPUEdgesProps(void *allEdgesDeviceProps) const
       unsigned char *inUsePrint = new unsigned char[size];
 
       for (BGSIZE i = 0; i < size; i++) {
-         inUsePrint[i] = 0;
+         inUsePrint[i] = false;
       }
 
       for (int i = 0; i < countVertices_; i++) {

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -100,7 +100,7 @@ CUDA_CALLABLE void createSpikingSynapse(AllSpikingSynapsesDeviceProperties *allE
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = true;
+   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -162,7 +162,7 @@ CUDA_CALLABLE void createDSSynapse(AllDSSynapsesDeviceProperties *allEdgesDevice
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = true;
+   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -247,7 +247,7 @@ CUDA_CALLABLE void createSTDPSynapse(AllSTDPSynapsesDeviceProperties *allEdgesDe
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = true;
+   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -330,7 +330,7 @@ CUDA_CALLABLE void createDynamicSTDPSynapse(AllDynamicSTDPSynapsesDeviceProperti
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = true;
+   allEdgesDevice->inUse_[iEdg] = 1;
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -488,7 +488,7 @@ CUDA_CALLABLE void eraseSpikingSynapse(AllSpikingSynapsesDeviceProperties *allEd
 {
    BGSIZE iSync = maxEdges * neuronIndex + synapseOffset;
    allEdgesDevice->edgeCounts_[neuronIndex]--;
-   allEdgesDevice->inUse_[iSync] = false;
+   allEdgesDevice->inUse_[iSync] = 0;   // True: 1, False: 0
    allEdgesDevice->W_[iSync] = 0;
 }
 

--- a/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+++ b/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
@@ -100,7 +100,7 @@ CUDA_CALLABLE void createSpikingSynapse(AllSpikingSynapsesDeviceProperties *allE
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
+   allEdgesDevice->inUse_[iEdg] = true;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -162,7 +162,7 @@ CUDA_CALLABLE void createDSSynapse(AllDSSynapsesDeviceProperties *allEdgesDevice
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
+   allEdgesDevice->inUse_[iEdg] = true;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -247,7 +247,7 @@ CUDA_CALLABLE void createSTDPSynapse(AllSTDPSynapsesDeviceProperties *allEdgesDe
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = 1;   // True: 1, False: 0
+   allEdgesDevice->inUse_[iEdg] = true;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -330,7 +330,7 @@ CUDA_CALLABLE void createDynamicSTDPSynapse(AllDynamicSTDPSynapsesDeviceProperti
    BGSIZE maxEdges = allEdgesDevice->maxEdgesPerVertex_;
    BGSIZE iEdg = maxEdges * neuronIndex + synapseOffset;
 
-   allEdgesDevice->inUse_[iEdg] = 1;
+   allEdgesDevice->inUse_[iEdg] = true;   // True: 1, False: 0
    allEdgesDevice->destVertexIndex_[iEdg] = destIndex;
    allEdgesDevice->sourceVertexIndex_[iEdg] = sourceIndex;
    allEdgesDevice->W_[iEdg] = edgSign(type) * 10.0e-9;
@@ -488,7 +488,7 @@ CUDA_CALLABLE void eraseSpikingSynapse(AllSpikingSynapsesDeviceProperties *allEd
 {
    BGSIZE iSync = maxEdges * neuronIndex + synapseOffset;
    allEdgesDevice->edgeCounts_[neuronIndex]--;
-   allEdgesDevice->inUse_[iSync] = 0;   // True: 1, False: 0
+   allEdgesDevice->inUse_[iSync] = false;   // True: 1, False: 0
    allEdgesDevice->W_[iSync] = 0;
 }
 
@@ -562,7 +562,7 @@ __global__ void updateSynapsesWeightsDevice(int numVertices, BGFLOAT deltaT, BGF
       for (BGSIZE synapseIndex = 0; (existingSynapsesChecked < existing_synapses) && !connected;
            synapseIndex++) {
          BGSIZE iEdg = maxEdges * destVertex + synapseIndex;
-         if (allEdgesDevice->inUse_[iEdg] == true) {
+         if (allEdgesDevice->inUse_[iEdg]) {
             // if there is a synapse between a and b
             if (allEdgesDevice->sourceVertexIndex_[iEdg] == srcVertex) {
                connected = true;

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -92,7 +92,7 @@ void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap &
          if (spSynapses.allowBackPropagation()) {
             for (int z = 0; synapse_notified < synapseCounts; z++) {
                BGSIZE iEdg = Simulator::getInstance().getMaxEdgesPerVertex() * idx + z;
-               if (spSynapses.inUse_[iEdg] == true) {
+               if (spSynapses.inUse_[iEdg]) {
                   spSynapses.postSpikeHit(iEdg);
                   synapse_notified++;
                }


### PR DESCRIPTION
Closes issue #459

This pull request updates the `inUse` member variable within the `AllEdges` class, shifting from `std::vector<std::unique_ptr<bool>>` to `std::vector<unsigned char>`. The decision to utilize `unsigned char` for storing Boolean values is driven by a focus on significantly enhancing serialization. This enables consistent use of the `serialize` method, thereby streamlining the codebase and eliminating the need for separate `load` and `save` methods in the cereal library.

Opting for `unsigned char` brings about a more memory-efficient solution compared to `int`. Additionally, it distinguishes itself from other member variables that store char.

 - [x] I have tested this change for GPU
