### PR TITLE
[ISSUE-629] Correct two small errors in the XmlRecorder

### DIFF
--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -126,7 +126,7 @@ string XmlRecorder::toXML(const string &name, vector<multipleTypes> &singleBuffe
    for (const multipleTypes &element : singleBuffer_) {
       if (basicType == typeid(uint64_t).name()) {
          os << get<uint64_t>(element) << " ";
-      } else if (basicType == typeid(double).name()) {
+      } else if (basicType == typeid(bool).name()) {
          os << get<bool>(element) << " ";
       } else if (basicType == typeid(int).name()) {
          os << get<int>(element) << " ";

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -166,8 +166,7 @@ protected:
       void captureData()
       {
          if (variableLocation_.getNumElements() > 0) {
-            variableHistory_.reserve(variableHistory_.size() + variableLocation_.getNumElements()
-                                     > 0);
+            variableHistory_.reserve(variableHistory_.size() + variableLocation_.getNumElements());
             for (int index = 0; index < variableLocation_.getNumElements(); index++) {
                variableHistory_.push_back(variableLocation_.getElement(index));
             }


### PR DESCRIPTION
fix #629 

There are two small issues that are addressed in the XmlRecorder class

1. Remove the "> 0" condition.
[Link to the code](https://github.com/UWB-Biocomputing/Graphitti/blob/93197dc18cf8bcf213af8b47293774a2ab28e439/Simulator/Recorders/XmlRecorder.h#L168-L170)
2. Replace "double" with "bool".
[Link to the code](https://github.com/UWB-Biocomputing/Graphitti/blob/93197dc18cf8bcf213af8b47293774a2ab28e439/Simulator/Recorders/XmlRecorder.cpp#L129-L130)