### PR TITLE
[issue-745] Refactor where summation is calculated

### DIFF
--- a/Simulator/Core/CPUModel.cpp
+++ b/Simulator/Core/CPUModel.cpp
@@ -23,9 +23,13 @@ void CPUModel::advance()
 {
    // ToDo: look at pointer v no pointer in params - to change
    // dereferencing the ptr, lose late binding -- look into changing!
-   layout_->getVertices().advanceVertices(connections_->getEdges(),
-                                          connections_->getEdgeIndexMap());
-   connections_->getEdges().advanceEdges(layout_->getVertices(), connections_->getEdgeIndexMap());
+   AllVertices &vertices = layout_->getVertices();
+   AllEdges &edges = connections_->getEdges();
+   EdgeIndexMap &edgeIndexMap = connections_->getEdgeIndexMap();
+
+   vertices.advanceVertices(edges, edgeIndexMap);
+   edges.advanceEdges(vertices, edgeIndexMap);
+   vertices.integrateVertexInputs(edges, edgeIndexMap);
 }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -153,9 +153,8 @@ void GPUModel::advance()
 
    // display running info to console
    // Advance neurons ------------->
-   dynamic_cast<AllSpikingNeurons &>(vertices).advanceVertices(edges,
-                                                              allVerticesDevice_, allEdgesDevice_,
-                                                              randNoise_d, synapseIndexMapDevice_);
+   dynamic_cast<AllSpikingNeurons &>(vertices).advanceVertices(
+      edges, allVerticesDevice_, allEdgesDevice_, randNoise_d, synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_advanceNeurons);
@@ -171,7 +170,8 @@ void GPUModel::advance()
 #endif   // PERFORMANCE_METRICS
 
    // integrate the inputs of the vertices
-   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
+   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(
+      allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_calcSummation);

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -153,7 +153,7 @@ void GPUModel::advance()
 
    // display running info to console
    // Advance neurons ------------->
