### PR TITLE
[ISSUE 378] Move Recorder allocation to setup() and delegate via OperationManager.

### DIFF
--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -16,6 +16,7 @@
 #include "Model.h"
 #include "Connections.h"
 #include "Factory.h"
+#include "OperationManager.h"
 #include "ParameterManager.h"
 #include "Recorder.h"
 #include "Simulator.h"
@@ -101,10 +102,8 @@ void Model::setupSim()
    // Time to initialization (layout)
    t_host_initialization_layout += Simulator::getInstance().getShort_timer().lap() / 1000000.0;
 #endif
-   // Init radii and rates history matrices with default values
-   if (recorder_ != nullptr) {
-      recorder_->init();
-   }
+   LOG4CPLUS_INFO(fileLogger_, "Setting up Recorder...");
+   OperationManager::getInstance().executeOperation(Operations::setup);
 
    // Creates all the vertices and generates data for them.
    createAllVertices();

--- a/Simulator/Core/Model.cpp
+++ b/Simulator/Core/Model.cpp
@@ -16,7 +16,6 @@
 #include "Model.h"
 #include "Connections.h"
 #include "Factory.h"
-#include "OperationManager.h"
 #include "ParameterManager.h"
 #include "Recorder.h"
 #include "Simulator.h"
@@ -103,7 +102,9 @@ void Model::setupSim()
    t_host_initialization_layout += Simulator::getInstance().getShort_timer().lap() / 1000000.0;
 #endif
    LOG4CPLUS_INFO(fileLogger_, "Setting up Recorder...");
-   OperationManager::getInstance().executeOperation(Operations::setup);
+   if (recorder_ != nullptr) {
+      recorder_->setup();
+   }
 
    // Creates all the vertices and generates data for them.
    createAllVertices();

--- a/Simulator/Core/OperationManager.cpp
+++ b/Simulator/Core/OperationManager.cpp
@@ -91,6 +91,8 @@ string OperationManager::operationToString(const Operations &operation) const
          return "printParameters";
       case Operations::loadParameters:
          return "loadParameters";
+      case Operations::setup:
+         return "setup";
       case Operations::serialize:
          return "serialize";
       case Operations::deserialize:

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -26,6 +26,8 @@ Hdf5Recorder::Hdf5Recorder()
    function<void()> printParametersFunc = std::bind(&Hdf5Recorder::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters,
                                                      printParametersFunc);
+   function<void()> setupFunc = std::bind(&Hdf5Recorder::setup, this);
+   OperationManager::getInstance().registerOperation(Operations::setup, setupFunc);
 
    // Initialize the logger for file operations
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
@@ -42,7 +44,7 @@ Hdf5Recorder::~Hdf5Recorder()
 }
 
 // Other member functions implementation...
-void Hdf5Recorder::init()
+void Hdf5Recorder::setup()
 {
    // Check the output file extension is .h5
    string suffix = ".h5";

--- a/Simulator/Recorders/Hdf5Recorder.cpp
+++ b/Simulator/Recorders/Hdf5Recorder.cpp
@@ -26,8 +26,6 @@ Hdf5Recorder::Hdf5Recorder()
    function<void()> printParametersFunc = std::bind(&Hdf5Recorder::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters,
                                                      printParametersFunc);
-   function<void()> setupFunc = std::bind(&Hdf5Recorder::setup, this);
-   OperationManager::getInstance().registerOperation(Operations::setup, setupFunc);
 
    // Initialize the logger for file operations
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -36,8 +36,7 @@ public:
    }
 
    // Other member functions...
-   /// Setup the internal structure of the class (allocate memories and initialize them).
-   /// Registered to OperationManager as Operation::setup
+   /// Setup the internal structure of the class (allocate memory and initialize it).
    virtual void setup() override;
 
    /// Terminate process

--- a/Simulator/Recorders/Hdf5Recorder.h
+++ b/Simulator/Recorders/Hdf5Recorder.h
@@ -36,9 +36,9 @@ public:
    }
 
    // Other member functions...
-   /// Initialize data
-   /// @param[in] stateOutputFileName File name to save histories
-   virtual void init() override;
+   /// Setup the internal structure of the class (allocate memories and initialize them).
+   /// Registered to OperationManager as Operation::setup
+   virtual void setup() override;
 
    /// Terminate process
    virtual void term() override;

--- a/Simulator/Recorders/Recorder.h
+++ b/Simulator/Recorders/Recorder.h
@@ -33,9 +33,8 @@ public:
    };
    virtual ~Recorder() = default;
 
