### PR TITLE
registered registerHistoryVariable to the operationManager now instea…

### DIFF
--- a/Simulator/Core/Core.cpp
+++ b/Simulator/Core/Core.cpp
@@ -191,7 +191,7 @@ int Core::runSimulation(string executableName, string cmdLineArguments)
    }
 
    // Helper function for recorder to register spike history variables for all neurons.
-   simulator.getModel().getLayout().getVertices().registerHistoryVariables();
+   OperationManager::getInstance().executeOperation(Operations::registerHistoryVariables);
 
    // Run simulation
    LOG4CPLUS_TRACE(consoleLogger, "Starting Simulation");

--- a/Simulator/Core/Operations.h
+++ b/Simulator/Core/Operations.h
@@ -23,6 +23,7 @@ public:
       restoreToDefault,   // Not sure what this refers to.
       copyToGPU,
       copyFromGPU,
-      allocateGPU
+      allocateGPU,
+      registerHistoryVariables
    };
 };

--- a/Simulator/Vertices/AllVertices.cpp
+++ b/Simulator/Vertices/AllVertices.cpp
@@ -22,6 +22,11 @@ AllVertices::AllVertices() : size_(0)
    OperationManager::getInstance().registerOperation(Operations::printParameters,
                                                      printParametersFunc);
 
+   // Register registerHistoryVariables function as a registerHistoryVariables operation in the OperationManager
+   function<void()> registerHistory = bind(&AllVertices::registerHistoryVariables, this);
+   OperationManager::getInstance().registerOperation(Operations::registerHistoryVariables,
+                                                      registerHistory);
+
 #if defined(USE_GPU)
    // Register allocNeuronDeviceStruct function as a allocateGPU operation in the OperationManager
    function<void()> allocateGPU = bind(&AllVertices::allocNeuronDeviceStruct, this);


### PR DESCRIPTION
…d of having simulator.getModel().getLayout().getVertices().registerHistoryVariables(); we can just use operationManager to invokeit

<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #

<!-- Please provide a brief overview of the changes implemented -->
#### Description
Will replace explicit class-by-class calls in Core.cpp:
 simulator.getModel().getLayout().getVertices().registerHistoryVariables(); by registering them to the operationManager

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [x] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