-   dynamic_cast<AllSpikingNeurons &>(vertices).advanceVertices(
+   vertices.advanceVertices(
       edges, allVerticesDevice_, allEdgesDevice_, randNoise_d, synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
@@ -170,7 +170,7 @@ void GPUModel::advance()
 #endif   // PERFORMANCE_METRICS
 
    // integrate the inputs of the vertices
-   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(
+   vertices.integrateVertexInputs(
       allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
 
 #ifdef PERFORMANCE_METRICS

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -153,8 +153,8 @@ void GPUModel::advance()
 
    // display running info to console
    // Advance neurons ------------->
-   vertices.advanceVertices(
-      edges, allVerticesDevice_, allEdgesDevice_, randNoise_d, synapseIndexMapDevice_);
+   vertices.advanceVertices(edges, allVerticesDevice_, allEdgesDevice_, randNoise_d,
+                            synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_advanceNeurons);
@@ -170,8 +170,7 @@ void GPUModel::advance()
 #endif   // PERFORMANCE_METRICS
 
    // integrate the inputs of the vertices
-   vertices.integrateVertexInputs(
-      allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
+   vertices.integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_calcSummation);

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -140,9 +140,9 @@ void GPUModel::advance()
    cudaStartTimer();
 #endif   // PERFORMANCE_METRICS
 
-   // Get neurons and synapses
-   AllVertices &neurons = layout_->getVertices();
-   AllEdges &synapses = connections_->getEdges();
+   // Get vertices and edges
+   AllVertices &vertices = layout_->getVertices();
+   AllEdges &edges = connections_->getEdges();
 
    normalMTGPU(randNoise_d);
 
@@ -153,7 +153,7 @@ void GPUModel::advance()
 
    // display running info to console
    // Advance neurons ------------->
-   dynamic_cast<AllSpikingNeurons &>(neurons).advanceVertices(connections_->getEdges(),
+   dynamic_cast<AllSpikingNeurons &>(vertices).advanceVertices(edges,
                                                               allVerticesDevice_, allEdgesDevice_,
                                                               randNoise_d, synapseIndexMapDevice_);
 
@@ -163,33 +163,35 @@ void GPUModel::advance()
 #endif   // PERFORMANCE_METRICS
 
    // Advance synapses ------------->
-   synapses.advanceEdges(allEdgesDevice_, allVerticesDevice_, synapseIndexMapDevice_);
+   edges.advanceEdges(allEdgesDevice_, allVerticesDevice_, synapseIndexMapDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_advanceSynapses);
    cudaStartTimer();
 #endif   // PERFORMANCE_METRICS
 
-   // calculate summation point
-   calcSummationPoint();
+   // // calculate summation point
+   // calcSummationPoint();
+   // integrate the inputs of the vertices
+   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_)
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_calcSummation);
 #endif   // PERFORMANCE_METRICS
 }
 
-/// Add psr of all incoming synapses to summation points.
-void GPUModel::calcSummationPoint()
-{
-   // CUDA parameters
-   const int threadsPerBlock = 256;
-   int blocksPerGrid
-      = (Simulator::getInstance().getTotalVertices() + threadsPerBlock - 1) / threadsPerBlock;
+// /// Add psr of all incoming synapses to summation points.
+// void GPUModel::calcSummationPoint()
+// {
+//    // CUDA parameters
+//    const int threadsPerBlock = 256;
+//    int blocksPerGrid
+//       = (Simulator::getInstance().getTotalVertices() + threadsPerBlock - 1) / threadsPerBlock;
 
-   calcSummationPointDevice<<<blocksPerGrid, threadsPerBlock>>>(
-      Simulator::getInstance().getTotalVertices(), allVerticesDevice_, synapseIndexMapDevice_,
-      allEdgesDevice_);
-}
+//    calcSummationPointDevice<<<blocksPerGrid, threadsPerBlock>>>(
+//       Simulator::getInstance().getTotalVertices(), allVerticesDevice_, synapseIndexMapDevice_,
+//       allEdgesDevice_);
+// }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.
 void GPUModel::updateConnections()
@@ -307,57 +309,57 @@ void GPUModel::copySynapseIndexMapHostToDevice(EdgeIndexMap &synapseIndexMapHost
                            cudaMemcpyHostToDevice));
 }
 