-   /// Initialize data
-   /// @param[in] stateOutputFileName  File name to save histories
-   virtual void init() = 0;
+   /// Setup the internal structure of the class (allocate memories and initialize them).
+   virtual void setup() = 0;
 
    /// Terminate process
    virtual void term() = 0;

--- a/Simulator/Recorders/Recorder.h
+++ b/Simulator/Recorders/Recorder.h
@@ -33,7 +33,7 @@ public:
    };
    virtual ~Recorder() = default;
 
-   /// Setup the internal structure of the class (allocate memories and initialize them).
+   /// Setup the internal structure of the class (allocate memory and initialize it).
    virtual void setup() = 0;
 
    /// Terminate process

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -23,13 +23,10 @@ XmlRecorder::XmlRecorder()
    function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters,
                                                      printParametersFunc);
-   function<void()> setupFunc = std::bind(&XmlRecorder::setup, this);
-   OperationManager::getInstance().registerOperation(Operations::setup, setupFunc);
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
-/// Setup the internal structure of the class (allocate memories and initialize them).
-/// Registered to OperationManager as Operation::setup
+/// Setup the internal structure of the class (allocate memory and initialize it).
 void XmlRecorder::setup()
 {
    // check the output file extension is .xml

--- a/Simulator/Recorders/XmlRecorder.cpp
+++ b/Simulator/Recorders/XmlRecorder.cpp
@@ -23,12 +23,14 @@ XmlRecorder::XmlRecorder()
    function<void()> printParametersFunc = std::bind(&XmlRecorder::printParameters, this);
    OperationManager::getInstance().registerOperation(Operations::printParameters,
                                                      printParametersFunc);
+   function<void()> setupFunc = std::bind(&XmlRecorder::setup, this);
+   OperationManager::getInstance().registerOperation(Operations::setup, setupFunc);
    fileLogger_ = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("file"));
 }
 
-/// Create a new xml file and initialize data
-/// @param[in] stateOutputFileName      File name to save histories
-void XmlRecorder::init()
+/// Setup the internal structure of the class (allocate memories and initialize them).
+/// Registered to OperationManager as Operation::setup
+void XmlRecorder::setup()
 {
    // check the output file extension is .xml
    string suffix = ".xml";

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -42,8 +42,9 @@ public:
       return new XmlRecorder();
    }
 
-   /// Initialize data in the newly loadeded xml file
-   virtual void init() override;
+   /// Setup the internal structure of the class (allocate memories and initialize them).
+   /// Registered to OperationManager as Operation::setup
+   virtual void setup() override;
 
    /// Terminate process
    virtual void term() override;

--- a/Simulator/Recorders/XmlRecorder.h
+++ b/Simulator/Recorders/XmlRecorder.h
@@ -42,8 +42,7 @@ public:
       return new XmlRecorder();
    }
 
-   /// Setup the internal structure of the class (allocate memories and initialize them).
-   /// Registered to OperationManager as Operation::setup
+   /// Setup the internal structure of the class (allocate memory and initialize it).
    virtual void setup() override;
 
    /// Terminate process

--- a/Testing/UnitTesting/Hdf5RecorderTests.cpp
+++ b/Testing/UnitTesting/Hdf5RecorderTests.cpp
@@ -16,13 +16,13 @@ TEST(Hdf5RecorderTest, CreateInstanceSuccess)
    ASSERT_TRUE(recorder != nullptr);
 }
 
