### PR TITLE
[Issue-894] Stop GitHub actions from running if a test fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,80 +41,60 @@ jobs:
   # simulator runs
     - id: tt
       name: run test-tiny
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-tiny.xml
     - name: verify test-tiny
-      if: always() && steps.tt.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-tiny-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-tiny-out.xml
 
     - id: ts
       name: run test-small
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-small.xml
     - name: verify test-small
-      if: always() && steps.ts.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-small-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-small-out.xml
 
     - id: tsc
       name: run test-small-connected
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-small-connected.xml
     - name: verify test-small-connected
-      if: always() && steps.tsc.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-small-connected-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-small-connected-out.xml
 
     - id: tsl
       name: run test-small-long
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-small-long.xml
     - name: verify test-small-long
-      if: always() && steps.tsl.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-small-long-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-small-long-out.xml
     
     - id: tscl
       name: run test-small-connected-long
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-small-connected-long.xml
     - name: verify test-small-connected-long
-      if: always() && steps.tscl.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-small-connected-long-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-small-connected-long-out.xml
 
     - id: ts911
       name: run test-small-911
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-small-911.xml
     - name: verify test-small-911
-      if: always() && steps.tt.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-small-911-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-small-911-out.xml
 
     - id: tm
       name: run test-medium
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-medium.xml
     - name: verify test-medium
-      if: always() && steps.tm.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-medium-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-medium-out.xml
 
     - id: tmc
       name: run test-medium-connected
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-medium-connected.xml
     - name: verify test-medium-connected
-      if: always() && steps.tmc.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-medium-connected-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-medium-connected-out.xml
 
     - id: tml
       name: run test-medium-long
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-medium-long.xml
     - name: verify test-medium-long
-      if: always() && steps.tml.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-medium-long-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-medium-long-out.xml
 
     - id: tmcl
       name: run test-medium-connected-long
-      if: always() && steps.build.conclusion == 'success'
       run: ./cgraphitti -c ../Testing/RegressionTesting/configfiles/test-medium-connected-long.xml
     - name: verify test-medium-connected-long
-      if: always() && steps.tmcl.conclusion == 'success'
       run: diff ../Testing/RegressionTesting/TestOutput/test-medium-connected-long-out.xml ../Testing/RegressionTesting/GoodOutput/Cpu/test-medium-connected-long-out.xml


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #894 

<!-- Please provide a brief overview of the changes implemented -->
#### Description

Removed if-statements. The if statements mean that GH actions would continue ONLY if tests are successfully built.
Now, GH actions would stop if a test fails to build or run.

Failed build example (with if-statements included): https://github.com/UWB-Biocomputing/Graphitti/actions/runs/21057665633/job/60557015669

<!-- Please check the boxes as applicable -->
<!-- 
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 
-->

<!-- Ensure all boxes are checked before submitting the PR -->
<!-- 
#### Testing (Mandatory for all changes)
- [ ] GPU Test: `test-medium-connected.xml` Passed
- [ ] GPU Test: `test-large-long.xml` Passed
-->
<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