-/// Calculate the sum of synaptic input to each neuron.
-///
-/// Calculate the sum of synaptic input to each neuron. One thread
-/// corresponds to one neuron. Iterates sequentially through the
-/// forward synapse index map (synapseIndexMapDevice_) to access only
-/// existing synapses. Using this structure eliminates the need to skip
-/// synapses that have undergone lazy deletion from the main
-/// (allEdgesDevice) synapse structure. The forward map is
-/// re-computed during each network restructure (once per epoch) to
-/// ensure that all synapse pointers for a neuron are stored
-/// contiguously.
-///
-/// @param[in] totalVertices           Number of vertices in the entire simulation.
-/// @param[in,out] allVerticesDevice   Pointer to Neuron structures in device memory.
-/// @param[in] synapseIndexMapDevice_  Pointer to forward map structures in device memory.
-/// @param[in] allEdgesDevice      Pointer to Synapse structures in device memory.
-__global__ void
-   calcSummationPointDevice(int totalVertices,
-                            AllSpikingNeuronsDeviceProperties *__restrict__ allVerticesDevice,
-                            const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
-                            const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice)
-{
-   // The usual thread ID calculation and guard against excess threads
-   // (beyond the number of vertices, in this case).
-   int idx = blockIdx.x * blockDim.x + threadIdx.x;
-   if (idx >= totalVertices)
-      return;
+// /// Calculate the sum of synaptic input to each neuron.
+// ///
+// /// Calculate the sum of synaptic input to each neuron. One thread
+// /// corresponds to one neuron. Iterates sequentially through the
+// /// forward synapse index map (synapseIndexMapDevice_) to access only
+// /// existing synapses. Using this structure eliminates the need to skip
+// /// synapses that have undergone lazy deletion from the main
+// /// (allEdgesDevice) synapse structure. The forward map is
+// /// re-computed during each network restructure (once per epoch) to
+// /// ensure that all synapse pointers for a neuron are stored
+// /// contiguously.
+// ///
+// /// @param[in] totalVertices           Number of vertices in the entire simulation.
+// /// @param[in,out] allVerticesDevice   Pointer to Neuron structures in device memory.
+// /// @param[in] synapseIndexMapDevice_  Pointer to forward map structures in device memory.
+// /// @param[in] allEdgesDevice      Pointer to Synapse structures in device memory.
+// __global__ void
+//    calcSummationPointDevice(int totalVertices,
+//                             AllSpikingNeuronsDeviceProperties *__restrict__ allVerticesDevice,
+//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
+//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice)
+// {
+//    // The usual thread ID calculation and guard against excess threads
+//    // (beyond the number of vertices, in this case).
+//    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+//    if (idx >= totalVertices)
+//       return;
 
-   // Number of incoming synapses
-   const BGSIZE synCount = synapseIndexMapDevice_->incomingEdgeCount_[idx];
-   // Optimization: terminate thread if no incoming synapses
-   if (synCount != 0) {
-      // Index of start of this neuron's block of forward map entries
-      const int beginIndex = synapseIndexMapDevice_->incomingEdgeBegin_[idx];
-      // Address of the start of this neuron's block of forward map entries
-      const BGSIZE *activeMapBegin = &(synapseIndexMapDevice_->incomingEdgeIndexMap_[beginIndex]);
-      // Summed post-synaptic response (PSR)
-      BGFLOAT sum = 0.0;
-      // Index of the current incoming synapse
-      BGSIZE synIndex;
-      // Repeat for each incoming synapse
-      for (BGSIZE i = 0; i < synCount; i++) {
-         // Get index of current incoming synapse
-         synIndex = activeMapBegin[i];
-         // Fetch its PSR and add into sum
-         sum += allEdgesDevice->psr_[synIndex];
-      }
-      // Store summed PSR into this neuron's summation point
-      allVerticesDevice->summationPoints_[idx] = sum;
-   }
-}
+//    // Number of incoming synapses
+//    const BGSIZE synCount = synapseIndexMapDevice_->incomingEdgeCount_[idx];
+//    // Optimization: terminate thread if no incoming synapses
+//    if (synCount != 0) {
+//       // Index of start of this neuron's block of forward map entries
+//       const int beginIndex = synapseIndexMapDevice_->incomingEdgeBegin_[idx];
+//       // Address of the start of this neuron's block of forward map entries
+//       const BGSIZE *activeMapBegin = &(synapseIndexMapDevice_->incomingEdgeIndexMap_[beginIndex]);
+//       // Summed post-synaptic response (PSR)
+//       BGFLOAT sum = 0.0;
+//       // Index of the current incoming synapse
+//       BGSIZE synIndex;
+//       // Repeat for each incoming synapse
+//       for (BGSIZE i = 0; i < synCount; i++) {
+//          // Get index of current incoming synapse
+//          synIndex = activeMapBegin[i];
+//          // Fetch its PSR and add into sum
+//          sum += allEdgesDevice->psr_[synIndex];
+//       }
+//       // Store summed PSR into this neuron's summation point
+//       allVerticesDevice->summationPoints_[idx] = sum;
+//    }
+// }
 
 /// Copy GPU Synapse data to CPU.
 void GPUModel::copyGPUtoCPU()

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -173,7 +173,7 @@ void GPUModel::advance()
    // // calculate summation point
    // calcSummationPoint();
    // integrate the inputs of the vertices
-   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_)
+   dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
 
 #ifdef PERFORMANCE_METRICS
    cudaLapTime(t_gpu_calcSummation);

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -170,8 +170,6 @@ void GPUModel::advance()
    cudaStartTimer();
 #endif   // PERFORMANCE_METRICS
 