-// Test case for init() and term()
+// Test case for setup() and term()
 TEST(Hdf5RecorderTest, Hdf5InitAndTermTest)
 {
    // Create an instance of Hdf5Recorder with a specific output file name
    std::string outputFile = "../Testing/UnitTesting/TestOutput/Hdf5test_output_term.h5";
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Ensure the file has been created successfully by the constructor
    FILE *f = fopen(outputFile.c_str(), "r");
@@ -45,7 +45,7 @@ TEST(Hdf5RecorderTest, RegisterVariableTest)
    // Create an instance of Hdf5Recorder
    std::string outputFile = "../Testing/UnitTesting/TestOutput/Hdf5test_output_register.h5";
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create an EventBuffer for testing
    EventBuffer<uint64_t> eventBuffer;
@@ -71,7 +71,7 @@ TEST(Hdf5RecorderTest, RegisterVectorVariableTest)
    // Create an instance of Hdf5Recorder
    std::string outputFile = "../Testing/UnitTesting/TestOutput/Hdf5test_output_register.h5";
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create mock EventBuffer objects for testing
    EventBuffer<uint64_t> buffer0;
@@ -101,7 +101,7 @@ TEST(Hdf5RecorderTest, RegisterVertexTypeTest)
    // Create an instance of Hdf5Recorder
    std::string outputFile = "../Testing/UnitTesting/TestOutput/Hdf5test_output_register.h5";
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create a vector of NeuronType enums
    RecordableVector<vertexType> neuronTypes;
@@ -133,7 +133,7 @@ TEST(Hdf5RecorderTest, SaveSimDataTest)
 
    // Create an instance of Hdf5Recorder
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create and configure EventBuffer for testing
    EventBuffer<uint64_t> eventBuffer(5);   // Initialize with a size that matches the mock data
@@ -177,7 +177,7 @@ TEST(Hdf5RecorderTest, SaveSimDataVertexTypeTest)
 
    // Create an instance of Hdf5Recorder
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create and configure RecordableVector<vertexType> for testing
    RecordableVector<vertexType> neuronTypes;
@@ -223,7 +223,7 @@ TEST(Hdf5RecorderTest, CompileHistoriesTest)
 
    // Create an instance of Hdf5Recorder
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create and configure variables for testing
    EventBuffer<uint64_t> eventBufferInt(5);   // Example with int type
@@ -274,7 +274,7 @@ TEST(Hdf5RecorderTest, CompileHistoriesVertexTypeTest)
 
    // Create an instance of Hdf5Recorder
    Hdf5Recorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
 
    // Create and configure EventBuffer for testing (stored as int)
    EventBuffer<uint64_t> eventBufferNeuron(5);

--- a/Testing/UnitTesting/Hdf5RecorderTests.cpp
+++ b/Testing/UnitTesting/Hdf5RecorderTests.cpp
@@ -17,14 +17,14 @@ TEST(Hdf5RecorderTest, CreateInstanceSuccess)
 }
 
 // Test case for setup() and term()
-TEST(Hdf5RecorderTest, Hdf5InitAndTermTest)
+TEST(Hdf5RecorderTest, Hdf5SetupAndTermTest)
 {
    // Create an instance of Hdf5Recorder with a specific output file name
    std::string outputFile = "../Testing/UnitTesting/TestOutput/Hdf5test_output_term.h5";
    Hdf5Recorder recorder(outputFile);
    recorder.setup();
 
-   // Ensure the file has been created successfully by the constructor
+   // Ensure the file has been created successfully by setup()
    FILE *f = fopen(outputFile.c_str(), "r");
    ASSERT_TRUE(f != NULL);
    fclose(f);

--- a/Testing/UnitTesting/XmlRecorderTests.cpp
+++ b/Testing/UnitTesting/XmlRecorderTests.cpp
@@ -29,12 +29,12 @@ TEST(XmlRecorderTest, CreateInstanceSuccess)
 }
 
 // Test case for open file successfully
-TEST(XmlRecorderTest, InitTest)
+TEST(XmlRecorderTest, SetupTest)
 {
    // Create an instance of XmlRecorder
    std::string outputFile = "../Testing/UnitTesting/TestOutput/test_output.xml";
    XmlRecorder recorder(outputFile);
-   recorder.init();
+   recorder.setup();
    // Test to see if output file exist
    FILE *f = fopen("../Testing/UnitTesting/TestOutput/test_output.xml", "r");
    bool fileExist = f != NULL;
@@ -226,7 +226,7 @@ TEST(XmlRecorderTest, SaveSimDataTest)
    EventBuffer<uint64_t> buffer(4);
 
    // initialize the XmlRecorder object
-   recorderTest_->init();
+   recorderTest_->setup();
 
    // Register a variable
    recorderTest_->registerVariable("neuron0", buffer, Recorder::UpdatedType::DYNAMIC);
@@ -273,7 +273,7 @@ TEST(XmlRecorderTest, SaveSimDataVertexTypeTest)
    recorderTest_->registerVariable("VertexTypes", vertTypes, Recorder::UpdatedType::DYNAMIC);
 
    // initialize the XmlRecorder object
-   recorderTest_->init();
+   recorderTest_->setup();
 
    // Call the compileHistories method
    recorderTest_->compileHistories();


### PR DESCRIPTION
Renames init() to setup() on Recorder implementations so memory allocation follows the same lifecycle pattern as Layout and Connections.

<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #378 

<!-- Please provide a brief overview of the changes implemented -->
#### Description
enamed Recorder::init() to setup() so Recorders follow the same lifecycle as Layout and Connections: constructors only register operations, and file/output allocation happens in setup().

XmlRecorder and Hdf5Recorder now register Operations::setup with OperationManager, and Model::setupSim() calls that instead of recorder_->init() directly. Unit tests were updated to match.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [ ] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
