### PR TITLE
Implement compileHistories() for UpdatedType:: DYNAMI for Hdf5 Recorder

### DIFF
--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -67,7 +67,7 @@ Model::Model()
 void Model::saveResults()
 {
    if (recorder_ != nullptr) {
-      recorder_->saveSimData(layout_->getVertices());
+      recorder_->saveSimData();
    }
 }
 
@@ -146,7 +146,7 @@ void Model::updateHistory()
       LOG4CPLUS_INFO(fileLogger_, "ERROR: Recorder class is null.");
    }
    if (recorder_ != nullptr) {
-      recorder_->compileHistories(layout_->getVertices());
+      recorder_->compileHistories();
    }
 }
 

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -104,7 +104,7 @@ void Hdf5Recorder::term()
 }
 
 // create the dataset for constant variable and store the data to dataset
-void Hdf5Recorder::saveSimData(const AllVertices &neurons)
+void Hdf5Recorder::saveSimData()
 {
    // Initialize datasets for constant variables
    for (auto &variableInfo : variableTable_) {
@@ -124,9 +124,11 @@ void Hdf5Recorder::saveSimData(const AllVertices &neurons)
 }
 
 // Processes and updates HDF5 datasets for variables marked as DYNAMIC
-void Hdf5Recorder::compileHistories(AllVertices &vertices)
+void Hdf5Recorder::compileHistories()
 {
    // Define the maximum chunk size for datasets to optimize storage and access
+   // This defines the maximum number of elements per chunk
+   // If the dataset size exceeds this value, HDF5 will create multiple chunks to store the data
    const hsize_t max_chunk_size = 1024;
 
    // Iterate over each variableInfo object in the variable table
@@ -178,21 +180,21 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
 
                // Prepare the data buffer and write the new data to the dataset
                if (variableInfo.hdf5Datatype_ == PredType::NATIVE_FLOAT) {
-                  std::vector<float> dataBuffer(variableInfo.variableLocation_.getNumElements());
+                  vector<float> dataBuffer(variableInfo.variableLocation_.getNumElements());
                   for (size_t i = 0; i < variableInfo.variableLocation_.getNumElements(); ++i) {
                      dataBuffer[i] = get<float>(variableInfo.variableLocation_.getElement(i));
                   }
                   variableInfo.hdf5DataSet_.write(dataBuffer.data(), variableInfo.hdf5Datatype_,
                                                   memSpace, fileSpace);
                } else if (variableInfo.hdf5Datatype_ == PredType::NATIVE_INT) {
-                  std::vector<int> dataBuffer(variableInfo.variableLocation_.getNumElements());
+                  vector<int> dataBuffer(variableInfo.variableLocation_.getNumElements());
                   for (size_t i = 0; i < variableInfo.variableLocation_.getNumElements(); ++i) {
                      dataBuffer[i] = get<int>(variableInfo.variableLocation_.getElement(i));
                   }
                   variableInfo.hdf5DataSet_.write(dataBuffer.data(), variableInfo.hdf5Datatype_,
                                                   memSpace, fileSpace);
                } else if (variableInfo.hdf5Datatype_ == PredType::NATIVE_UINT64) {
-                  std::vector<uint64_t> dataBuffer(variableInfo.variableLocation_.getNumElements());
+                  vector<uint64_t> dataBuffer(variableInfo.variableLocation_.getNumElements());
                   for (size_t i = 0; i < variableInfo.variableLocation_.getNumElements(); ++i) {
                      dataBuffer[i] = get<uint64_t>(variableInfo.variableLocation_.getElement(i));
                   }
@@ -200,7 +202,8 @@ void Hdf5Recorder::compileHistories(AllVertices &vertices)
                                                   memSpace, fileSpace);
                } else {
                   // Throw an exception if the data type is unsupported
-                  throw std::runtime_error("Unsupported data type");
+                  throw runtime_error("Unsupported data type for variable: "
+                                      + variableInfo.variableName_);
                }
             }
          }

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -60,9 +60,7 @@ public:
 
    // TODO: No parameters needed (AllVertices &vertices)
    /// Compile/capture variable history information in every epoch
-   virtual void compileHistories(AllVertices &neurons) override
-   {
-   }
+   virtual void compileHistories(AllVertices &neurons) override;
 
    // TODO: No parameters needed (AllVertices &vertices)
    /// Writes simulation results to an output destination.
@@ -202,29 +200,6 @@ private:
 
    // Member variables for HDF5 datasets
    H5File *resultOut_;