-   // // calculate summation point
-   // calcSummationPoint();
    // integrate the inputs of the vertices
    dynamic_cast<AllSpikingNeurons &>(vertices).integrateVertexInputs(allVerticesDevice_, synapseIndexMapDevice_, allEdgesDevice_);
 
@@ -179,19 +177,6 @@ void GPUModel::advance()
    cudaLapTime(t_gpu_calcSummation);
 #endif   // PERFORMANCE_METRICS
 }
-
-// /// Add psr of all incoming synapses to summation points.
-// void GPUModel::calcSummationPoint()
-// {
-//    // CUDA parameters
-//    const int threadsPerBlock = 256;
-//    int blocksPerGrid
-//       = (Simulator::getInstance().getTotalVertices() + threadsPerBlock - 1) / threadsPerBlock;
-
-//    calcSummationPointDevice<<<blocksPerGrid, threadsPerBlock>>>(
-//       Simulator::getInstance().getTotalVertices(), allVerticesDevice_, synapseIndexMapDevice_,
-//       allEdgesDevice_);
-// }
 
 /// Update the connection of all the Neurons and Synapses of the simulation.
 void GPUModel::updateConnections()
@@ -308,58 +293,6 @@ void GPUModel::copySynapseIndexMapHostToDevice(EdgeIndexMap &synapseIndexMapHost
    HANDLE_ERROR(cudaMemcpy(synapseIndexMapDevice_, &synapseIMapDevice, sizeof(EdgeIndexMapDevice),
                            cudaMemcpyHostToDevice));
 }
-
-// /// Calculate the sum of synaptic input to each neuron.
-// ///
-// /// Calculate the sum of synaptic input to each neuron. One thread
-// /// corresponds to one neuron. Iterates sequentially through the
-// /// forward synapse index map (synapseIndexMapDevice_) to access only
-// /// existing synapses. Using this structure eliminates the need to skip
-// /// synapses that have undergone lazy deletion from the main
-// /// (allEdgesDevice) synapse structure. The forward map is
-// /// re-computed during each network restructure (once per epoch) to
-// /// ensure that all synapse pointers for a neuron are stored
-// /// contiguously.
-// ///
-// /// @param[in] totalVertices           Number of vertices in the entire simulation.
-// /// @param[in,out] allVerticesDevice   Pointer to Neuron structures in device memory.
-// /// @param[in] synapseIndexMapDevice_  Pointer to forward map structures in device memory.
-// /// @param[in] allEdgesDevice      Pointer to Synapse structures in device memory.
-// __global__ void
-//    calcSummationPointDevice(int totalVertices,
-//                             AllSpikingNeuronsDeviceProperties *__restrict__ allVerticesDevice,
-//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
-//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice)
-// {
-//    // The usual thread ID calculation and guard against excess threads
-//    // (beyond the number of vertices, in this case).
-//    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-//    if (idx >= totalVertices)
-//       return;
-
-//    // Number of incoming synapses
-//    const BGSIZE synCount = synapseIndexMapDevice_->incomingEdgeCount_[idx];
-//    // Optimization: terminate thread if no incoming synapses
-//    if (synCount != 0) {
-//       // Index of start of this neuron's block of forward map entries
-//       const int beginIndex = synapseIndexMapDevice_->incomingEdgeBegin_[idx];
-//       // Address of the start of this neuron's block of forward map entries
-//       const BGSIZE *activeMapBegin = &(synapseIndexMapDevice_->incomingEdgeIndexMap_[beginIndex]);
-//       // Summed post-synaptic response (PSR)
-//       BGFLOAT sum = 0.0;
-//       // Index of the current incoming synapse
-//       BGSIZE synIndex;
-//       // Repeat for each incoming synapse
-//       for (BGSIZE i = 0; i < synCount; i++) {
-//          // Get index of current incoming synapse
-//          synIndex = activeMapBegin[i];
-//          // Fetch its PSR and add into sum
-//          sum += allEdgesDevice->psr_[synIndex];
-//       }
-//       // Store summed PSR into this neuron's summation point
-//       allVerticesDevice->summationPoints_[idx] = sum;
-//    }
-// }
 
 /// Copy GPU Synapse data to CPU.
 void GPUModel::copyGPUtoCPU()

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -112,9 +112,6 @@ protected:
    /// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
    virtual void deleteDeviceStruct(void **allVerticesDevice, void **allEdgesDevice);
 
