### PR TITLE
Update GraphManager to fix dependency

### DIFF
--- a/Simulator/Utils/GraphManager.cpp
+++ b/Simulator/Utils/GraphManager.cpp
@@ -25,13 +25,12 @@ bool GraphManager::readGraph()
 
    // If graphFilePath_ isn't already defined, get it from ParameterManager
    if (graphFilePath_ == "") {
-
-       // string file_name;
-       string path = "//graphmlFile/text()";
-       if (!ParameterManager::getInstance().getStringByXpath(path, graphFilePath_)) {
-           cerr << "Could not find XML path: " << path << ".\n";
-           return false;
-       };
+      // string file_name;
+      string path = "//graphmlFile/text()";
+      if (!ParameterManager::getInstance().getStringByXpath(path, graphFilePath_)) {
+         cerr << "Could not find XML path: " << path << ".\n";
+         return false;
+      };
    }
 
    graph_file.open(graphFilePath_.c_str());

--- a/Simulator/Utils/GraphManager.cpp
+++ b/Simulator/Utils/GraphManager.cpp
@@ -23,12 +23,16 @@ bool GraphManager::readGraph()
    // Load graphml file into a BGL graph
    ifstream graph_file;
 
-   // string file_name;
-   string path = "//graphmlFile/text()";
-   if (!ParameterManager::getInstance().getStringByXpath(path, graphFilePath_)) {
-      cerr << "Could not find XML path: " << path << ".\n";
-      return false;
-   };
+   // If graphFilePath_ isn't already defined, get it from ParameterManager
+   if (graphFilePath_ == "") {
+
+       // string file_name;
+       string path = "//graphmlFile/text()";
+       if (!ParameterManager::getInstance().getStringByXpath(path, graphFilePath_)) {
+           cerr << "Could not find XML path: " << path << ".\n";
+           return false;
+       };
+   }
 
    graph_file.open(graphFilePath_.c_str());
    if (!graph_file.is_open()) {


### PR DESCRIPTION
closes #634 
Removed GraphManager's dependence on ParameterManager in readGraph(). Now ParameterManager is only used when graphFilePath_ has not been defined yet.