-   /*DataSet dataSetXloc_;
-   DataSet dataSetYloc_;
-   DataSet dataSetNeuronTypes_;
-   DataSet dataSetNeuronThresh_;
-   DataSet dataSetStarterNeurons_;
-   DataSet dataSetTsim_;
-   DataSet dataSetSimulationEndTime_;
-   DataSet dataSetProbedNeurons_;
-   DataSet dataSetSpikesHist_;
-   DataSet dataSetSpikesProbedNeurons_;
-
-   // HDF5 dataset names
-   const H5std_string nameSpikesHist = "spikesHistory";
-   const H5std_string nameXloc = "xloc";
-   const H5std_string nameYloc = "yloc";
-   const H5std_string nameNeuronTypes = "neuronTypes";
-   const H5std_string nameNeuronThresh = "neuronThresh";
-   const H5std_string nameStarterNeurons = "starterNeurons";
-   const H5std_string nameTsim = "Tsim";
-   const H5std_string nameSimulationEndTime = "simulationEndTime";
-   const H5std_string nameSpikesProbedNeurons = "spikesProbedNeurons";
-   const H5std_string nameAttrPNUnit = "attrPNUint";
-   const H5std_string nameProbedNeurons = "probedNeurons";*/
 
    // Keep track of where we are in incrementally writing spikes
    vector<hsize_t> offsetSpikesProbedNeurons_;

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -58,11 +58,11 @@ public:
    /// Terminate process
    virtual void term() override;
 
-   
+
    /// Compile/capture variable history information in every epoch
    virtual void compileHistories() override;
 
-   
+
    /// Writes simulation results to an output destination.
    virtual void saveSimData() override;
 

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -58,13 +58,13 @@ public:
    /// Terminate process
    virtual void term() override;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Compile/capture variable history information in every epoch
-   virtual void compileHistories(AllVertices &neurons) override;
+   virtual void compileHistories() override;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Writes simulation results to an output destination.
-   virtual void saveSimData(const AllVertices &neurons) override;
+   virtual void saveSimData() override;
 
    /// Prints out all parameters to logging file.
    /// Registered to OperationManager as Operation::printParameters

--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -33,14 +33,14 @@ void Xml911Recorder::getValues()
 /// Compile history information in every epoch
 ///
 /// @param[in] vertices   The entire list of vertices.
-void Xml911Recorder::compileHistories(AllVertices &vertices)
+void Xml911Recorder::compileHistories()
 {
 }
 
 /// Writes simulation results to an output destination.
 ///
 /// @param  vertices the Vertex list to search from.