-   // /// Add psr of all incoming synapses to summation points.
-   // virtual void calcSummationPoint();
-
    /// Pointer to device random noise array.
    float *randNoise_d;
 
@@ -158,11 +155,4 @@ void normalMTGPU(float *randNoise_d);
 void initMTGPU(unsigned int seed, unsigned int blocks, unsigned int threads, unsigned int nPerRng,
                unsigned int mt_rng_count);
 }
-
-// //! Calculate summation point.
-// extern __global__ void
-//    calcSummationPointDevice(int totalVertices,
-//                             AllSpikingNeuronsDeviceProperties *__restrict__ allNeurnsDevice,
-//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
-//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice);
 #endif

--- a/Simulator/Core/GPUModel.h
+++ b/Simulator/Core/GPUModel.h
@@ -112,8 +112,8 @@ protected:
    /// @param[out] allEdgesDevice         Memory location of the pointer to the synapses list on device memory.
    virtual void deleteDeviceStruct(void **allVerticesDevice, void **allEdgesDevice);
 
-   /// Add psr of all incoming synapses to summation points.
-   virtual void calcSummationPoint();
+   // /// Add psr of all incoming synapses to summation points.
+   // virtual void calcSummationPoint();
 
    /// Pointer to device random noise array.
    float *randNoise_d;
@@ -159,10 +159,10 @@ void initMTGPU(unsigned int seed, unsigned int blocks, unsigned int threads, uns
                unsigned int mt_rng_count);
 }
 
-//! Calculate summation point.
-extern __global__ void
-   calcSummationPointDevice(int totalVertices,
-                            AllSpikingNeuronsDeviceProperties *__restrict__ allNeurnsDevice,
-                            const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
-                            const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice);
+// //! Calculate summation point.
+// extern __global__ void
+//    calcSummationPointDevice(int totalVertices,
+//                             AllSpikingNeuronsDeviceProperties *__restrict__ allNeurnsDevice,
+//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
+//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice);
 #endif

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -279,15 +279,6 @@ void AllSpikingSynapses::advanceEdge(BGSIZE iEdg, AllVertices &neurons)
 
    // decay the post spike response
    psr *= decay;
-   // // and apply it to the summation point
-   // #ifdef USE_OMP
-   //    #pragma omp atomic #endif
-   // #endif
-   // neurons.summationPoints_[sumPointIndex] += psr;
-   // #ifdef USE_OMP
-   //    //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
-   //    //#pragma omp flush (summationPoint)
-   // #endif
 }
 
 ///  Calculate the post synapse response after a spike.

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.cpp
@@ -279,15 +279,15 @@ void AllSpikingSynapses::advanceEdge(BGSIZE iEdg, AllVertices &neurons)
 
    // decay the post spike response
    psr *= decay;
-   // and apply it to the summation point
-   #ifdef USE_OMP
-      #pragma omp atomic #endif
-   #endif
-   neurons.summationPoints_[sumPointIndex] += psr;
-   #ifdef USE_OMP
-      //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
-      //#pragma omp flush (summationPoint)
-   #endif
+   // // and apply it to the summation point
+   // #ifdef USE_OMP
+   //    #pragma omp atomic #endif
+   // #endif
+   // neurons.summationPoints_[sumPointIndex] += psr;
+   // #ifdef USE_OMP
+   //    //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
+   //    //#pragma omp flush (summationPoint)
+   // #endif
 }
 
 ///  Calculate the post synapse response after a spike.

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -135,13 +135,15 @@ public:
    ///
    ///  @param  edges               Reference to the allEdges struct on host memory.
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
-      
+
    /// Performs an integration operation per vertex using the inputs to the vertex.
    ///
    /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
    /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
    /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
