### PR TITLE
Fixed bug in the checking for available space in the queue

### DIFF
--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -73,7 +73,7 @@ void All911Edges::advanceEdges(AllVertices &vertices, EdgeIndexMap &edgeIndexMap
          assert(dst == vertex);
 
          CircularBuffer<Call> &dstQueue = all911Vertices.getQueue(dst);
-         if (dstQueue.size() == (dstQueue.capacity() - all911Vertices.busyServers(dst))) {
+         if (dstQueue.size() >= (dstQueue.capacity() - all911Vertices.busyServers(dst))) {
             // Call is dropped because there is no space in the waiting queue
             if (!isRedial_[edgeIdx]) {
                // Only count the dropped call if it's not a redial


### PR DESCRIPTION
Fixes #577 

This fixes a bug in checking for available space in the queue. When NG911 vertices pull messages from their incoming edges a check is done to ensure that there is space in the queue, this change ensures that the check doesn't fail.