-void Xml911Recorder::saveSimData(const AllVertices &vertices)
+void Xml911Recorder::saveSimData()
 {
    auto &conns = Simulator::getInstance().getModel().getConnections();
    Connections911 &conns911 = dynamic_cast<Connections911 &>(conns);

--- a/Simulator/Recorders/NG911/Xml911Recorder.h
+++ b/Simulator/Recorders/NG911/Xml911Recorder.h
@@ -40,12 +40,12 @@ public:
    /// Compile history information in every epoch
    ///
    /// @param[in] vertices   The entire list of vertices.
-   virtual void compileHistories(AllVertices &vertices) override;
+   virtual void compileHistories() override;
 
    /// Writes simulation results to an output destination.
    ///
    /// @param  vertices the Vertex list to search from.
-   virtual void saveSimData(const AllVertices &vertices) override;
+   virtual void saveSimData() override;
 
    ///  Prints out all parameters to logging file.
    ///  Registered to OperationManager as Operation::printParameters

--- a/Simulator/Recorders/Recorder.h
+++ b/Simulator/Recorders/Recorder.h
@@ -52,13 +52,13 @@ public:
    /// Terminate process
    virtual void term() = 0;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Compile/capture variable history information in every epoch
-   virtual void compileHistories(AllVertices &vertices) = 0;
+   virtual void compileHistories() = 0;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Writes simulation results to an output destination.
-   virtual void saveSimData(const AllVertices &vertices) = 0;
+   virtual void saveSimData() = 0;
 
    /// Prints loaded parameters to logging file.
    virtual void printParameters() = 0;

--- a/Simulator/Recorders/Recorder.h
+++ b/Simulator/Recorders/Recorder.h
@@ -52,11 +52,11 @@ public:
    /// Terminate process
    virtual void term() = 0;
 
-   
+
    /// Compile/capture variable history information in every epoch
    virtual void compileHistories() = 0;
 
-   
+
    /// Writes simulation results to an output destination.
    virtual void saveSimData() = 0;
 

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -73,7 +73,7 @@ void XmlRecorder::term()
 
 // TODO : @param[in] vertices will be removed eventually after HDF5Recorder implementing
 /// Compile history information in every epoch
-void XmlRecorder::compileHistories(AllVertices &vertices)
+void XmlRecorder::compileHistories()
 {
    //capture data information in each epoch
    for (int rowIndex = 0; rowIndex < variableTable_.size(); rowIndex++) {
@@ -86,7 +86,7 @@ void XmlRecorder::compileHistories(AllVertices &vertices)
 
 // TODO : @param[in] vertices will be removed eventually after HDF5Recorder implementing
 /// Writes simulation results to an output destination.
-void XmlRecorder::saveSimData(const AllVertices &vertices)
+void XmlRecorder::saveSimData()
 {
    // Write XML header information:
    string header = "<?xml version=\"1.0\" standalone=\"no\"?>\n";

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -60,13 +60,13 @@ public:
    /// Terminate process
    virtual void term() override;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Compile/capture variable history information in every epoch
-   virtual void compileHistories(AllVertices &vertices) override;
+   virtual void compileHistories() override;
 
-   // TODO: No parameters needed (AllVertices &vertices)
+   
    /// Writes simulation results to an output destination.
-   virtual void saveSimData(const AllVertices &vertices) override;
+   virtual void saveSimData() override;
 
    ///  Prints out all parameters to logging file.
    ///  Registered to OperationManager as Operation::printParameters

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -60,11 +60,11 @@ public:
    /// Terminate process
    virtual void term() override;
 
-   
+
    /// Compile/capture variable history information in every epoch
    virtual void compileHistories() override;
 
-   
+
    /// Writes simulation results to an output destination.
    virtual void saveSimData() override;
 

--- a/Testing/UnitTesting/Hdf5RecorderTests.cpp
+++ b/Testing/UnitTesting/Hdf5RecorderTests.cpp
@@ -86,11 +86,8 @@ TEST(Hdf5RecorderTest, SaveSimDataTest)
    // Register the variable with Hdf5Recorder
    recorder.registerVariable("test_var1", eventBuffer, Recorder::UpdatedType::CONSTANT);
 
-   // Create a unique_ptr to an empty AllVertices object
-   unique_ptr<AllVertices> vertices = 0;
-
    // Call saveSimData() to write the data to the file
-   recorder.saveSimData(*vertices);
+   recorder.saveSimData();
 
    // Open the HDF5 file and read back the data
    H5File file(outputFile, H5F_ACC_RDONLY);
@@ -129,8 +126,6 @@ TEST(Hdf5RecorderTest, CompileHistoriesTest)
    // Register the variable with Hdf5Recorder as DYNAMIC
    recorder.registerVariable("test_var_int", eventBufferInt, Recorder::UpdatedType::DYNAMIC);
 
-   // Create a unique_ptr to an empty AllVertices object
-   unique_ptr<AllVertices> vertices = 0;
 
    // Call compileHistories() multiple times to simulate multiple epochs
    for (int epoch = 0; epoch < 3; ++epoch) {
@@ -142,7 +137,7 @@ TEST(Hdf5RecorderTest, CompileHistoriesTest)
       eventBufferInt.insertEvent(4 * (epoch + 1));
       eventBufferInt.insertEvent(5 * (epoch + 1));
 
-      recorder.compileHistories(*vertices);
+      recorder.compileHistories();
    }
 
    // Open the HDF5 file and read back the data

--- a/Testing/UnitTesting/XmlRecorderTests.cpp
+++ b/Testing/UnitTesting/XmlRecorderTests.cpp
@@ -146,7 +146,7 @@ TEST(XmlRecorderTest, CompileHistoriesTest)
    buffer0.insertEvent(2);
 
    // Call the compileHistories method
-   recorderTest_->compileHistories(*vertices.get());
+   recorderTest_->compileHistories();
    vector<std::variant<uint64_t, bool, int, BGFLOAT>> history = recorderTest_->getHistory(0);
 
    // Verify the events compiled hisotry
@@ -214,9 +214,9 @@ TEST(XmlRecorderTest, SaveSimDataTest)
    buffer.insertEvent(3);
 
    // Call the compileHistories method
-   recorderTest_->compileHistories(*vertices.get());
+   recorderTest_->compileHistories();
    // Call the saveSimData() function
-   recorderTest_->saveSimData(*vertices.get());
+   recorderTest_->saveSimData();
 
    // Open the test_output.xml file and read its content
    std::ifstream inputFile("../Testing/UnitTesting/TestOutput/test_output.xml");


### PR DESCRIPTION
Closes #658 

#### Description
Implement compileHistories() for UpdatedType:: DYNAMIC for Hdf5 Recorder, inside the compileHistories(), in order to allow us to create HDF5 files that hold data that is generated incrementally during the simulation and saved after each simulation epoch, we need to extend the size of the dataset, so I change a way to create a dataset by using chunk, and then using the hyperslab to the extended portion of the dataset, but don't forget to call startNewEpoch at the beginning of each simulation epoch to prepare for recording new events.