-   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice) = 0;
+   virtual void integrateVertexInputs(void *allVerticesDevice,
+                                      EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice)
+      = 0;
 #else   // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Neuron (called by every simulation step).

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -135,6 +135,13 @@ public:
    ///
    ///  @param  edges               Reference to the allEdges struct on host memory.
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) = 0;
+      
+   /// Performs an integration operation per vertex using the inputs to the vertex.
+   ///
+   /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
+   /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
+   /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
+   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice) = 0;
 #else   // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Neuron (called by every simulation step).
@@ -143,6 +150,12 @@ public:
    ///  @param  edges         The Synapse list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
    virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap) = 0;
+
+   /// Performs an integration operation per vertex using the inputs to the vertex.
+   ///
+   ///  @param  edges         The edge list to search from.
+   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+   virtual void integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap) = 0;
 
 #endif   // defined(USE_GPU)
 };

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -160,6 +160,11 @@ int All911Vertices::busyServers(int vIdx) const
 
 #if !defined(USE_GPU)
 
+// Short description of the method.
+void All911Vertices::integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap)
+{
+   //TODO: Figure out where the appropriate logic is and move it here.
+}
 
 // Update internal state of the indexed vertex (called by every simulation step).
 void All911Vertices::advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap)

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -241,6 +241,12 @@ public:
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
    virtual void advanceVertices(AllEdges &edges, const EdgeIndexMap &edgeIndexMap) override;
 
+   /// Performs an integration operation per vertex using the inputs to the vertex.
+   ///
+   ///  @param  edges         The edge list to search from.
+   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+   virtual void integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap);
+
 protected:
 
 #endif   // defined(USE_GPU)

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -254,7 +254,7 @@ public:
    ///
    ///  @param  edges         The edge list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
-   virtual void integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap);
+   virtual void integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap) override;
 
 protected:
 

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -232,13 +232,15 @@ public:
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
                                 float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) {};
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) {};
-   
+
    /// Performs an integration operation per vertex using the inputs to the vertex.
    ///
    /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
    /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
    /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
-   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice) {};
+   virtual void integrateVertexInputs(void *allVerticesDevice,
+                                      EdgeIndexMapDevice *edgeIndexMapDevice,
+                                      void *allEdgesDevice) {};
 #else   // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Vertex (called by every simulation step).

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -232,6 +232,13 @@ public:
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,
                                 float randNoise[], EdgeIndexMapDevice *edgeIndexMapDevice) {};
    virtual void setAdvanceVerticesDeviceParams(AllEdges &edges) {};
+   
+   /// Performs an integration operation per vertex using the inputs to the vertex.
+   ///
+   /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
+   /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
+   /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
+   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice) {};
 #else   // !defined(USE_GPU)
 public:
    ///  Update internal state of the indexed Vertex (called by every simulation step).

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -129,15 +129,15 @@ void AllSpikingNeurons::integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edg
       BGSIZE iEdg = edgeIndexMap.incomingEdgeIndexMap_[i];
       BGFLOAT &psr = synapses.psr_[iEdg];
       int sumPointIndex = synapses.destVertexIndex_[iEdg];
-      // and apply it to the summation point
-      #ifdef USE_OMP
+   // and apply it to the summation point
+   #ifdef USE_OMP
       #pragma omp atomic #endif
-      #endif
+   #endif
       summationPoints_[sumPointIndex] += psr;
-      #ifdef USE_OMP
-      //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
-      //#pragma omp flush (summationPoint)
-      #endif
+   #ifdef USE_OMP
+   //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
+   //#pragma omp flush (summationPoint)
+   #endif
    }
 }
 

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -115,6 +115,32 @@ void AllSpikingNeurons::advanceVertices(AllEdges &synapses, const EdgeIndexMap &
    }
 }
 
