### PR TITLE
[ISSUE-692] Move Spike History Registration Function to AllVertices for Enhanced Flexibility

### DIFF
--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -190,6 +190,9 @@ int Core::runSimulation(string executableName, string cmdLineArguments)
       }
    }
 
+   // Helper function for recorder to register spike history variables for all neurons.
+   simulator.getModel().getLayout().getVertices().registerHistoryVariables();
+
    // Run simulation
    LOG4CPLUS_TRACE(consoleLogger, "Starting Simulation");
    simulator.simulate();

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -80,6 +80,11 @@ public:
    ///  summation points to their Vm and resets the summation points to zero
    vector<BGFLOAT> summationPoints_;
 
+   /// Helper function for recorder to register spike history variables for all neurons.
+   /// Option 1: Register neuron information in vertexEvents_ one by one.
+   /// Option 2: Register a vector of EventBuffer variables.
+   virtual void registerHistoryVariables() = 0;
+
    ///  Cereal serialization method
    template <class Archive> void serialize(Archive &archive, std::uint32_t const version);
 

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -120,6 +120,9 @@ public:
    /// endStep (exclusive)
    virtual void loadEpochInputs(uint64_t currentStep, uint64_t endStep) override;
 
+   /// unused virtual function placeholder
+   virtual void registerHistoryVariables() override {}; 
+
    /// Accessor for the waiting queue of a vertex
    ///
    /// @param vIdx   The index of the vertex

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -121,7 +121,9 @@ public:
    virtual void loadEpochInputs(uint64_t currentStep, uint64_t endStep) override;
 
    /// unused virtual function placeholder
-   virtual void registerHistoryVariables() override {}; 
+   virtual void registerHistoryVariables() override
+   {
+   }
 
    /// Accessor for the waiting queue of a vertex
    ///

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -20,15 +20,12 @@ void AllSpikingNeurons::setupVertices()
 
    hasFired_.assign(size_, false);
    vertexEvents_.assign(size_, maxSpikes);
-
-   // Register spike history variables
-   registerSpikeHistoryVariables();
 }
 
 ///  Register spike history variables for all neurons.
 ///  Option 1: Register neuron information in vertexEvents_ one by one.
 ///  Option 2: Register a vector of EventBuffer variables.
-void AllSpikingNeurons::registerSpikeHistoryVariables()
+void AllSpikingNeurons::registerHistoryVariables()
 {
    Recorder &recorder = Simulator::getInstance().getModel().getRecorder();
    string baseName = "Neuron_";

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -47,6 +47,11 @@ public:
    ///  Clear the spike counts out of all Neurons.
    void clearSpikeCounts();
 
+   /// Helper function for recorder to register spike history variables for all neurons.
+   /// Option 1: Register neuron information in vertexEvents_ one by one.
+   /// Option 2: Register a vector of EventBuffer variables.
+   virtual void registerHistoryVariables() override;
+
    ///  Cereal serialization method
    template <class Archive> void serialize(Archive &archive);
 
@@ -112,12 +117,6 @@ protected:
    ///  True if back propagation is allowed.
    ///  (parameters used for advanceVerticesDevice.)
    bool fAllowBackPropagation_;
-
-   /// helper for recorder register variables in setupVertices()
-   /// Register spike history variables for all neurons.
-   /// Option 1: Register neuron information in vertexEvents_ one by one.
-   /// Option 2: Register a vector of EventBuffer variables.
-   void registerSpikeHistoryVariables();
 };
 
 // TODO: move this into EventBuffer.h. Well, hasFired_ and inherited members have to stay somehow.


### PR DESCRIPTION
<!-- Insert the issue number and appropriate closing keyword. If using another keyword, change the default 'Closes' keyword -->
Closes #692

<!-- Please provide a brief overview of the changes implemented -->
#### Description
This PR refactors the spike history variable registration function, moving it from the `AllSpikingNeurons` class to the `AllVertices` class. Additionally, the function name has been changed from `registerSpikeHistoryVariables` to `registerHistoryVariables` to make it more generic and less Neuron-specific. This change allows the function to be accessible from the Core module, particularly after the deserialization process. 

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Please check the boxes after testing -->
#### Testing (Mandatory for all changes)
- [x] Tested for GPU (test-medium-connected.xml)
- [x] Tested for GPU (test-long-connected.xml)

<!-- 
Please assign the PR to yourself and add the appropriate label. 
Please add the reviewer after all the actions are passed successfully.
Thank you for your contribution!
-->
