### PR TITLE
[ISSUE-720] Remove Unused Functions from Xml911Recorder.cpp

### DIFF
--- a/Simulator/Recorders/NG911/Xml911Recorder.cpp
+++ b/Simulator/Recorders/NG911/Xml911Recorder.cpp
@@ -15,21 +15,6 @@
 #include "Connections911.h"
 // #include "Global.h"
 
-/// Init radii and rates history matrices with default values
-void Xml911Recorder::initDefaultValues()
-{
-}
-
-/// Init radii and rates history matrices with current radii and rates
-void Xml911Recorder::initValues()
-{
-}
-
-/// Get the current radii and rates vlaues
-void Xml911Recorder::getValues()
-{
-}
-
 /// Compile history information in every epoch
 ///
 /// @param[in] vertices   The entire list of vertices.


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #720 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
This pull request addresses an issue caused by merge conflicts in the `Xml911Recorder` class. Removed the definitions of the functions `initDefaultValues()`, `initValues()`, and `getValues()` from `Xml911Recorder.cpp`, which had no corresponding declarations in `Xml911Recorder.h`.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