+/// Add psr of all incoming synapses to summation points.
+///
+///  @param  edges         The edge list to search from.
+///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+void AllSpikingNeurons::integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap)
+{
+   AllNeuroEdges &synapses = dynamic_cast<AllNeuroEdges &>(edges);
+
+   //totalEdgeCount_ and destVertexIndex_ are properties of AllEdges
+   //Access from synapses instead of edges for readability and consistency with the psr_ access call
+   for (BGSIZE i = 0; i < synapses.totalEdgeCount_; i++) {
+      BGSIZE iEdg = edgeIndexMap.incomingEdgeIndexMap_[i];
+      BGFLOAT &psr = synapses.psr_[iEdg];
+      int sumPointIndex = synapses.destVertexIndex_[iEdg];
+      // and apply it to the summation point
+      #ifdef USE_OMP
+      #pragma omp atomic #endif
+      #endif
+      summationPoints_[sumPointIndex] += psr;
+      #ifdef USE_OMP
+      //PAB: atomic above has implied flush (following statement generates error -- can't be member variable)
+      //#pragma omp flush (summationPoint)
+      #endif
+   }
+}
+
 ///  Fire the selected Neuron and calculate the result.
 ///
 ///  @param  index       Index of the Neuron to update.

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -67,7 +67,8 @@ public:
    /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
    /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
    /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
-   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice);
+   virtual void integrateVertexInputs(void *allVerticesDevice,
+                                      EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice);
 
    ///  Clear the spike counts out of all neurons.
    //

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -151,16 +151,6 @@ struct AllSpikingNeuronsDeviceProperties : public AllVerticesDeviceProperties {
 };
 #endif   // defined(USE_GPU)
 
-// //TODO: It'd be nice to put this inside the #if defined(USE_GPU) if possible
-// #if defined(__CUDACC__)
-// //! Calculate summation point.
-// extern __global__ void
-//    calcSummationPointDevice(int totalVertices,
-//                             AllSpikingNeuronsDeviceProperties *__restrict__ allNeurnsDevice,
-//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
-//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice);
-// #endif
-
 CEREAL_REGISTER_TYPE(AllSpikingNeurons);
 
 ///  Cereal serialization method

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.h
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.h
@@ -62,6 +62,13 @@ public:
    ///  @param  synapses               Reference to the allEdges struct on host memory.
    virtual void setAdvanceVerticesDeviceParams(AllEdges &synapses);
 
+   /// Add psr of all incoming synapses to summation points.
+   ///
+   /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
+   /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
+   /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
+   virtual void integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice);
+
    ///  Clear the spike counts out of all neurons.
    //
    ///  @param  allVerticesDevice   GPU address of the allVertices struct on device memory.
@@ -83,6 +90,12 @@ public:
    ///  @param  synapses         The Synapse list to search from.
    ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
    virtual void advanceVertices(AllEdges &synapses, const EdgeIndexMap &edgeIndexMap);
+
+   /// Add psr of all incoming synapses to summation points.
+   ///
+   ///  @param  edges         The edge list to search from.
+   ///  @param  edgeIndexMap  Reference to the EdgeIndexMap.
+   virtual void integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIndexMap);
 
    /// Get the spike history of neuron[index] at the location offIndex.
    /// More specifically, retrieves the global simulation time step for the spike
@@ -137,6 +150,16 @@ struct AllSpikingNeuronsDeviceProperties : public AllVerticesDeviceProperties {
    int *numElementsInEpoch_;
 };
 #endif   // defined(USE_GPU)
