### PR TITLE
[ISSUE-606] Remove Additional Slot from Event Buffer 

### DIFF
--- a/Simulator/Vertices/EventBuffer.cpp
+++ b/Simulator/Vertices/EventBuffer.cpp
@@ -13,14 +13,9 @@
 #include <cassert>
 #include <limits>
 
-// EventBuffer::EventBuffer(int maxEvents) :
-//    eventTimeSteps_(maxEvents + 1, numeric_limits<unsigned long>::max())
-// {
-//    clear();
-// }
 EventBuffer::EventBuffer(int maxEvents)
 {
-   eventTimeSteps_.assign(maxEvents + 1, numeric_limits<unsigned long>::max());
+   eventTimeSteps_.assign(maxEvents, numeric_limits<unsigned long>::max());
    clear();
    setDataType();
 }
@@ -56,7 +51,7 @@ void EventBuffer::resize(int maxEvents)
 {
    // Only an empty buffer can be resized
    assert(eventTimeSteps_.empty());
-   eventTimeSteps_.resize(maxEvents + 1, 0);
+   eventTimeSteps_.resize(maxEvents, 0);
    // If we resized, we should clear everything
    clear();
 }
@@ -77,13 +72,14 @@ uint64_t EventBuffer::operator[](int i) const
 void EventBuffer::startNewEpoch()
 {
    epochStart_ = queueEnd_;
+   queueFront_ = queueEnd_;
    numEventsInEpoch_ = 0;
 }
 
 void EventBuffer::insertEvent(uint64_t timeStep)
 {
    // If the buffer is full, then this is an error condition
-   assert(((queueEnd_ + 1) % eventTimeSteps_.size()) != queueFront_);
+   assert((numEventsInEpoch_ < eventTimeSteps_.size()));
 
    // Insert time step and increment the queue end index, mod the buffer size
    eventTimeSteps_[queueEnd_] = timeStep;

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
@@ -57,7 +57,7 @@ void AllSpikingNeurons::copyToDevice(void *deviceAddress)
 
    // All EventBuffers are of the same size,
    // which is one greater than maxSpikes in GPU spikeHistory array.
-   int maxSpikes = vertexEvents_[0].eventTimeSteps_.size() - 1;
+   int maxSpikes = vertexEvents_[0].eventTimeSteps_.size();
    for (int i = 0; i < count; i++) {
       HANDLE_ERROR(cudaMemcpy(pSpikeHistory[i], vertexEvents_[i].eventTimeSteps_.data(),
                               maxSpikes * sizeof(uint64_t), cudaMemcpyHostToDevice));
@@ -114,7 +114,7 @@ void AllSpikingNeurons::copyFromDevice(void *deviceAddress)
 
    // All EventBuffers are of the same size,
    // which is one greater than maxSpikes in GPU spikeHistory array.
-   int maxSpikes = vertexEvents_[0].eventTimeSteps_.size() - 1;
+   int maxSpikes = vertexEvents_[0].eventTimeSteps_.size();
    for (int i = 0; i < numVertices; i++) {
       HANDLE_ERROR(cudaMemcpy(vertexEvents_[i].eventTimeSteps_.data(), pSpikeHistory[i],
                               maxSpikes * sizeof(uint64_t *), cudaMemcpyDeviceToHost));


### PR DESCRIPTION
Closes #606 

This PR addresses a bug related to the event buffer implementation. The issue stemmed from an additional slot in the event buffer, leading to inconsistencies between CPU and GPU implementations. This inconsistency caused unexpected behavior during GPU simulation.

Changes Made:
Removed the additional slot from the event buffer initialization, ensuring consistency between CPU and GPU implementations and enhanced the condition for detecting a full buffer using `numEventsInEpoch_`.
Adjusted the buffer size on the GPU side to match the modified event buffer, ensuring compatibility with the CPU implementation.

- [x] Tested for GPU with 12 configuration files. GPU testing was also conducted on `test-large-very-long.xml` file for both `XmlRecorder` and `Hdf5GrowthRecorder` till epoch 50.