### PR TITLE
[ISSUE-914] Rename debug command from /debug to /debug-code

### DIFF
--- a/.github/prompts/debug.prompt.md
+++ b/.github/prompts/debug.prompt.md
@@ -1,5 +1,5 @@
 ---
-name: debug
+name: debug-code
 description: Trace and explain the root cause of a bug in the C++17 Graphitti code
 agent: agent
 tools: ["search", "read"]

--- a/docs/Developer/CopilotDebug.md
+++ b/docs/Developer/CopilotDebug.md
@@ -92,7 +92,7 @@ You can then:
 3. Open Copilot Chat and type:
 
 ```text
-/debug The spike count is off by 1 when running large graphs with more than 10,000 vertices.
+/debug-code The spike count is off by 1 when running large graphs with more than 10,000 vertices.
 ```
 
 4. Copilot analyzes the selected code and repository using the debug prompt workflow, then returns a report with an execution trace and a proposed fix.


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #914 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
It seems that sometimes Copilot has a built-in /debug command that causes it to analyze its context window, available models, etc. Sometimes, when running /debug it runs the prompt file, other times, it performs its own internal debugging session. Changing the slash command name from /debug to /debug-code prevents Copilot from having to choose between the two.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [ ] GPU Test: `test-medium-connected.xml` Passed
- [ ] GPU Test: `test-large-long.xml` Passed