### PR TITLE
[ISSUE-753] CMakeLists fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if(ENABLE_CUDA)
         add_compile_definitions(USE_GPU)
 #Specify the CUDA architecture / gencode that will be targeted
         ### Set gencode and architecture variables to the correct values for your specific NVIDIA hardware
-        set(CMAKE_CUDA_ARCHITECTURES 75)        
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode=arch=compute_75,code=sm_75)
+        set(CMAKE_CUDA_ARCHITECTURES 37)        
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode=arch=compute_37,code=sm_37)
             
 else()
         message("\n----Generating Makefile for Graphitti CPU version----")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required(VERSION 3.12)
 #
 #"YES" / GPU choice only available if CUDA library is installed and the GPU is CUDA capable.
 ############################################################################################
+
 if(NOT ENABLE_CUDA)
         set(ENABLE_CUDA NO)
 endif()
@@ -45,8 +46,8 @@ if(ENABLE_CUDA)
         add_compile_definitions(USE_GPU)
 #Specify the CUDA architecture / gencode that will be targeted
         ### Set gencode and architecture variables to the correct values for your specific NVIDIA hardware
-        set(CMAKE_CUDA_ARCHITECTURES 37)        
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode=arch=compute_37,code=sm_37)
+        set(CMAKE_CUDA_ARCHITECTURES 75)        
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode=arch=compute_75,code=sm_75)
             
 else()
         message("\n----Generating Makefile for Graphitti CPU version----")
@@ -161,18 +162,24 @@ include_directories(
        
 if(ENABLE_CUDA)
         
-        set(cuda_sources Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp 
-        Simulator/Vertices/Neuro/AllVerticesDeviceFuncs_d.cpp 
-        Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp 
-        Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp 
-        Simulator/Edges/Neuro/AllDSSynapses_d.cpp 
-        Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp 
-        Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp 
-        Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp 
-        Simulator/Vertices/Neuro/AllIFNeurons_d.cpp 
-        Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp 
+        set(cuda_ConnectionsSources 
         Simulator/Connections/Neuro/ConnGrowth_d.cpp )
-        set_source_files_properties(${cuda_sources} PROPERTIES LANGUAGE CUDA)
+        set_source_files_properties(${cuda_ConnectionsSources} PROPERTIES LANGUAGE CUDA)
+
+        set(cuda_EdgesSources Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp
+        Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp
+        Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
+        Simulator/Edges/Neuro/AllDSSynapses_d.cpp
+        Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp)
+        set_source_files_properties(${cuda_EdgesSources} PROPERTIES LANGUAGE CUDA)
+
+        set(cuda_VerticesSources 
+        Simulator/Vertices/Neuro/AllVerticesDeviceFuncs_d.cpp
+        Simulator/Vertices/Neuro/AllLIFNeurons_d.cpp
+        Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
+        Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
+        Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp)
+        set_source_files_properties(${cuda_VerticesSources} PROPERTIES LANGUAGE CUDA)
 endif()
 
    #Collect source files and create libraries
@@ -184,7 +191,7 @@ endif()
 file(GLOB_RECURSE Connections_Source Simulator/Connections/*.cpp Simulator/Connections/*.h)
 
 if(ENABLE_CUDA)
-        add_library(Connections STATIC ${Connections_Source} ${cuda_sources})
+        add_library(Connections STATIC ${Connections_Source} ${cuda_ConnectionsSources})
 else()
         list(REMOVE_ITEM Connections_Source "${CMAKE_CURRENT_SOURCE_DIR}/Simulator/Connections/Neuro/ConnGrowth_d.cpp")
         add_library(Connections STATIC ${Connections_Source})
@@ -195,7 +202,7 @@ endif()
 file(GLOB_RECURSE Vertices_Source Simulator/Vertices/*.cpp Simulator/Vertices/*.h)
 
 if(ENABLE_CUDA)
-        add_library(Vertices SHARED ${Vertices_Source} ${cuda_sources})
+        add_library(Vertices STATIC ${Vertices_Source} ${cuda_VerticesSources})
 else()
         list(REMOVE_ITEM Vertices_Source "${CMAKE_CURRENT_SOURCE_DIR}/Simulator/Vertices/Neuro/AllVerticesDeviceFuncs.h")
         list(REMOVE_ITEM Vertices_Source "${CMAKE_CURRENT_SOURCE_DIR}/Simulator/Vertices/Neuro/AllVerticesDeviceFuncs_d.cpp")
@@ -212,7 +219,7 @@ endif()
 # Create Edges library
 file(GLOB_RECURSE Edges_Source Simulator/Edges/*.cpp Simulator/Edges/*.h)
 if(ENABLE_CUDA)
-        add_library(Edges SHARED ${Edges_Source} ${cuda_sources})
+        add_library(Edges STATIC ${Edges_Source} ${cuda_EdgesSources})
 else()
         list(REMOVE_ITEM Edges_Source "${CMAKE_CURRENT_SOURCE_DIR}/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs.h")
         list(REMOVE_ITEM Edges_Source "${CMAKE_CURRENT_SOURCE_DIR}/Simulator/Edges/Neuro/AllSynapsesDeviceFuncs_d.cpp")


### PR DESCRIPTION
Closes #753

#### Description
I was unable to run ggraphitti with the old CMakeLists configuration. I was able to compile and link, but when the program loaded there was a seg fault. I investigated and there is an external variable, classSynapses_d, that is defined in AllSynapsesDeviceFuncs_d.cpp. Under the old CMakeLists configuration, this file was included in multiple libraries, two of which were linked together. I am not sure how this works.

I changed the source files for the three libraries, edges, vertices, and connections, to only include the necessary sources for each library.  In addition to this change, I made the libraries static. This solved the problem I had, and now ggraphitti loads and runs correctly. 

#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed