### PR TITLE
[ISSUE 576] Modified the secondary process in the cluster point process script

### DIFF
--- a/Tools/InputGeneration/ClusterPointProcess/cluster_point_process_functions.py
+++ b/Tools/InputGeneration/ClusterPointProcess/cluster_point_process_functions.py
@@ -142,7 +142,7 @@ def secprocess(sp_sigma, duration_mean, duration_min, patience_mean, onsite_mean
             actClust[outliers] = np.random.exponential(scale=sp_sigma, size=len(outliers))
             outliers = np.where(actClust > upper_fence)[0]
         
-        sec_evts_t_tmp = prim_evts[pe_num][0] + actClust.reshape(expected_points_num)
+        sec_evts_t_tmp = prim_evts[pe_num][0] + np.cumsum(actClust.reshape(expected_points_num))
         sec_evts_t = np.append(sec_evts_t, sec_evts_t_tmp)
 
         # We will locate the secondary events within a circle, with the primary event at the center


### PR DESCRIPTION
This PR modifies the time of occurrence of the secondary points of the cluster point process to be their cumulative sum added to the primary event's time of occurrence. Conceptually, an emergency incident starts a homogeneous Poisson process that beggins at that particular time.