### PR TITLE
[ISSUE-594] Update CUDA Standard to 17 for C++17 Features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,8 +290,8 @@ include_directories(Testing/lib/GoogleTest/googletest-master/googletest/include)
 
 # Set CUDA_SEPERABLE_COMPILATION to ON for all libraries that contain .cpp files with device functions compiled as CUDA files
 if(ENABLE_CUDA)
-        set_property(TARGET Edges PROPERTY CUDA_STANDARD 11)
-        set_property(TARGET Vertices PROPERTY CUDA_STANDARD 11)
+        set_property(TARGET Edges PROPERTY CUDA_STANDARD 17)
+        set_property(TARGET Vertices PROPERTY CUDA_STANDARD 17)
         # Enables CUDA code in these libraries to be compiled into separate object files and then linked together
         set_property(TARGET Edges PROPERTY CUDA_SEPARABLE_COMPILATION ON)
         set_property(TARGET Vertices PROPERTY CUDA_SEPARABLE_COMPILATION ON)


### PR DESCRIPTION
Closes #594  

This pull request updates the CUDA_STANDARD in `CMakeLists.txt` from 11 to 17 to leverage C++17 features like `std::variant` for GPU programming.

To ensure correctness, the GPU simulation was run for a set of 12 configurations (ranging from small to large) before and after the update on commit [f6320b2 ](https://github.com/UWB-Biocomputing/Graphitti/commit/f6320b2e1ccd74cf49440adc93c4c5201fec1061) on the master branch. The results show no difference in the output, indicating compatibility with the standard 17.

![cuda 17 test](https://github.com/UWB-Biocomputing/Graphitti/assets/53545471/12418146-417a-45c2-abb3-7c34eeaf5de7)

Additional testing may be planned for configurations `test-large-very-long.xml` and `911` for completeness.

- [x] Tested for GPU configuration files from tiny to long as noted above.