### PR TITLE
Issue 838 deallocate gpu memory

### DIFF
--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -67,9 +67,9 @@ void GPUModel::deleteDeviceStruct(void **allVerticesDevice, void **allEdgesDevic
    AllEdges &synapses = connections_->getEdges();
 
    // Deallocate device memory
-   neurons.deleteNeuronDeviceStruct(*allVerticesDevice);
+   neurons.deleteNeuronDeviceStruct();
    // Deallocate device memory
-   synapses.deleteEdgeDeviceStruct(*allEdgesDevice);
+   synapses.deleteEdgeDeviceStruct();
    HANDLE_ERROR(cudaFree(randNoise_d));
 }
 
@@ -121,8 +121,7 @@ void GPUModel::finish()
    // copy device synapse and neuron structs to host memory
    copyGPUtoCPU();
    // deallocates memories on CUDA device
-   deleteDeviceStruct((void **)&allVerticesDevice_, (void **)&allEdgesDevice_);
-   deleteSynapseImap();
+   OperationManager::getInstance().executeOperation(Operations::deallocateGPUMemory);
 
 #ifdef PERFORMANCE_METRICS
    cudaEventDestroy(start);
@@ -371,7 +370,7 @@ void GPUModel::copyGPUtoCPU()
 void GPUModel::copyCPUtoGPU()
 {
    // copy host neurons and synapse structs to device memory
-   AllVertices &neuroyns = laout_->getVertices();
+   AllVertices &neurons = layout_->getVertices();
    AllEdges &synapses = connections_->getEdges();
    neurons.copyToDevice();
    synapses.copyEdgeHostToDevice();

--- a/Simulator/Core/GPUModel.cpp
+++ b/Simulator/Core/GPUModel.cpp
@@ -33,9 +33,14 @@ GPUModel::GPUModel() :
                                                      allocateGPU);
    
    // Register copySynapseIndexMapHostToDevice function as a copyCPUtoGPU operation in the OperationManager
-   function<void()> copyCPUtoGPU= bind(&GPUModel::copySynapseIndexMapHostToDevice, this);
+   function<void()> copyCPUtoGPU = bind(&GPUModel::copySynapseIndexMapHostToDevice, this);
    OperationManager::getInstance().registerOperation(Operations::copyToGPU,
                                                       copyCPUtoGPU);
+
+   // Register deleteSynapseImap function as a deallocateGPUMemory operation in the OperationManager
+   function<void()> deallocateGPUMemory = bind(&GPUModel::deleteSynapseImap, this);
+   OperationManager::getInstance().registerOperation(Operations::deallocateGPUMemory,
+                                                      deallocateGPUMemory);
 
    #endif
 }
@@ -366,7 +371,7 @@ void GPUModel::copyGPUtoCPU()
 void GPUModel::copyCPUtoGPU()
 {
    // copy host neurons and synapse structs to device memory
-   AllVertices &neurons = layout_->getVertices();
+   AllVertices &neuroyns = laout_->getVertices();
    AllEdges &synapses = connections_->getEdges();
    neurons.copyToDevice();
    synapses.copyEdgeHostToDevice();

--- a/Simulator/Edges/AllEdges.cpp
+++ b/Simulator/Edges/AllEdges.cpp
@@ -41,6 +41,12 @@ AllEdges::AllEdges() : totalEdgeCount_(0), maxEdgesPerVertex_(0), countVertices_
    function<void()> copyFromGPU= bind(&AllEdges::copyEdgeDeviceToHost, this);
    OperationManager::getInstance().registerOperation(Operations::copyFromGPU,
                                                       copyFromGPU);
+
+   // Register deleteEdgeDeviceStruct function as a deallocateGPUMemory operation in the OperationManager
+   function<void()> deallocateGPUMemory = bind(&AllEdges::deleteEdgeDeviceStruct, this);
+   OperationManager::getInstance().registerOperation(Operations::deallocateGPUMemory,
+                                                      deallocateGPUMemory);
+
    #endif
 
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -107,8 +107,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allEdgesDevice  GPU address of the allEdges struct on device memory.
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) = 0;
+   virtual void deleteEdgeDeviceStruct() = 0;
 
    ///  Copy all edges' data from host to device.   
    virtual void copyEdgeHostToDevice() = 0;

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -68,7 +68,7 @@ public:
    virtual void allocEdgeDeviceStruct() {};
    virtual void allocEdgeDeviceStruct(void **allEdgesDevice, int numVertices,
                                       int maxEdgesPerVertex) {};
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) {};
+   virtual void deleteEdgeDeviceStruct() {};
    virtual void copyEdgeHostToDevice() {};
    virtual void copyEdgeHostToDevice(void *allEdgesDevice, int numVertices,
                                      int maxEdgesPerVertex) {};

