### PR TITLE
[ISSUE-621] Fix compatibility issue with 'registerSpikeHistoryVariables' function

### DIFF
--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -88,12 +88,6 @@ public:
    uint64_t getSpikeHistory(int index, int offIndex);
 
 protected:
-   /// helper for recorder register variables in setupVertices()
-   /// Register spike history variables for all neurons.
-   /// Option 1: Register neuron information in vertexEvents_ one by one.
-   /// Option 2: Register a vector of EventBuffer variables.
-   void registerSpikeHistoryVariables();
-
    ///  Helper for #advanceNeuron. Updates state of a single neuron.
    ///
    ///  @param  index            Index of the neuron to update.
@@ -104,9 +98,9 @@ protected:
    ///  @param  index            Index of the neuron to fire.
    virtual void fire(int index);
 
-#endif   // defined(USE_GPU)
+#endif   // !defined(USE_GPU)
 
-   // TODO change the "public" after regineering Recorder
+   // TODO change the "public" after re-engineering Recorder
 public:
    ///  The booleans which track whether the neuron has fired.
    vector<bool> hasFired_;
@@ -115,9 +109,15 @@ public:
    vector<EventBuffer> vertexEvents_;
 
 protected:
-   ///  True if back propagaion is allowed.
+   ///  True if back propagation is allowed.
    ///  (parameters used for advanceVerticesDevice.)
    bool fAllowBackPropagation_;
+
+   /// helper for recorder register variables in setupVertices()
+   /// Register spike history variables for all neurons.
+   /// Option 1: Register neuron information in vertexEvents_ one by one.
+   /// Option 2: Register a vector of EventBuffer variables.
+   void registerSpikeHistoryVariables();
 };
 
 // TODO: move this into EventBuffer.h. Well, hasFired_ and inherited members have to stay somehow.


### PR DESCRIPTION
Closes #621 

This PR addresses the compatibility issue with the `registerSpikeHistoryVariables` function in `AllSpikingNeurons.h`. The function was previously declared under CPU-specific code, causing compilation errors when accessed from GPU code. To resolve this issue, I've moved the function declaration to both CPU and GPU accessible location.

- [x] Tested for GPU with test-long-connected.xml and test-medium-connected.xml files