### PR TITLE
DeviceVector GPU Fix

### DIFF
--- a/Simulator/Utils/DeviceVector.h
+++ b/Simulator/Utils/DeviceVector.h
@@ -88,11 +88,8 @@ public:
    /// @param size Initial size of the host vector (defaults to 0)
    /// @post Host vector is created with 'size' default-constructed elements
    /// @post Device pointer is nullptr (no GPU memory allocated)
-   explicit DeviceVector(size_t size = 0) : hostData_(size)
+   explicit DeviceVector(size_t size = 0) : hostData_(size), devicePtr_(nullptr)
    {
-#if defined(__CUDACC__)
-      devicePtr_ = nullptr;
-#endif
    }
 
    ~DeviceVector() = default;
@@ -449,7 +446,9 @@ public:
 private:
    std::vector<T> hostData_;   // Host-side vector
 
-#if defined(__CUDACC__)
+   // Introducing compilation guards (__CUDACC__) for the device pointer
+   // causes a runtime error during GPU simulations.
+   // This is likely because DeviceVector is included in both
+   // host (.cpp) and device (_d.cpp) code, and compiled on both sides.
    T *devicePtr_;   // Device pointer
-#endif
 };


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #855 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
1. Fix DeviceVector GPU fix where devicePtr_ needs to out of conditional compilation guards.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [ ] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