--- a/Simulator/Edges/Neuro/AllDSSynapses.h
+++ b/Simulator/Edges/Neuro/AllDSSynapses.h
@@ -134,8 +134,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allEdgesDevice     GPU address of the allEdges struct on device memory.
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) override;
+   virtual void deleteEdgeDeviceStruct() override;
 
    ///  Copy all synapses' data from host to device.
    ///

--- a/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDSSynapses_d.cpp
@@ -66,12 +66,11 @@ void AllDSSynapses::allocDeviceStruct(AllDSSynapsesDeviceProperties &allEdges, i
 
 ///  Delete GPU memories.
 ///
-///  @param  allEdgesDevice  GPU address of the AllDSSynapsesDeviceProperties struct
-///                             on device memory.
-void AllDSSynapses::deleteEdgeDeviceStruct(void *allEdgesDevice)
+void AllDSSynapses::deleteEdgeDeviceStruct()
 {
    AllDSSynapsesDeviceProperties allEdges;
-
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allEdgesDevice = static_cast<void*>(gpuModel->getAllEdgesDevice());
    HANDLE_ERROR(cudaMemcpy(&allEdges, allEdgesDevice, sizeof(AllDSSynapsesDeviceProperties),
                            cudaMemcpyDeviceToHost));
 

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses.h
@@ -137,8 +137,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allEdgesDevice  GPU address of the allEdges struct on device memory.
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) override;
+   virtual void deleteEdgeDeviceStruct() override;
 
    ///  Copy all synapses' data from host to device.
    ///

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
@@ -73,7 +73,8 @@ void AllDynamicSTDPSynapses::allocDeviceStruct(
 void AllDynamicSTDPSynapses::deleteEdgeDeviceStruct(void *allEdgesDevice)
 {
    AllDynamicSTDPSynapsesDeviceProperties allEdges;
-
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allEdgesDevice = static_cast<void*>(gpuModel->getAllEdgesDevice());
    HANDLE_ERROR(cudaMemcpy(&allEdges, allEdgesDevice,
                            sizeof(AllDynamicSTDPSynapsesDeviceProperties), cudaMemcpyDeviceToHost));
 

--- a/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllDynamicSTDPSynapses_d.cpp
@@ -70,7 +70,7 @@ void AllDynamicSTDPSynapses::allocDeviceStruct(
 ///
 ///  @param  allEdgesDevice  GPU address of the AllDynamicSTDPSynapsesDeviceProperties struct
 ///                             on device memory.
-void AllDynamicSTDPSynapses::deleteEdgeDeviceStruct(void *allEdgesDevice)
+void AllDynamicSTDPSynapses::deleteEdgeDeviceStruct()
 {
    AllDynamicSTDPSynapsesDeviceProperties allEdges;
    GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());

--- a/Simulator/Edges/Neuro/AllSTDPSynapses.h
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses.h
@@ -167,8 +167,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allEdgesDevice  GPU address of the allEdges struct on device memory.
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) override;
+   virtual void deleteEdgeDeviceStruct() override;
 
    ///  Copy all synapses' data from host to device.
    virtual void copyEdgeHostToDevice() override;

--- a/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllSTDPSynapses_d.cpp
@@ -92,11 +92,11 @@ void AllSTDPSynapses::allocDeviceStruct(AllSTDPSynapsesDeviceProperties &allEdge
 
 ///  Delete GPU memories.
 ///
-///  @param  allEdgesDevice  GPU address of the AllSTDPSynapsesDeviceProperties struct
-///                             on device memory.
-void AllSTDPSynapses::deleteEdgeDeviceStruct(void *allEdgesDevice)
+void AllSTDPSynapses::deleteEdgeDeviceStruct()
 {
    AllSTDPSynapsesDeviceProperties allEdgesDeviceProps;
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allEdgesDevice = static_cast<void*>(gpuModel->getAllEdgesDevice());
    HANDLE_ERROR(cudaMemcpy(&allEdgesDeviceProps, allEdgesDevice,
                            sizeof(AllSTDPSynapsesDeviceProperties), cudaMemcpyDeviceToHost));
    deleteDeviceStruct(allEdgesDeviceProps);

--- a/Simulator/Edges/Neuro/AllSpikingSynapses.h
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses.h
@@ -135,8 +135,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allEdgesDevice  GPU address of the allEdges struct on device memory.
-   virtual void deleteEdgeDeviceStruct(void *allEdgesDevice) override;
+   virtual void deleteEdgeDeviceStruct() override;
 
    ///  Copy all synapses' data from host to device.
    ///

--- a/Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp
+++ b/Simulator/Edges/Neuro/AllSpikingSynapses_d.cpp
@@ -90,11 +90,11 @@ void AllSpikingSynapses::allocDeviceStruct(AllSpikingSynapsesDeviceProperties &a
 
 ///  Delete GPU memories.
 ///
-///  @param  allEdgesDevice  GPU address of the AllSpikingSynapsesDeviceProperties struct
-///                             on device memory.
-void AllSpikingSynapses::deleteEdgeDeviceStruct(void *allEdgesDevice)
+void AllSpikingSynapses::deleteEdgeDeviceStruct()
 {
    AllSpikingSynapsesDeviceProperties allEdges;
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allEdgesDevice = static_cast<void*>(gpuModel->getAllEdgesDevice());
    HANDLE_ERROR(cudaMemcpy(&allEdges, allEdgesDevice, sizeof(AllSpikingSynapsesDeviceProperties),
                            cudaMemcpyDeviceToHost));
    deleteDeviceStruct(allEdges);

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -37,6 +37,11 @@ AllVertices::AllVertices() : size_(0)
    function<void()> copyFromGPU= bind(&AllVertices::copyFromDevice, this);
    OperationManager::getInstance().registerOperation(Operations::copyFromGPU,
                                                       copyFromGPU);
+
+   // Register deleteNeuronDeviceStruct function as a deallocateGPUMemory operation in the OperationManager
+   function<void()> deallocateGPUMemory = bind(&AllVertices::deleteNeuronDeviceStruct, this);
+   OperationManager::getInstance().registerOperation(Operations::deallocateGPUMemory,
+                                                      deallocateGPUMemory);
    #endif
 
    // Get a copy of the file and vertex logger to use log4cplus macros to print to debug files

--- a/Simulator/Vertices/AllVertices.h
+++ b/Simulator/Vertices/AllVertices.h
@@ -106,8 +106,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allVerticesDevice   GPU address of the allVertices struct on device memory.
-   virtual void deleteNeuronDeviceStruct(void *allVerticesDevice) = 0;
+   virtual void deleteNeuronDeviceStruct() = 0;
 
    ///  Copy all vertices' data from host to device.
    virtual void copyToDevice() = 0;

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -226,7 +226,7 @@ private:
    // These signatures are required to make the class non-abstract
 public:
    virtual void allocNeuronDeviceStruct() {};
-   virtual void deleteNeuronDeviceStruct(void *allVerticesDevice) {};
+   virtual void deleteNeuronDeviceStruct() {};
    virtual void copyToDevice() {};
    virtual void copyFromDevice() {};
    virtual void advanceVertices(AllEdges &edges, void *allVerticesDevice, void *allEdgesDevice,

--- a/Simulator/Vertices/Neuro/AllIFNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIFNeurons.h
@@ -94,8 +94,7 @@ public:
 
    ///  Delete GPU memories.
    ///
-   ///  @param  allVerticesDevice   GPU address of the allNeurons struct on device memory.
-   virtual void deleteNeuronDeviceStruct(void *allVerticesDevice);
+   virtual void deleteNeuronDeviceStruct();
 
    ///  Clear the spike counts out of all neurons.
    //

--- a/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIFNeurons_d.cpp
@@ -70,10 +70,11 @@ void AllIFNeurons::allocDeviceStruct(AllIFNeuronsDeviceProperties &allVerticesDe
 
 ///  Delete GPU memories.
 ///
-///  @param  allVerticesDevice   GPU address of the AllIFNeuronsDeviceProperties struct on device memory.
-void AllIFNeurons::deleteNeuronDeviceStruct(void *allVerticesDevice)
+void AllIFNeurons::deleteNeuronDeviceStruct()
 {
    AllIFNeuronsDeviceProperties allVerticesDeviceProps;
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allVerticesDevice = static_cast<void*>(gpuModel->getAllVerticesDevice());
    HANDLE_ERROR(cudaMemcpy(&allVerticesDeviceProps, allVerticesDevice,
                            sizeof(AllIFNeuronsDeviceProperties), cudaMemcpyDeviceToHost));
    deleteDeviceStruct(allVerticesDeviceProps);

--- a/Simulator/Vertices/Neuro/AllIZHNeurons.h
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons.h
@@ -144,8 +144,7 @@ public:
 
    ///  Delete GPU memories.
    //
-   ///  @param  allVerticesDevice   GPU address of the allNeurons struct on device memory.
-   virtual void deleteNeuronDeviceStruct(void *allVerticesDevice) override;
+   virtual void deleteNeuronDeviceStruct() override;
 
    ///  Copy spike history data stored in device memory to host.
    //

--- a/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
+++ b/Simulator/Vertices/Neuro/AllIZHNeurons_d.cpp
@@ -69,12 +69,11 @@ void AllIZHNeurons::allocDeviceStruct(AllIZHNeuronsDeviceProperties &allVertices
 
 ///  Delete GPU memories.
 ///
-///  @param  allVerticesDevice   GPU address of the AllIZHNeuronsDeviceProperties struct
-///                             on device memory.
-void AllIZHNeurons::deleteNeuronDeviceStruct(void *allVerticesDevice)
+void AllIZHNeurons::deleteNeuronDeviceStruct()
 {
    AllIZHNeuronsDeviceProperties allVerticesDeviceProps;
-
+   GPUModel* gpuModel = static_cast<GPUModel*>(&Simulator::getInstance().getModel());
+   void* allVerticesDevice = static_cast<void*>(gpuModel->getAllVerticesDevice());
    HANDLE_ERROR(cudaMemcpy(&allVerticesDeviceProps, allVerticesDevice,
                            sizeof(AllIZHNeuronsDeviceProperties), cudaMemcpyDeviceToHost));
 


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #issue838

<!-- Please provide a brief overview of the changes implemented -->
#### Description
Refactor all deallocateGPUMemory-related methods to remove parameters, enabling centralized GPU deallocation via OperationManager. This mirrors the existing copyToGPU and copyFromGPU refactors for consistency and streamlined control.

Currently, GPU memory deallocation relies on a chain of responsibility across multiple classes. This change enables centralized control by registering parameterless deallocation functions with the OperationManager.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [x] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
