### PR TITLE
[ISSUE 805] Fix Segmentation Fault in STDP Simulation After Deserialization of Large GPU-based Growth Simulation

### DIFF
--- a/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons.cpp
@@ -20,15 +20,7 @@ void AllSpikingNeurons::setupVertices()
 
    hasFired_.assign(size_, false);
    vertexEvents_.assign(size_, maxSpikes);
-#if defined(USE_GPU)
-   // We don't allocate memory for summationPoints_ in CPU when building the GPU
-   // implementation. This is to avoid misusing it in GPU code.
-   // summationPoints_ = nullptr;
-
-#else
    summationPoints_.assign(size_, 0);
-
-#endif
 }
 
 ///  Register spike history variables for all neurons.

--- a/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllSpikingNeurons_d.cpp
@@ -84,6 +84,9 @@ void AllSpikingNeurons::copyToDevice(void *deviceAddress)
       HANDLE_ERROR(cudaMemcpy(pSpikeHistory[i], vertexEvents_[i].dataSeries_.data(),
                               maxSpikes * sizeof(uint64_t), cudaMemcpyHostToDevice));
    }
+
+   HANDLE_ERROR(cudaMemcpy(allVerticesDevice.summationPoints_, summationPoints_.data(),
+                           count * sizeof(BGFLOAT), cudaMemcpyHostToDevice));
 }
 void AllSpikingNeurons::copyFromDevice(void *deviceAddress)
 {
@@ -141,6 +144,9 @@ void AllSpikingNeurons::copyFromDevice(void *deviceAddress)
       HANDLE_ERROR(cudaMemcpy(vertexEvents_[i].dataSeries_.data(), pSpikeHistory[i],
                               maxSpikes * sizeof(uint64_t *), cudaMemcpyDeviceToHost));
    }
+
+   HANDLE_ERROR(cudaMemcpy(summationPoints_.data(), allVerticesDevice.summationPoints_,
+                           numVertices * sizeof(BGFLOAT), cudaMemcpyDeviceToHost));
 }
 
 ///  Clear the spike counts out of all neurons in device memory.


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #805 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
This pull request addresses a segmentation fault observed during the STDP simulation after deserializing a large, GPU-based growth simulation. 

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
The simulation was tested using the following commands:

    GPU-based simulation:
    ggraphitti -g 1 -c ../configfiles/tR_1.0--fE_0.90_10000.xml -s Output/Results/tR_1.0--fE_0.90_10000_serialized.xml

    CPU-based simulation:
    cgraphitti -c ../configfiles/stdp_fE_0.90_10000.xml -d ./Output/Results/tR_1.0--fE_0.90_10000_serialized.xml

Both commands were successfully executed without encountering the segmentation fault after the proposed fixes were applied

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