+
+// //TODO: It'd be nice to put this inside the #if defined(USE_GPU) if possible
+// #if defined(__CUDACC__)
+// //! Calculate summation point.
+// extern __global__ void
+//    calcSummationPointDevice(int totalVertices,
+//                             AllSpikingNeuronsDeviceProperties *__restrict__ allNeurnsDevice,
+//                             const EdgeIndexMapDevice *__restrict__ synapseIndexMapDevice_,
+//                             const AllSpikingSynapsesDeviceProperties *__restrict__ allEdgesDevice);
+// #endif
 
 CEREAL_REGISTER_TYPE(AllSpikingNeurons);
 

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
@@ -28,9 +28,9 @@
 /// @param[in] allEdgesDevice      Pointer to Synapse structures in device memory.
 
 __global__ void calcSummationPointDevice(int totalVertices,
-                            AllSpikingNeuronsDeviceProperties *allVerticesDevice,
-                            EdgeIndexMapDevice *edgeIndexMapDevice,
-                            AllSpikingSynapsesDeviceProperties *allEdgesDevice);
+                                         AllSpikingNeuronsDeviceProperties *allVerticesDevice,
+                                         EdgeIndexMapDevice *edgeIndexMapDevice,
+                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice);
 
 void AllSpikingNeurons::copyToDevice(void *deviceAddress)
 {
@@ -181,7 +181,9 @@ void AllSpikingNeurons::setAdvanceVerticesDeviceParams(AllEdges &synapses)
 /// @param allVerticesDevice       GPU address of the allVertices struct on device memory.
 /// @param edgeIndexMapDevice      GPU address of the EdgeIndexMap on device memory.
 /// @param allEdgesDevice          GPU address of the allEdges struct on device memory.
-void AllSpikingNeurons::integrateVertexInputs(void *allVerticesDevice, EdgeIndexMapDevice *edgeIndexMapDevice, void *allEdgesDevice)
+void AllSpikingNeurons::integrateVertexInputs(void *allVerticesDevice,
+                                              EdgeIndexMapDevice *edgeIndexMapDevice,
+                                              void *allEdgesDevice)
 {
    // CUDA parameters
    const int threadsPerBlock = 256;
@@ -190,9 +192,7 @@ void AllSpikingNeurons::integrateVertexInputs(void *allVerticesDevice, EdgeIndex
    int vertex_count = Simulator::getInstance().getTotalVertices();
 
    calcSummationPointDevice<<<blocksPerGrid, threadsPerBlock>>>(
-      vertex_count, 
-      (AllSpikingNeuronsDeviceProperties *)allVerticesDevice, 
-      edgeIndexMapDevice,
+      vertex_count, (AllSpikingNeuronsDeviceProperties *)allVerticesDevice, edgeIndexMapDevice,
       (AllSpikingSynapsesDeviceProperties *)allEdgesDevice);
 }
 
@@ -213,11 +213,10 @@ void AllSpikingNeurons::integrateVertexInputs(void *allVerticesDevice, EdgeIndex
 /// @param[in] edgeIndexMapDevice  Pointer to forward map structures in device memory.
 /// @param[in] allEdgesDevice      Pointer to Synapse structures in device memory.
 
-__global__ void
-   calcSummationPointDevice(int totalVertices,
-                            AllSpikingNeuronsDeviceProperties *allVerticesDevice,
-                            EdgeIndexMapDevice *edgeIndexMapDevice,
-                            AllSpikingSynapsesDeviceProperties *allEdgesDevice)
+__global__ void calcSummationPointDevice(int totalVertices,
+                                         AllSpikingNeuronsDeviceProperties *allVerticesDevice,
+                                         EdgeIndexMapDevice *edgeIndexMapDevice,
+                                         AllSpikingSynapsesDeviceProperties *allEdgesDevice)
 {
    // The usual thread ID calculation and guard against excess threads
    // (beyond the number of vertices, in this case).


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #745 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
The summation point logic was being done in the neuron edges for the CPU model while the GPU model had a calcSummationPoint method that handled the GPU-side summation point logic. The feature branch refactors this by introducing a integrateVertexInputs method to AllVertices for both CPU and GPU. The neuron implementation of AllVertices can then implement the summation point logic in this method. This refactor also allows models types other than neuron (such as 911) to define how they want to integration their vertex inputs since not all model types will use summation point logic.


<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
