### PR TITLE
Refactor NG911 call storage from Call structs to separate field vectors

### DIFF
--- a/Simulator/Edges/NG911/All911Edges.cpp
+++ b/Simulator/Edges/NG911/All911Edges.cpp
@@ -25,7 +25,14 @@ void All911Edges::setupEdges()
 
       isRedial_.assign(maxTotalEdges, false);
 
-      call_.resize(maxTotalEdges);
+      callVertexId_.assign(maxTotalEdges, 0);
+      callTime_.assign(maxTotalEdges, 0);
+      callDuration_.assign(maxTotalEdges, 0);
+      callX_.assign(maxTotalEdges, 0);
+      callY_.assign(maxTotalEdges, 0);
+      callPatience_.assign(maxTotalEdges, 0);
+      callOnSiteTime_.assign(maxTotalEdges, 0);
+      callResponderType_.assign(maxTotalEdges, 0);
    }
 }
 

--- a/Simulator/Edges/NG911/All911Edges.h
+++ b/Simulator/Edges/NG911/All911Edges.h
@@ -140,8 +140,15 @@ public:
    /// If the call in the edge is a redial. Store 1 (true) or 0 (false)
    vector<unsigned char> isRedial_;
 
-   /// The call information per edge
-   vector<Call> call_;
+   /// The call information per edge, stored as separate vectors
+   vector<int> callVertexId_;
+   vector<uint64_t> callTime_;
+   vector<int> callDuration_;
+   vector<BGFLOAT> callX_;
+   vector<BGFLOAT> callY_;
+   vector<int> callPatience_;
+   vector<int> callOnSiteTime_;
+   vector<int> callResponderType_;
 };
 
 #if defined(USE_GPU)

--- a/Simulator/Edges/NG911/All911Edges_d.cpp
+++ b/Simulator/Edges/NG911/All911Edges_d.cpp
@@ -177,81 +177,29 @@ void All911Edges::copyHostToDevice(void *allEdgesDevice,
                            maxTotalEdges * sizeof(unsigned char), cudaMemcpyHostToDevice));
 
    // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuVertexId = new int[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuVertexId[i] = call_[i].vertexId;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.vertexId_, cpuVertexId, maxTotalEdges * sizeof(int),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuVertexId;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   uint64_t *cpuTime = new uint64_t[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuTime[i] = call_[i].time;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.time_, cpuTime, maxTotalEdges * sizeof(uint64_t),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuTime;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuDuration = new int[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuDuration[i] = call_[i].duration;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.duration_, cpuDuration, maxTotalEdges * sizeof(int),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuDuration;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   BGFLOAT *cpuX = new BGFLOAT[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuX[i] = call_[i].x;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.x_, cpuX, maxTotalEdges * sizeof(BGFLOAT),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuX;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   BGFLOAT *cpuY = new BGFLOAT[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuY[i] = call_[i].y;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.y_, cpuY, maxTotalEdges * sizeof(BGFLOAT),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuY;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuPatience = new int[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuPatience[i] = call_[i].patience;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.patience_, cpuPatience, maxTotalEdges * sizeof(int),
-                           cudaMemcpyHostToDevice));
-   delete[] cpuPatience;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuOnSiteTime = new int[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      cpuOnSiteTime[i] = call_[i].onSiteTime;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.onSiteTime_, cpuOnSiteTime,
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.vertexId_, callVertexId_.data(),
                            maxTotalEdges * sizeof(int), cudaMemcpyHostToDevice));
-   delete[] cpuOnSiteTime;
 
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuResponderType = new int[maxTotalEdges];
-   for (int i = 0; i < maxTotalEdges; i++) {
-      if (call_[i].type == "Law")
-         cpuResponderType[i] = 7;
-      else if (call_[i].type == "EMS")
-         cpuResponderType[i] = 5;
-      else if (call_[i].type == "Fire")
-         cpuResponderType[i] = 6;
-   }
-   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.responderType_, cpuResponderType,
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.time_, callTime_.data(),
+                           maxTotalEdges * sizeof(uint64_t), cudaMemcpyHostToDevice));
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.duration_, callDuration_.data(),
                            maxTotalEdges * sizeof(int), cudaMemcpyHostToDevice));
-   delete[] cpuResponderType;
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.x_, callX_.data(), maxTotalEdges * sizeof(BGFLOAT),
+                           cudaMemcpyHostToDevice));
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.y_, callY_.data(), maxTotalEdges * sizeof(BGFLOAT),
+                           cudaMemcpyHostToDevice));
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.patience_, callPatience_.data(),
+                           maxTotalEdges * sizeof(int), cudaMemcpyHostToDevice));
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.onSiteTime_, callOnSiteTime_.data(),
+                           maxTotalEdges * sizeof(int), cudaMemcpyHostToDevice));
+
+   HANDLE_ERROR(cudaMemcpy(allEdgesDeviceProps.responderType_, callResponderType_.data(),
+                           maxTotalEdges * sizeof(int), cudaMemcpyHostToDevice));
 
    HANDLE_ERROR(cudaMemcpy(allEdgesDevice, &allEdgesDeviceProps,
                            sizeof(All911EdgesDeviceProperties), cudaMemcpyHostToDevice));
@@ -308,82 +256,29 @@ void All911Edges::copyDeviceToHost(All911EdgesDeviceProperties &allEdgesDevicePr
    HANDLE_ERROR(cudaMemcpy(isRedial_.data(), allEdgesDeviceProps.isRedial_,
                            maxTotalEdges * sizeof(unsigned char), cudaMemcpyDeviceToHost));
 
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuVertexId = new int[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuVertexId, allEdgesDeviceProps.vertexId_, maxTotalEdges * sizeof(int),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].vertexId = cpuVertexId[i];
-   }
-   delete[] cpuVertexId;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   uint64_t *cpuTime = new uint64_t[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuTime, allEdgesDeviceProps.time_, maxTotalEdges * sizeof(uint64_t),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].time = cpuTime[i];
-   }
-   delete[] cpuTime;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuDuration = new int[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuDuration, allEdgesDeviceProps.duration_, maxTotalEdges * sizeof(int),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].duration = cpuDuration[i];
-   }
-   delete[] cpuDuration;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   BGFLOAT *cpuX = new BGFLOAT[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuX, allEdgesDeviceProps.x_, maxTotalEdges * sizeof(BGFLOAT),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].x = cpuX[i];
-   }
-   delete[] cpuX;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   BGFLOAT *cpuY = new BGFLOAT[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuY, allEdgesDeviceProps.y_, maxTotalEdges * sizeof(BGFLOAT),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].y = cpuY[i];
-   }
-   delete[] cpuY;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuPatience = new int[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuPatience, allEdgesDeviceProps.patience_, maxTotalEdges * sizeof(int),
-                           cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].patience = cpuPatience[i];
-   }
-   delete[] cpuPatience;
-
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuOnSiteTime = new int[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuOnSiteTime, allEdgesDeviceProps.onSiteTime_,
+   HANDLE_ERROR(cudaMemcpy(callVertexId_.data(), allEdgesDeviceProps.vertexId_,
                            maxTotalEdges * sizeof(int), cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      call_[i].onSiteTime = cpuOnSiteTime[i];
-   }
-   delete[] cpuOnSiteTime;
 
-   // Use heap memory by using a dynamic array to prevent stack overflow/segmentation faults
-   int *cpuResponderType = new int[maxTotalEdges];
-   HANDLE_ERROR(cudaMemcpy(cpuResponderType, allEdgesDeviceProps.responderType_,
+   HANDLE_ERROR(cudaMemcpy(callTime_.data(), allEdgesDeviceProps.time_,
+                           maxTotalEdges * sizeof(uint64_t), cudaMemcpyDeviceToHost));
+
+   HANDLE_ERROR(cudaMemcpy(callDuration_.data(), allEdgesDeviceProps.duration_,
                            maxTotalEdges * sizeof(int), cudaMemcpyDeviceToHost));
-   for (int i = 0; i < maxTotalEdges; i++) {
-      if (cpuResponderType[i] == 7)
-         call_[i].type = "Law";
-      else if (cpuResponderType[i] == 5)
-         call_[i].type = "EMS";
-      else if (cpuResponderType[i] == 6)
-         call_[i].type = "Fire";
-   }
-   delete[] cpuResponderType;
+
+   HANDLE_ERROR(cudaMemcpy(callX_.data(), allEdgesDeviceProps.x_, maxTotalEdges * sizeof(BGFLOAT),
+                           cudaMemcpyDeviceToHost));
+
+   HANDLE_ERROR(cudaMemcpy(callY_.data(), allEdgesDeviceProps.y_, maxTotalEdges * sizeof(BGFLOAT),
+                           cudaMemcpyDeviceToHost));
+
+   HANDLE_ERROR(cudaMemcpy(callPatience_.data(), allEdgesDeviceProps.patience_,
+                           maxTotalEdges * sizeof(int), cudaMemcpyDeviceToHost));
+
+   HANDLE_ERROR(cudaMemcpy(callOnSiteTime_.data(), allEdgesDeviceProps.onSiteTime_,
+                           maxTotalEdges * sizeof(int), cudaMemcpyDeviceToHost));
+
+   HANDLE_ERROR(cudaMemcpy(callResponderType_.data(), allEdgesDeviceProps.responderType_,
+                           maxTotalEdges * sizeof(int), cudaMemcpyDeviceToHost));
 }
 
 ///  Get edge_counts in AllEdges struct on device memory.

--- a/Simulator/Utils/CallCircularBuffer.h
+++ b/Simulator/Utils/CallCircularBuffer.h
@@ -1,0 +1,256 @@
+/**
+ * @file CallCircularBuffer.h
+ * @ingroup Simulator/Utils
+ *
+ * @brief Circular buffer for NG911 calls using separate field vectors.
+ *
+ * Mirrors the GPU layout so host and device memory can be copied directly.
+ */
+
+#pragma once
+
+#include "BGTypes.h"
+#include "CallUtils.h"
+#include "InputEvent.h"
+#include <cassert>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+class CallCircularBuffer {
+public:
+   explicit CallCircularBuffer(int capacity = 0)
+   {
+      resize(capacity);
+      clear();
+   }
+
+   void resize(int capacity)
+   {
+      assert(isEmpty());
+      const size_t bufferSize = static_cast<size_t>(capacity) + 1;
+      vertexId_.resize(bufferSize);
+      time_.resize(bufferSize);
+      duration_.resize(bufferSize);
+      x_.resize(bufferSize);
+      y_.resize(bufferSize);
+      patience_.resize(bufferSize);
+      onSiteTime_.resize(bufferSize);
+      responderType_.resize(bufferSize);
+      clear();
+   }
+
+   void put(const Call &call)
+   {
+      assert(!isFull());
+      setAt(front_, call);
+      front_ = (front_ + 1) % bufferSize();
+   }
+
+   std::optional<Call> get()
+   {
+      if (isEmpty()) {
+         return std::nullopt;
+      }
+
+      Call value = callAt(end_);
+      end_ = (end_ + 1) % bufferSize();
+      return value;
+   }
+
+   std::optional<Call> peek() const
+   {
+      if (isEmpty()) {
+         return std::nullopt;
+      }
+      return callAt(end_);
+   }
+
+   void clear()
+   {
+      front_ = 0;
+      end_ = 0;
+   }
+
+   bool isEmpty() const
+   {
+      return front_ == end_;
+   }
+
+   bool isFull() const
+   {
+      return ((front_ + 1) % bufferSize()) == end_;
+   }
+
+   size_t capacity() const
+   {
+      return bufferSize() - 1;
+   }
+
+   size_t size() const
+   {
+      if (front_ >= end_) {
+         return front_ - end_;
+      }
+      return bufferSize() + front_ - end_;
+   }
+
+   size_t getFrontIndex() const
+   {
+      return front_;
+   }
+
+   size_t getEndIndex() const
+   {
+      return end_;
+   }
+
+   void setFrontIndex(unsigned long front)
+   {
+      front_ = front;
+   }
+
+   void setEndIndex(unsigned long end)
+   {
+      end_ = end;
+   }
+
+   size_t bufferSize() const
+   {
+      return vertexId_.size();
+   }
+
+   void resizeBuffer(size_t bufferSize)
+   {
+      vertexId_.resize(bufferSize);
+      time_.resize(bufferSize);
+      duration_.resize(bufferSize);
+      x_.resize(bufferSize);
+      y_.resize(bufferSize);
+      patience_.resize(bufferSize);
+      onSiteTime_.resize(bufferSize);
+      responderType_.resize(bufferSize);
+   }
+
+   Call callAt(size_t index) const
+   {
+      return makeCall(vertexId_[index], time_[index], duration_[index], x_[index], y_[index],
+                      patience_[index], onSiteTime_[index], responderType_[index]);
+   }
+
+   void setAt(size_t index, const Call &call)
+   {
+      vertexId_[index] = call.vertexId;
+      time_[index] = call.time;
+      duration_[index] = call.duration;
+      x_[index] = call.x;
+      y_[index] = call.y;
+      patience_[index] = call.patience;
+      onSiteTime_[index] = call.onSiteTime;
+      responderType_[index] = responderTypeToInt(call.type);
+   }
+
+   void copyAt(size_t dstIndex, size_t srcIndex)
+   {
+      vertexId_[dstIndex] = vertexId_[srcIndex];
+      time_[dstIndex] = time_[srcIndex];
+      duration_[dstIndex] = duration_[srcIndex];
+      x_[dstIndex] = x_[srcIndex];
+      y_[dstIndex] = y_[srcIndex];
+      patience_[dstIndex] = patience_[srcIndex];
+      onSiteTime_[dstIndex] = onSiteTime_[srcIndex];
+      responderType_[dstIndex] = responderType_[srcIndex];
+   }
+
+   std::vector<int> &vertexId()
+   {
+      return vertexId_;
+   }
+
+   std::vector<uint64_t> &time()
+   {
+      return time_;
+   }
+
+   std::vector<int> &duration()
+   {
+      return duration_;
+   }
+
+   std::vector<BGFLOAT> &x()
+   {
+      return x_;
+   }
+
+   std::vector<BGFLOAT> &y()
+   {
+      return y_;
+   }
+
+   std::vector<int> &patience()
+   {
+      return patience_;
+   }
+
+   std::vector<int> &onSiteTime()
+   {
+      return onSiteTime_;
+   }
+
+   std::vector<int> &responderType()
+   {
+      return responderType_;
+   }
+
+   const std::vector<int> &vertexId() const
+   {
+      return vertexId_;
+   }
+
+   const std::vector<uint64_t> &time() const
+   {
+      return time_;
+   }
+
+   const std::vector<int> &duration() const
+   {
+      return duration_;
+   }
+
+   const std::vector<BGFLOAT> &x() const
+   {
+      return x_;
+   }
+
+   const std::vector<BGFLOAT> &y() const
+   {
+      return y_;
+   }
+
+   const std::vector<int> &patience() const
+   {
+      return patience_;
+   }
+
+   const std::vector<int> &onSiteTime() const
+   {
+      return onSiteTime_;
+   }
+
+   const std::vector<int> &responderType() const
+   {
+      return responderType_;
+   }
+
+private:
+   std::vector<int> vertexId_;
+   std::vector<uint64_t> time_;
+   std::vector<int> duration_;
+   std::vector<BGFLOAT> x_;
+   std::vector<BGFLOAT> y_;
+   std::vector<int> patience_;
+   std::vector<int> onSiteTime_;
+   std::vector<int> responderType_;
+   size_t front_ = 0;
+   size_t end_ = 0;
+};

--- a/Simulator/Utils/CallSlotArrays.h
+++ b/Simulator/Utils/CallSlotArrays.h
@@ -1,0 +1,181 @@
+/**
+ * @file CallSlotArrays.h
+ * @ingroup Simulator/Utils
+ *
+ * @brief Fixed-size per-vertex call storage using separate field vectors.
+ */
+
+#pragma once
+
+#include "BGTypes.h"
+#include "CallUtils.h"
+#include "InputEvent.h"
+#include <vector>
+
+class CallSlotArrays {
+public:
+   void resize(size_t numSlots)
+   {
+      vertexId_.assign(numSlots, 0);
+      time_.assign(numSlots, 0);
+      duration_.assign(numSlots, 0);
+      x_.assign(numSlots, 0);
+      y_.assign(numSlots, 0);
+      patience_.assign(numSlots, 0);
+      onSiteTime_.assign(numSlots, 0);
+      responderType_.assign(numSlots, 0);
+   }
+
+   size_t size() const
+   {
+      return vertexId_.size();
+   }
+
+   Call callAt(size_t index) const
+   {
+      return makeCall(vertexId_[index], time_[index], duration_[index], x_[index], y_[index],
+                      patience_[index], onSiteTime_[index], responderType_[index]);
+   }
+
+   void setAt(size_t index, const Call &call)
+   {
+      vertexId_[index] = call.vertexId;
+      time_[index] = call.time;
+      duration_[index] = call.duration;
+      x_[index] = call.x;
+      y_[index] = call.y;
+      patience_[index] = call.patience;
+      onSiteTime_[index] = call.onSiteTime;
+      responderType_[index] = responderTypeToInt(call.type);
+   }
+
+   void setTimeAt(size_t index, uint64_t time)
+   {
+      time_[index] = time;
+   }
+
+   uint64_t timeAt(size_t index) const
+   {
+      return time_[index];
+   }
+
+   int responderTypeAt(size_t index) const
+   {
+      return responderType_[index];
+   }
+
+   BGFLOAT xAt(size_t index) const
+   {
+      return x_[index];
+   }
+
+   BGFLOAT yAt(size_t index) const
+   {
+      return y_[index];
+   }
+
+   int patienceAt(size_t index) const
+   {
+      return patience_[index];
+   }
+
+   int onSiteTimeAt(size_t index) const
+   {
+      return onSiteTime_[index];
+   }
+
+   int durationAt(size_t index) const
+   {
+      return duration_[index];
+   }
+
+   std::vector<int> &vertexId()
+   {
+      return vertexId_;
+   }
+
+   std::vector<uint64_t> &time()
+   {
+      return time_;
+   }
+
+   std::vector<int> &duration()
+   {
+      return duration_;
+   }
+
+   std::vector<BGFLOAT> &x()
+   {
+      return x_;
+   }
+
+   std::vector<BGFLOAT> &y()
+   {
+      return y_;
+   }
+
+   std::vector<int> &patience()
+   {
+      return patience_;
+   }
+
+   std::vector<int> &onSiteTime()
+   {
+      return onSiteTime_;
+   }
+
+   std::vector<int> &responderType()
+   {
+      return responderType_;
+   }
+
+   const std::vector<int> &vertexId() const
+   {
+      return vertexId_;
+   }
+
+   const std::vector<uint64_t> &time() const
+   {
+      return time_;
+   }
+
+   const std::vector<int> &duration() const
+   {
+      return duration_;
+   }
+
+   const std::vector<BGFLOAT> &x() const
+   {
+      return x_;
+   }
+
+   const std::vector<BGFLOAT> &y() const
+   {
+      return y_;
+   }
+
+   const std::vector<int> &patience() const
+   {
+      return patience_;
+   }
+
+   const std::vector<int> &onSiteTime() const
+   {
+      return onSiteTime_;
+   }
+
+   const std::vector<int> &responderType() const
+   {
+      return responderType_;
+   }
+
+private:
+   std::vector<int> vertexId_;
+   std::vector<uint64_t> time_;
+   std::vector<int> duration_;
+   std::vector<BGFLOAT> x_;
+   std::vector<BGFLOAT> y_;
+   std::vector<int> patience_;
+   std::vector<int> onSiteTime_;
+   std::vector<int> responderType_;
+};

--- a/Simulator/Utils/CallUtils.h
+++ b/Simulator/Utils/CallUtils.h
@@ -9,6 +9,7 @@
 
 #include "BGTypes.h"
 #include "InputEvent.h"
+#include "VertexType.h"
 #include <cstdint>
 #include <string>
 
@@ -16,26 +17,26 @@
 inline int responderTypeToInt(const std::string &type)
 {
    if (type == "Law") {
-      return 7;
+      return static_cast<int>(vertexType::LAW);
    }
    if (type == "EMS") {
-      return 5;
+      return static_cast<int>(vertexType::EMS);
    }
    if (type == "Fire") {
-      return 6;
+      return static_cast<int>(vertexType::FIRE);
    }
-   return 0;
+   return static_cast<int>(vertexType::VTYPE_UNDEF);
 }
 
 inline std::string responderTypeToString(int responderType)
 {
-   if (responderType == 7) {
+   if (responderType == static_cast<int>(vertexType::LAW)) {
       return "Law";
    }
-   if (responderType == 5) {
+   if (responderType == static_cast<int>(vertexType::EMS)) {
       return "EMS";
    }
-   if (responderType == 6) {
+   if (responderType == static_cast<int>(vertexType::FIRE)) {
       return "Fire";
    }
    return "";

--- a/Simulator/Utils/CallUtils.h
+++ b/Simulator/Utils/CallUtils.h
@@ -1,0 +1,67 @@
+/**
+ * @file CallUtils.h
+ * @ingroup Simulator/Utils
+ *
+ * @brief Helpers for NG911 call field vectors and responder type conversion.
+ */
+
+#pragma once
+
+#include "BGTypes.h"
+#include "InputEvent.h"
+#include <cstdint>
+#include <string>
+
+/// Responder type codes matching vertexType enum values for EMS, FIRE, and LAW.
+inline int responderTypeToInt(const std::string &type)
+{
+   if (type == "Law") {
+      return 7;
+   }
+   if (type == "EMS") {
+      return 5;
+   }
+   if (type == "Fire") {
+      return 6;
+   }
+   return 0;
+}
+
+inline std::string responderTypeToString(int responderType)
+{
+   if (responderType == 7) {
+      return "Law";
+   }
+   if (responderType == 5) {
+      return "EMS";
+   }
+   if (responderType == 6) {
+      return "Fire";
+   }
+   return "";
+}
+
+inline Call makeCall(int vertexId, uint64_t time, int duration, BGFLOAT x, BGFLOAT y, int patience,
+                     int onSiteTime, int responderType)
+{
+   Call call;
+   call.vertexId = vertexId;
+   call.time = time;
+   call.duration = duration;
+   call.x = x;
+   call.y = y;
+   call.patience = patience;
+   call.onSiteTime = onSiteTime;
+   call.type = responderTypeToString(responderType);
+   return call;
+}
+
+inline Call makeCall(const Call &call, int responderTypeOverride = -1)
+{
+   if (responderTypeOverride >= 0) {
+      return makeCall(call.vertexId, call.time, call.duration, call.x, call.y, call.patience,
+                      call.onSiteTime, responderTypeOverride);
+   }
+   return makeCall(call.vertexId, call.time, call.duration, call.x, call.y, call.patience,
+                   call.onSiteTime, responderTypeToInt(call.type));
+}

--- a/Simulator/Utils/InputManager.h
+++ b/Simulator/Utils/InputManager.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "CircularBuffer.h"
+#include "CallCircularBuffer.h"
 #include "ParameterManager.h"
 #include <boost/foreach.hpp>
 #include <boost/property_tree/exceptions.hpp>
@@ -169,6 +170,21 @@ public:
 
       while (!eventQueue.empty() && eventQueue.front().time < lastStep) {
          // We shouldn't have previous epoch events in the queue
+         assert(eventQueue.front().time >= firstStep);
+         buffer.put(eventQueue.front());
+         eventQueue.pop();
+      }
+
+      return buffer;
+   }
+
+   /// @brief  Inserts events into a CallCircularBuffer for NG911 simulations.
+   CallCircularBuffer &getEvents(const VertexId_t &vertexId, uint64_t firstStep, uint64_t lastStep,
+                                 CallCircularBuffer &buffer)
+   {
+      queue<T> &eventQueue = eventsMap_[vertexId];
+
+      while (!eventQueue.empty() && eventQueue.front().time < lastStep) {
          assert(eventQueue.front().time >= firstStep);
          buffer.put(eventQueue.front());
          eventQueue.pop();

--- a/Simulator/Utils/InputManager.h
+++ b/Simulator/Utils/InputManager.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include "CircularBuffer.h"
 #include "CallCircularBuffer.h"
+#include "CircularBuffer.h"
 #include "ParameterManager.h"
 #include <boost/foreach.hpp>
 #include <boost/property_tree/exceptions.hpp>

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -593,9 +593,8 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
 
       // Calculate the driving time to the incident in seconds
       double driveTime = (dist2incident / avgDrivingSpeed_) * 3600;
-      serverCountdown_[vertexIdx][availUnit] = driveTime + vertexQueue.onSiteTime()[queueEnd];
-
-      serverCountdown_[vertexIdx][availUnit] = vertexQueue.duration()[queueEnd];
+      serverCountdown_[vertexIdx][availUnit]
+         = static_cast<int>(driveTime) + vertexQueue.onSiteTime()[queueEnd];
       LOG4CPLUS_DEBUG(vertexLogger_,
                       "Response, driving time: " << driveTime << ", On-site time: "
                                                  << vertexQueue.onSiteTime()[queueEnd]);
@@ -629,13 +628,15 @@ BGSIZE All911Vertices::getEdgeToClosestResponder(int responderType, BGFLOAT x, B
    All911Edges &edges911 = dynamic_cast<All911Edges &>(connections.getEdges());
    EdgeIndexMap &edgeIndexMap = connections.getEdgeIndexMap();
 
-   vertexType requiredType;
-   if (responderType == 7)
+   vertexType requiredType = vertexType::VTYPE_UNDEF;
+   if (responderType == static_cast<int>(vertexType::LAW)) {
       requiredType = vertexType::LAW;
-   else if (responderType == 5)
+   } else if (responderType == static_cast<int>(vertexType::EMS)) {
       requiredType = vertexType::EMS;
-   else if (responderType == 6)
+   } else if (responderType == static_cast<int>(vertexType::FIRE)) {
       requiredType = vertexType::FIRE;
+   }
+   assert(requiredType != vertexType::VTYPE_UNDEF);
 
    // loop over the outgoing edges looking for the responder with the shortest
    // Euclidean distance to the call's location.

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -12,6 +12,7 @@
 #include "GraphManager.h"
 #include "Layout911.h"
 #include "ParameterManager.h"
+#include "CallUtils.h"
 #include <cmath>
 
 // Allocate memory for all class properties
@@ -210,7 +211,7 @@ void All911Vertices::registerHistoryVariables()
 }
 
 // Accessor for the waiting queue of a vertex
-CircularBuffer<Call> &All911Vertices::getQueue(int vIdx)
+CallCircularBuffer &All911Vertices::getQueue(int vIdx)
 {
    return vertexQueues_[vIdx];
 }
@@ -262,7 +263,7 @@ void All911Vertices::integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIn
          // The destination vertex should be the one pulling the information
          assert(dst == vertex);
 
-         CircularBuffer<Call> &dstQueue = getQueue(dst);
+         CallCircularBuffer &dstQueue = getQueue(dst);
          // Compute the size of the destination queue
          // Allows us to use larger capacity queues but treat them like they are smaller
          // to simplify the mirroring on the GPU.
@@ -288,15 +289,21 @@ void All911Vertices::integrateVertexInputs(AllEdges &edges, EdgeIndexMap &edgeIn
                // Record that we received a call
                receivedCalls(dst)++;
                LOG4CPLUS_DEBUG(vertexLogger_, "Call dropped: " << droppedCalls(dst) << ", time: "
-                                                               << all911Edges.call_[edgeIdx].time
+                                                               << all911Edges.callTime_[edgeIdx]
                                                                << ", vertex: " << dst
                                                                << ", queue size: " << dstQueueSize);
             }
          } else {
             // Transfer call to destination
             assert(((queueFrontIndex + 1) % numTrunks_[dst] + 1) != queueEndIndex);
-            vector<Call> &queueBuffer = dstQueue.getBuffer();
-            queueBuffer[queueFrontIndex] = all911Edges.call_[edgeIdx];
+            dstQueue.vertexId()[queueFrontIndex] = all911Edges.callVertexId_[edgeIdx];
+            dstQueue.time()[queueFrontIndex] = all911Edges.callTime_[edgeIdx];
+            dstQueue.duration()[queueFrontIndex] = all911Edges.callDuration_[edgeIdx];
+            dstQueue.x()[queueFrontIndex] = all911Edges.callX_[edgeIdx];
+            dstQueue.y()[queueFrontIndex] = all911Edges.callY_[edgeIdx];
+            dstQueue.patience()[queueFrontIndex] = all911Edges.callPatience_[edgeIdx];
+            dstQueue.onSiteTime()[queueFrontIndex] = all911Edges.callOnSiteTime_[edgeIdx];
+            dstQueue.responderType()[queueFrontIndex] = all911Edges.callResponderType_[edgeIdx];
             uint64_t newFrontIndex = (queueFrontIndex + 1) % (numTrunks_[dst] + 1);
             dstQueue.setFrontIndex(newFrontIndex);
             // Record that we received a call
@@ -357,7 +364,14 @@ void All911Vertices::advanceCALR(BGSIZE vertexIdx, All911Edges &edges911,
 
       // Place new call in the edge going to the PSAP
       assert(edges911.isAvailable_[edgeIdx]);
-      edges911.call_[edgeIdx] = nextCall.value();
+      edges911.callVertexId_[edgeIdx] = nextCall->vertexId;
+      edges911.callTime_[edgeIdx] = nextCall->time;
+      edges911.callDuration_[edgeIdx] = nextCall->duration;
+      edges911.callX_[edgeIdx] = nextCall->x;
+      edges911.callY_[edgeIdx] = nextCall->y;
+      edges911.callPatience_[edgeIdx] = nextCall->patience;
+      edges911.callOnSiteTime_[edgeIdx] = nextCall->onSiteTime;
+      edges911.callResponderType_[edgeIdx] = responderTypeToInt(nextCall->type);
       edges911.isAvailable_[edgeIdx] = false;
       LOG4CPLUS_DEBUG(vertexLogger_, "Calling PSAP at time: " << nextCall->time);
    }
@@ -395,27 +409,36 @@ void All911Vertices::advancePSAP(BGSIZE vertexIdx, All911Edges &edges911,
       if ((!countdownWasZero) & (countdown == 0)) {
          // Server becomes free to take calls
          // TODO: What about wrap-up time?
-         Call &endingCall = servingCall_[vertexIdx][server];
+         CallSlotArrays &endingCall = servingCall_[vertexIdx];
 
          //Store call metrics
          wasAbandonedHistory_[vertexIdx].insertEvent(false);
-         beginTimeHistory_[vertexIdx].insertEvent(endingCall.time);
+         beginTimeHistory_[vertexIdx].insertEvent(endingCall.timeAt(server));
          answerTimeHistory_[vertexIdx].insertEvent(answerTime_[vertexIdx][server]);
          endTimeHistory_[vertexIdx].insertEvent(g_simulationStep);
          LOG4CPLUS_DEBUG(vertexLogger_,
                          "Finishing call, begin time: "
-                            << endingCall.time << ", end time: " << g_simulationStep
-                            << ", waited: " << answerTime_[vertexIdx][server] - endingCall.time);
+                            << endingCall.timeAt(server) << ", end time: " << g_simulationStep
+                            << ", waited: "
+                            << answerTime_[vertexIdx][server] - endingCall.timeAt(server));
 
          // Dispatch the Responder closest to the emergency location.
-         BGSIZE respEdge = getEdgeToClosestResponder(endingCall, vertexIdx);
+         BGSIZE respEdge = getEdgeToClosestResponder(endingCall.responderTypeAt(server),
+                                                       endingCall.xAt(server),
+                                                       endingCall.yAt(server), vertexIdx);
          BGSIZE responder = edges911.destVertexIndex_[respEdge];
          LOG4CPLUS_DEBUG(vertexLogger_, "Dispatching Responder: " << responder);
 
          // Place the call in the edge going to the responder
          // Call becomes a dispatch order at this time
-         endingCall.time = g_simulationStep;
-         edges911.call_[respEdge] = endingCall;
+         edges911.callVertexId_[respEdge] = endingCall.vertexId()[server];
+         edges911.callTime_[respEdge] = g_simulationStep;
+         edges911.callDuration_[respEdge] = endingCall.durationAt(server);
+         edges911.callX_[respEdge] = endingCall.xAt(server);
+         edges911.callY_[respEdge] = endingCall.yAt(server);
+         edges911.callPatience_[respEdge] = endingCall.patienceAt(server);
+         edges911.callOnSiteTime_[respEdge] = endingCall.onSiteTimeAt(server);
+         edges911.callResponderType_[respEdge] = endingCall.responderTypeAt(server);
          edges911.isAvailable_[respEdge] = false;
       }
    }
@@ -429,23 +452,23 @@ void All911Vertices::advancePSAP(BGSIZE vertexIdx, All911Edges &edges911,
       // TODO: calls with duration of zero are being added but because countdown will be zero
       //       they don't show up in the logs
       //
-      // Internal CircularBuffer buffer size is capacity + 1
-      vector<Call> queueBuffer = vertexQueues_[vertexIdx].getBuffer();
-      uint64_t queueEnd = vertexQueues_[vertexIdx].getEndIndex();
-      Call call = queueBuffer[queueEnd];
+      CallCircularBuffer &vertexQueue = vertexQueues_[vertexIdx];
+      uint64_t queueEnd = vertexQueue.getEndIndex();
+      uint64_t callTime = vertexQueue.time()[queueEnd];
+      int callPatience = vertexQueue.patience()[queueEnd];
       uint64_t newEndIndex = (queueEnd + 1) % (numTrunks_[vertexIdx] + 1);
-      vertexQueues_[vertexIdx].setEndIndex(newEndIndex);
+      vertexQueue.setEndIndex(newEndIndex);
 
-      if (call.patience < (g_simulationStep - call.time)) {
+      if (callPatience < (g_simulationStep - callTime)) {
          // If the patience time is less than the waiting time, the call is abandoned
          wasAbandonedHistory_[vertexIdx].insertEvent(true);
-         beginTimeHistory_[vertexIdx].insertEvent(call.time);
+         beginTimeHistory_[vertexIdx].insertEvent(callTime);
          // Answer time and end time get zero as sentinel for non-valid values
          answerTimeHistory_[vertexIdx].insertEvent(0);
          endTimeHistory_[vertexIdx].insertEvent(0);
          LOG4CPLUS_DEBUG(vertexLogger_, "Call was abandoned, Patience: "
-                                           << call.patience
-                                           << " Ring Time: " << g_simulationStep - call.time);
+                                           << callPatience
+                                           << " Ring Time: " << g_simulationStep - callTime);
       } else {
          // The available server starts serving the call
          int availServer;
@@ -458,11 +481,11 @@ void All911Vertices::advancePSAP(BGSIZE vertexIdx, All911Edges &edges911,
                break;
             }
          }
-         servingCall_[vertexIdx][availServer] = call;
+         servingCall_[vertexIdx].setAt(availServer, vertexQueue.callAt(queueEnd));
          answerTime_[vertexIdx][availServer] = g_simulationStep;
-         serverCountdown_[vertexIdx][availServer] = call.duration;
+         serverCountdown_[vertexIdx][availServer] = vertexQueue.duration()[queueEnd];
          LOG4CPLUS_DEBUG(vertexLogger_, "Serving Call starting at time: "
-                                           << call.time << ", sim-step: " << g_simulationStep);
+                                           << callTime << ", sim-step: " << g_simulationStep);
       }
    }
 
@@ -516,17 +539,18 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
       // If it became zero, the unit responds to the new incident
       if ((!countdownWasZero) & (countdown == 0)) {
          // Unit becomes available to responde to new incidents
-         Call &endingIncident = servingCall_[vertexIdx][unit];
+         CallSlotArrays &endingIncident = servingCall_[vertexIdx];
 
          //Store incident response metrics
          wasAbandonedHistory_[vertexIdx].insertEvent(false);
-         beginTimeHistory_[vertexIdx].insertEvent(endingIncident.time);
+         beginTimeHistory_[vertexIdx].insertEvent(endingIncident.timeAt(unit));
          answerTimeHistory_[vertexIdx].insertEvent(answerTime_[vertexIdx][unit]);
          endTimeHistory_[vertexIdx].insertEvent(g_simulationStep);
          LOG4CPLUS_DEBUG(vertexLogger_,
                          "Finishing response, begin time: "
-                            << endingIncident.time << ", end time: " << g_simulationStep
-                            << ", waited: " << answerTime_[vertexIdx][unit] - endingIncident.time);
+                            << endingIncident.timeAt(unit) << ", end time: " << g_simulationStep
+                            << ", waited: "
+                            << answerTime_[vertexIdx][unit] - endingIncident.timeAt(unit));
       }
    }
 
@@ -535,12 +559,10 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
    // incidents in the waiting queue
    for (size_t unit = 0; unit < numberOfAvailableUnits && !vertexQueues_[vertexIdx].isEmpty();
         ++unit) {
-      // Internal CircularBuffer buffer size is capacity + 1
-      vector<Call> queueBuffer = vertexQueues_[vertexIdx].getBuffer();
-      uint64_t queueEnd = vertexQueues_[vertexIdx].getEndIndex();
-      Call incident = queueBuffer[queueEnd];
+      CallCircularBuffer &vertexQueue = vertexQueues_[vertexIdx];
+      uint64_t queueEnd = vertexQueue.getEndIndex();
       uint64_t newEndIndex = (queueEnd + 1) % (numTrunks_[vertexIdx] + 1);
-      vertexQueues_[vertexIdx].setEndIndex(newEndIndex);
+      vertexQueue.setEndIndex(newEndIndex);
 
       // The available unit starts serving the call
       int availUnit = -1;
@@ -552,7 +574,7 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
             = (unsigned char)(availableUnits[unitIndex]
                               == true - (availableUnits[unitIndex] == true && availUnit == -1));
       }
-      servingCall_[vertexIdx][availUnit] = incident;
+      servingCall_[vertexIdx].setAt(availUnit, vertexQueue.callAt(queueEnd));
       answerTime_[vertexIdx][availUnit] = g_simulationStep;
 
       // We need to calculate the distance in miles but the x and y coordinates
@@ -564,18 +586,18 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
       //    1 degree of longitude = cos(latitude) * 69.172
       double lngDegreeLength = cos(layout911.yloc_[vertexIdx] * (pi / 180)) * 69.172;
       double latDegreeLength = 69.0;
-      double deltaLng = incident.x - layout911.xloc_[vertexIdx];
-      double deltaLat = incident.y - layout911.yloc_[vertexIdx];
+      double deltaLng = vertexQueue.x()[queueEnd] - layout911.xloc_[vertexIdx];
+      double deltaLat = vertexQueue.y()[queueEnd] - layout911.yloc_[vertexIdx];
       double dist2incident
          = sqrt(pow(deltaLng * lngDegreeLength, 2) + pow(deltaLat * latDegreeLength, 2));
 
       // Calculate the driving time to the incident in seconds
       double driveTime = (dist2incident / avgDrivingSpeed_) * 3600;
-      serverCountdown_[vertexIdx][availUnit] = driveTime + incident.onSiteTime;
+      serverCountdown_[vertexIdx][availUnit] = driveTime + vertexQueue.onSiteTime()[queueEnd];
 
-      serverCountdown_[vertexIdx][availUnit] = incident.duration;
+      serverCountdown_[vertexIdx][availUnit] = vertexQueue.duration()[queueEnd];
       LOG4CPLUS_DEBUG(vertexLogger_, "Response, driving time: " << driveTime << ", On-site time: "
-                                                                << incident.onSiteTime);
+                                                                << vertexQueue.onSiteTime()[queueEnd]);
    }
 
    // Update number of busy servers. This is used to check if there is space in the queue
@@ -599,18 +621,19 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
 
 /// Finds the outgoing edge from the given vertex to the Responder closest to
 /// the emergency call location
-BGSIZE All911Vertices::getEdgeToClosestResponder(const Call &call, BGSIZE vertexIdx)
+BGSIZE All911Vertices::getEdgeToClosestResponder(int responderType, BGFLOAT x, BGFLOAT y,
+                                                   BGSIZE vertexIdx)
 {
    Connections &connections = Simulator::getInstance().getModel().getConnections();
    All911Edges &edges911 = dynamic_cast<All911Edges &>(connections.getEdges());
    EdgeIndexMap &edgeIndexMap = connections.getEdgeIndexMap();
 
    vertexType requiredType;
-   if (call.type == "Law")
+   if (responderType == 7)
       requiredType = vertexType::LAW;
-   else if (call.type == "EMS")
+   else if (responderType == 5)
       requiredType = vertexType::EMS;
-   else if (call.type == "Fire")
+   else if (responderType == 6)
       requiredType = vertexType::FIRE;
 
    // loop over the outgoing edges looking for the responder with the shortest
@@ -628,7 +651,7 @@ BGSIZE All911Vertices::getEdgeToClosestResponder(const Call &call, BGSIZE vertex
 
       BGSIZE dstVertex = edges911.destVertexIndex_[outEdg];
       if (layout911.getVertices().vertexTypeMap_[dstVertex] == requiredType) {
-         double distance = layout911.getDistance(dstVertex, call.x, call.y);
+         double distance = layout911.getDistance(dstVertex, x, y);
 
          if (distance < minDistance) {
             minDistance = distance;

--- a/Simulator/Vertices/NG911/All911Vertices.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices.cpp
@@ -8,11 +8,11 @@
 
 #include "All911Vertices.h"
 #include "All911Edges.h"
+#include "CallUtils.h"
 #include "Connections911.h"
 #include "GraphManager.h"
 #include "Layout911.h"
 #include "ParameterManager.h"
-#include "CallUtils.h"
 #include <cmath>
 
 // Allocate memory for all class properties
@@ -423,9 +423,9 @@ void All911Vertices::advancePSAP(BGSIZE vertexIdx, All911Edges &edges911,
                             << answerTime_[vertexIdx][server] - endingCall.timeAt(server));
 
          // Dispatch the Responder closest to the emergency location.
-         BGSIZE respEdge = getEdgeToClosestResponder(endingCall.responderTypeAt(server),
-                                                       endingCall.xAt(server),
-                                                       endingCall.yAt(server), vertexIdx);
+         BGSIZE respEdge
+            = getEdgeToClosestResponder(endingCall.responderTypeAt(server), endingCall.xAt(server),
+                                        endingCall.yAt(server), vertexIdx);
          BGSIZE responder = edges911.destVertexIndex_[respEdge];
          LOG4CPLUS_DEBUG(vertexLogger_, "Dispatching Responder: " << responder);
 
@@ -596,8 +596,9 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
       serverCountdown_[vertexIdx][availUnit] = driveTime + vertexQueue.onSiteTime()[queueEnd];
 
       serverCountdown_[vertexIdx][availUnit] = vertexQueue.duration()[queueEnd];
-      LOG4CPLUS_DEBUG(vertexLogger_, "Response, driving time: " << driveTime << ", On-site time: "
-                                                                << vertexQueue.onSiteTime()[queueEnd]);
+      LOG4CPLUS_DEBUG(vertexLogger_,
+                      "Response, driving time: " << driveTime << ", On-site time: "
+                                                 << vertexQueue.onSiteTime()[queueEnd]);
    }
 
    // Update number of busy servers. This is used to check if there is space in the queue
@@ -622,7 +623,7 @@ void All911Vertices::advanceRESP(BGSIZE vertexIdx, All911Edges &edges911,
 /// Finds the outgoing edge from the given vertex to the Responder closest to
 /// the emergency call location
 BGSIZE All911Vertices::getEdgeToClosestResponder(int responderType, BGFLOAT x, BGFLOAT y,
-                                                   BGSIZE vertexIdx)
+                                                 BGSIZE vertexIdx)
 {
    Connections &connections = Simulator::getInstance().getModel().getConnections();
    All911Edges &edges911 = dynamic_cast<All911Edges &>(connections.getEdges());

--- a/Simulator/Vertices/NG911/All911Vertices.h
+++ b/Simulator/Vertices/NG911/All911Vertices.h
@@ -66,7 +66,8 @@
 #pragma once
 
 #include "AllVertices.h"
-#include "CircularBuffer.h"
+#include "CallCircularBuffer.h"
+#include "CallSlotArrays.h"
 #include "EventBuffer.h"
 #include "Global.h"
 #include "InputEvent.h"
@@ -130,7 +131,7 @@ public:
    ///
    /// @param vIdx   The index of the vertex
    /// @return    The waiting queue for the given vertex
-   CircularBuffer<Call> &getQueue(int vIdx);
+   CallCircularBuffer &getQueue(int vIdx);
 
    /// Accessor for the droppedCalls counter of a vertex
    ///
@@ -166,7 +167,7 @@ public:
    vector<EventBuffer<float>> utilizationHistory_;
 
    /// These are the queues where calls will wait to be served
-   vector<CircularBuffer<Call>> vertexQueues_;
+   vector<CallCircularBuffer> vertexQueues_;
 
    /// The number of calls that have been dropped (got a busy signal)
    RecordableVector<int> droppedCalls_;
@@ -193,7 +194,7 @@ public:
    BGFLOAT avgDrivingSpeed_;
 
    /// Holds the calls being served by each server
-   vector<vector<Call>> servingCall_;
+   vector<CallSlotArrays> servingCall_;
 
    /// The time that the call being served was answered by the server
    vector<vector<uint64_t>> answerTime_;
@@ -217,7 +218,7 @@ protected:
    /// @param call         The call that needs a Responder
    /// @param vertexIdx    The index of the vertex serving the call (A PSAP)
    /// @return    The index of the outgoing edge to the closest Responder
-   BGSIZE getEdgeToClosestResponder(const Call &call, BGSIZE vertexIdx);
+   BGSIZE getEdgeToClosestResponder(int responderType, BGFLOAT x, BGFLOAT y, BGSIZE vertexIdx);
 
    /// The number of vertices that needs device noise. Only caller regions need noise for determining
    /// redial so this is meant to help save memory. A member variable is used so that we don't have to

--- a/Simulator/Vertices/NG911/All911Vertices_d.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices_d.cpp
@@ -825,8 +825,8 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       HANDLE_ERROR(cudaMemcpy(callDurationCpu, allVerticesDevice.vertexQueuesBufferDuration_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
       for (int i = 0; i < numberOfVertices; i++) {
-         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], vertexQueues_[i].duration().data(), bufferBytes,
-                                 cudaMemcpyHostToDevice));
+         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], vertexQueues_[i].duration().data(),
+                                 bufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // BGFLOAT **vertexQueuesBufferX_;
@@ -1409,8 +1409,8 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       HANDLE_ERROR(cudaMemcpy(callLocationXCpu, allVerticesDevice.vertexQueuesBufferX_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
       for (int i = 0; i < numberOfVertices; i++) {
-         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].x().data(), callLocationXCpu[i],
-                                 floatBufferBytes, cudaMemcpyDeviceToHost));
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].x().data(), callLocationXCpu[i], floatBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // BGFLOAT **vertexQueuesBufferY_;
@@ -1419,8 +1419,8 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       HANDLE_ERROR(cudaMemcpy(callLocationYCpu, allVerticesDevice.vertexQueuesBufferY_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
       for (int i = 0; i < numberOfVertices; i++) {
-         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].y().data(), callLocationYCpu[i],
-                                 floatBufferBytes, cudaMemcpyDeviceToHost));
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].y().data(), callLocationYCpu[i], floatBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // int **vertexQueuesBufferPatience_;

--- a/Simulator/Vertices/NG911/All911Vertices_d.cpp
+++ b/Simulator/Vertices/NG911/All911Vertices_d.cpp
@@ -795,26 +795,18 @@ void All911Vertices::deleteDeviceStruct(All911VerticesDeviceProperties &allVerti
 void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t stepsPerEpoch,
                                               All911VerticesDeviceProperties &allVerticesDevice)
 {
+   const size_t bufferBytes = (stepsPerEpoch + 1) * sizeof(int);
+   const size_t timeBufferBytes = (stepsPerEpoch + 1) * sizeof(uint64_t);
+   const size_t floatBufferBytes = (stepsPerEpoch + 1) * sizeof(BGFLOAT);
+
    // int **vertexQueuesBufferVertexId_;
    {
       int *callIdCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callIdCpu, allVerticesDevice.vertexQueuesBufferVertexId_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callIdInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callIdInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callIdInBuffer[j] = buffer[j].vertexId;
-         }
-         HANDLE_ERROR(cudaMemcpy(callIdCpu[i], callIdInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callIdInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callIdCpu[i], vertexQueues_[i].vertexId().data(), bufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // uint64_t **vertexQueuesBufferTime_;
@@ -822,21 +814,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       uint64_t *callTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callTimeCpu, allVerticesDevice.vertexQueuesBufferTime_,
                               numberOfVertices * sizeof(uint64_t *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<uint64_t> callTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callTimeInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callTimeInBuffer[j] = buffer[j].time;
-         }
-         HANDLE_ERROR(cudaMemcpy(callTimeCpu[i], callTimeInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(uint64_t), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callTimeCpu[i], vertexQueues_[i].time().data(), timeBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // int **vertexQueuesBufferDuration_;
@@ -844,21 +824,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       int *callDurationCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callDurationCpu, allVerticesDevice.vertexQueuesBufferDuration_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callDurationInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callDurationInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callDurationInBuffer[j] = buffer[j].duration;
-         }
-         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], callDurationInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callDurationInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], vertexQueues_[i].duration().data(), bufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // BGFLOAT **vertexQueuesBufferX_;
@@ -866,21 +834,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       BGFLOAT *callLocationXCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationXCpu, allVerticesDevice.vertexQueuesBufferX_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationXInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationXInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callLocationXInBuffer[j] = buffer[j].x;
-         }
-         HANDLE_ERROR(cudaMemcpy(callLocationXCpu[i], callLocationXInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(BGFLOAT), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callLocationXInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callLocationXCpu[i], vertexQueues_[i].x().data(), floatBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // BGFLOAT **vertexQueuesBufferY_;
@@ -888,21 +844,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       BGFLOAT *callLocationYCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationYCpu, allVerticesDevice.vertexQueuesBufferY_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationYInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationYInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callLocationYInBuffer[j] = buffer[j].y;
-         }
-         HANDLE_ERROR(cudaMemcpy(callLocationYCpu[i], callLocationYInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(BGFLOAT), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callLocationYInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callLocationYCpu[i], vertexQueues_[i].y().data(), floatBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // int **vertexQueuesBufferPatience_;
@@ -910,21 +854,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       int *callPatienceCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callPatienceCpu, allVerticesDevice.vertexQueuesBufferPatience_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callPatienceInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callPatienceInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callPatienceInBuffer[j] = buffer[j].patience;
-         }
-         HANDLE_ERROR(cudaMemcpy(callPatienceCpu[i], callPatienceInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callPatienceInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callPatienceCpu[i], vertexQueues_[i].patience().data(),
+                                 bufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // int **vertexQueuesBufferOnSiteTime_;
@@ -932,21 +864,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       int *callOnSiteTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu, allVerticesDevice.vertexQueuesBufferOnSiteTime_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callOnSiteTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callOnSiteTimeInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            callOnSiteTimeInBuffer[j] = buffer[j].onSiteTime;
-         }
-         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu[i], callOnSiteTimeInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callOnSiteTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu[i], vertexQueues_[i].onSiteTime().data(),
+                                 bufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // int **vertexQueuesBufferResponderType_;
@@ -955,28 +875,9 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
       HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu,
                               allVerticesDevice.vertexQueuesBufferResponderType_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callResponderTypeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callResponderTypeInBuffer.resize(stepsPerEpoch + 1);
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            std::string typeInBuffer = buffer[j].type;
-            if (typeInBuffer == "EMS") {
-               callResponderTypeInBuffer[j] = 5;
-            } else if (typeInBuffer == "Fire") {
-               callResponderTypeInBuffer[j] = 6;
-            } else if (typeInBuffer == "Law") {
-               callResponderTypeInBuffer[j] = 7;
-            }
-         }
-         HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu[i], callResponderTypeInBuffer.data(),
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callResponderTypeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu[i], vertexQueues_[i].responderType().data(),
+                                 bufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // uint64_t *vertexQueuesFront_;
@@ -1001,7 +902,7 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
    {
       uint64_t queueSizeCpu[numberOfVertices];
       for (int i = 0; i < numberOfVertices; i++) {
-         queueSizeCpu[i] = vertexQueues_[i].getBuffer().size();
+         queueSizeCpu[i] = vertexQueues_[i].bufferSize();
       }
       HANDLE_ERROR(cudaMemcpy(allVerticesDevice.vertexQueuesBufferSize_, queueSizeCpu,
                               numberOfVertices * sizeof(uint64_t), cudaMemcpyHostToDevice));
@@ -1014,29 +915,18 @@ void All911Vertices::copyVertexQueuesToDevice(int numberOfVertices, uint64_t ste
 void All911Vertices::copyServingCallToDevice(int numberOfVertices,
                                              All911VerticesDeviceProperties &allVerticesDevice)
 {
-   // Logic is similar to copyVertexQueuesToDevice but we use max number of servers
-   // for the inner vector dimension
-   //
+   const size_t intBufferBytes = maxNumberOfServers_ * sizeof(int);
+   const size_t timeBufferBytes = maxNumberOfServers_ * sizeof(uint64_t);
+   const size_t floatBufferBytes = maxNumberOfServers_ * sizeof(BGFLOAT);
+
    // int **servingCallBufferVertexId_;
    {
       int *callIdCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callIdCpu, allVerticesDevice.servingCallBufferVertexId_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callIdInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callIdInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callIdInBuffer[j] = buffer[j].vertexId;
-         }
-         HANDLE_ERROR(cudaMemcpy(callIdCpu[i], callIdInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callIdInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callIdCpu[i], servingCall_[i].vertexId().data(), intBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // uint64_t **servingCallBufferTime_;
@@ -1044,21 +934,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       uint64_t *callTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callTimeCpu, allVerticesDevice.servingCallBufferTime_,
                               numberOfVertices * sizeof(uint64_t *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<uint64_t> callTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callTimeInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callTimeInBuffer[j] = buffer[j].time;
-         }
-         HANDLE_ERROR(cudaMemcpy(callTimeCpu[i], callTimeInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(uint64_t), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callTimeCpu[i], servingCall_[i].time().data(), timeBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // int **servingCallBufferDuration_;
@@ -1066,21 +944,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       int *callDurationCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callDurationCpu, allVerticesDevice.servingCallBufferDuration_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callDurationInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callDurationInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callDurationInBuffer[j] = buffer[j].duration;
-         }
-         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], callDurationInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callDurationInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callDurationCpu[i], servingCall_[i].duration().data(),
+                                 intBufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // BGFLOAT **servingCallBufferX_;
@@ -1088,21 +954,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       BGFLOAT *callLocationXCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationXCpu, allVerticesDevice.servingCallBufferX_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationXInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationXInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callLocationXInBuffer[j] = buffer[j].x;
-         }
-         HANDLE_ERROR(cudaMemcpy(callLocationXCpu[i], callLocationXInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(BGFLOAT), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callLocationXInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callLocationXCpu[i], servingCall_[i].x().data(), floatBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // BGFLOAT **servingCallBufferY_;
@@ -1110,21 +964,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       BGFLOAT *callLocationYCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationYCpu, allVerticesDevice.servingCallBufferY_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationYInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationYInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callLocationYInBuffer[j] = buffer[j].y;
-         }
-         HANDLE_ERROR(cudaMemcpy(callLocationYCpu[i], callLocationYInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(BGFLOAT), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callLocationYInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callLocationYCpu[i], servingCall_[i].y().data(), floatBufferBytes,
+                                 cudaMemcpyHostToDevice));
       }
    }
    // int **servingCallBufferPatience_;
@@ -1132,21 +974,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       int *callPatienceCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callPatienceCpu, allVerticesDevice.servingCallBufferPatience_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callPatienceInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callPatienceInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callPatienceInBuffer[j] = buffer[j].patience;
-         }
-         HANDLE_ERROR(cudaMemcpy(callPatienceCpu[i], callPatienceInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callPatienceInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callPatienceCpu[i], servingCall_[i].patience().data(),
+                                 intBufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // int **servingCallBufferOnSiteTime_;
@@ -1154,21 +984,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       int *callOnSiteTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu, allVerticesDevice.servingCallBufferOnSiteTime_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callOnSiteTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callOnSiteTimeInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            callOnSiteTimeInBuffer[j] = buffer[j].onSiteTime;
-         }
-         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu[i], callOnSiteTimeInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callOnSiteTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu[i], servingCall_[i].onSiteTime().data(),
+                                 intBufferBytes, cudaMemcpyHostToDevice));
       }
    }
    // int **servingCallBufferResponderType_;
@@ -1177,28 +995,9 @@ void All911Vertices::copyServingCallToDevice(int numberOfVertices,
       HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu,
                               allVerticesDevice.servingCallBufferResponderType_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callResponderTypeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callResponderTypeInBuffer.resize(maxNumberOfServers_);
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            std::string typeInBuffer = buffer[j].type;
-            if (typeInBuffer == "EMS") {
-               callResponderTypeInBuffer[j] = 5;
-            } else if (typeInBuffer == "Fire") {
-               callResponderTypeInBuffer[j] = 6;
-            } else if (typeInBuffer == "Law") {
-               callResponderTypeInBuffer[j] = 7;
-            }
-         }
-         HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu[i], callResponderTypeInBuffer.data(),
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyHostToDevice));
-         // clear vector before filling with next vertex's call ids
-         callResponderTypeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu[i], servingCall_[i].responderType().data(),
+                                 intBufferBytes, cudaMemcpyHostToDevice));
       }
    }
 }
@@ -1570,29 +1369,18 @@ void All911Vertices::copyToDevice()
 void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t stepsPerEpoch,
                                                 All911VerticesDeviceProperties &allVerticesDevice)
 {
-   // TODO: Review implementation with Prof Stiber
+   const size_t bufferBytes = (stepsPerEpoch + 1) * sizeof(int);
+   const size_t timeBufferBytes = (stepsPerEpoch + 1) * sizeof(uint64_t);
+   const size_t floatBufferBytes = (stepsPerEpoch + 1) * sizeof(BGFLOAT);
+
    // int **vertexQueuesBufferVertexId_;
    {
       int *callIdCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callIdCpu, allVerticesDevice.vertexQueuesBufferVertexId_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callIdInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         // Make sure internal buffer can hold all device values
-         callIdInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callIdInBuffer.data(), callIdCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         // Only copy over the number of IDs that we have on the CPU.
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].vertexId = callIdInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call IDs
-         callIdInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].vertexId().data(), callIdCpu[i], bufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // uint64_t **vertexQueuesBufferTime_;
@@ -1600,21 +1388,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       uint64_t *callTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callTimeCpu, allVerticesDevice.vertexQueuesBufferTime_,
                               numberOfVertices * sizeof(uint64_t *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<uint64_t> callTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callTimeInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callTimeInBuffer.data(), callTimeCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(uint64_t), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].time = callTimeInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].time().data(), callTimeCpu[i], timeBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // int **vertexQueuesBufferDuration_;
@@ -1622,21 +1398,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       int *callDurationCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callDurationCpu, allVerticesDevice.vertexQueuesBufferDuration_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callDurationInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callDurationInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callDurationInBuffer.data(), callDurationCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].duration = callDurationInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callDurationInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].duration().data(), callDurationCpu[i],
+                                 bufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // BGFLOAT **vertexQueuesBufferX_;
@@ -1644,21 +1408,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       BGFLOAT *callLocationXCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationXCpu, allVerticesDevice.vertexQueuesBufferX_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationXInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationXInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callLocationXInBuffer.data(), callLocationXCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(BGFLOAT), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].x = callLocationXInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callLocationXInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].x().data(), callLocationXCpu[i],
+                                 floatBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // BGFLOAT **vertexQueuesBufferY_;
@@ -1666,21 +1418,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       BGFLOAT *callLocationYCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationYCpu, allVerticesDevice.vertexQueuesBufferY_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationYInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationYInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callLocationYInBuffer.data(), callLocationYCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(BGFLOAT), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].y = callLocationYInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callLocationYInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].y().data(), callLocationYCpu[i],
+                                 floatBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // int **vertexQueuesBufferPatience_;
@@ -1688,21 +1428,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       int *callPatienceCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callPatienceCpu, allVerticesDevice.vertexQueuesBufferPatience_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callPatienceInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callPatienceInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callPatienceInBuffer.data(), callPatienceCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].patience = callPatienceInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callPatienceInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].patience().data(), callPatienceCpu[i],
+                                 bufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // int **vertexQueuesBufferOnSiteTime_;
@@ -1710,21 +1438,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       int *callOnSiteTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu, allVerticesDevice.vertexQueuesBufferOnSiteTime_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callOnSiteTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callOnSiteTimeInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeInBuffer.data(), callOnSiteTimeCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].onSiteTime = callOnSiteTimeInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callOnSiteTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].onSiteTime().data(), callOnSiteTimeCpu[i],
+                                 bufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // int **vertexQueuesBufferResponderType_;
@@ -1733,27 +1449,9 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu,
                               allVerticesDevice.vertexQueuesBufferResponderType_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callResponderTypeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callResponderTypeInBuffer.resize(stepsPerEpoch + 1);
-         HANDLE_ERROR(cudaMemcpy(callResponderTypeInBuffer.data(), callResponderTypeCpu[i],
-                                 (stepsPerEpoch + 1) * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = vertexQueues_[i].getBuffer();
-         for (int j = 0; j < buffer.size(); j++) {
-            if (callResponderTypeInBuffer[j] == 5) {
-               buffer[j].type = "EMS";
-            } else if (callResponderTypeInBuffer[j] == 6) {
-               buffer[j].type = "Fire";
-            } else if (callResponderTypeInBuffer[j] == 7) {
-               buffer[j].type = "Law";
-            }
-         }
-         // clear vector before filling with next vertex's call ids
-         callResponderTypeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(vertexQueues_[i].responderType().data(), callResponderTypeCpu[i],
+                                 bufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // uint64_t *vertexQueuesFront_;
@@ -1780,7 +1478,7 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
       HANDLE_ERROR(cudaMemcpy(queueSizeCpu, allVerticesDevice.vertexQueuesBufferSize_,
                               numberOfVertices * sizeof(uint64_t), cudaMemcpyDeviceToHost));
       for (int i = 0; i < numberOfVertices; i++) {
-         vertexQueues_[i].getBuffer().resize(queueSizeCpu[i]);
+         vertexQueues_[i].resizeBuffer(queueSizeCpu[i]);
       }
    }
 }
@@ -1788,26 +1486,18 @@ void All911Vertices::copyVertexQueuesFromDevice(int numberOfVertices, uint64_t s
 void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
                                                All911VerticesDeviceProperties &allVerticesDevice)
 {
+   const size_t intBufferBytes = maxNumberOfServers_ * sizeof(int);
+   const size_t timeBufferBytes = maxNumberOfServers_ * sizeof(uint64_t);
+   const size_t floatBufferBytes = maxNumberOfServers_ * sizeof(BGFLOAT);
+
    // int **servingCallBufferVertexId_;
    {
       int *callIdCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callIdCpu, allVerticesDevice.servingCallBufferVertexId_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callIdInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callIdInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callIdInBuffer.data(), callIdCpu[i],
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].vertexId = callIdInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callIdInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].vertexId().data(), callIdCpu[i], intBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // uint64_t **servingCallBufferTime_;
@@ -1815,21 +1505,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       uint64_t *callTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callTimeCpu, allVerticesDevice.servingCallBufferTime_,
                               numberOfVertices * sizeof(uint64_t *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<uint64_t> callTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callTimeInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callTimeInBuffer.data(), callTimeCpu[i],
-                                 maxNumberOfServers_ * sizeof(uint64_t), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].time = callTimeInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].time().data(), callTimeCpu[i], timeBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // int **servingCallBufferDuration_;
@@ -1837,21 +1515,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       int *callDurationCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callDurationCpu, allVerticesDevice.servingCallBufferDuration_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callDurationInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callDurationInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callDurationInBuffer.data(), callDurationCpu[i],
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].duration = callDurationInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callDurationInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].duration().data(), callDurationCpu[i],
+                                 intBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // BGFLOAT **servingCallBufferX_;
@@ -1859,21 +1525,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       BGFLOAT *callLocationXCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationXCpu, allVerticesDevice.servingCallBufferX_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationXInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationXInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callLocationXInBuffer.data(), callLocationXCpu[i],
-                                 maxNumberOfServers_ * sizeof(BGFLOAT), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].x = callLocationXInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callLocationXInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].x().data(), callLocationXCpu[i], floatBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // BGFLOAT **servingCallBufferY_;
@@ -1881,21 +1535,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       BGFLOAT *callLocationYCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callLocationYCpu, allVerticesDevice.servingCallBufferY_,
                               numberOfVertices * sizeof(BGFLOAT *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<BGFLOAT> callLocationYInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callLocationYInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callLocationYInBuffer.data(), callLocationYCpu[i],
-                                 maxNumberOfServers_ * sizeof(BGFLOAT), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].y = callLocationYInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callLocationYInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].y().data(), callLocationYCpu[i], floatBufferBytes,
+                                 cudaMemcpyDeviceToHost));
       }
    }
    // int **servingCallBufferPatience_;
@@ -1903,21 +1545,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       int *callPatienceCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callPatienceCpu, allVerticesDevice.servingCallBufferPatience_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callPatienceInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callPatienceInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callPatienceInBuffer.data(), callPatienceCpu[i],
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].patience = callPatienceInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callPatienceInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].patience().data(), callPatienceCpu[i],
+                                 intBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // int **servingCallBufferOnSiteTime_;
@@ -1925,21 +1555,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       int *callOnSiteTimeCpu[numberOfVertices];
       HANDLE_ERROR(cudaMemcpy(callOnSiteTimeCpu, allVerticesDevice.servingCallBufferOnSiteTime_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callOnSiteTimeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callOnSiteTimeInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callOnSiteTimeInBuffer.data(), callOnSiteTimeCpu[i],
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            buffer[j].onSiteTime = callOnSiteTimeInBuffer[j];
-         }
-         // clear vector before filling with next vertex's call ids
-         callOnSiteTimeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].onSiteTime().data(), callOnSiteTimeCpu[i],
+                                 intBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
    // int **servingCallBufferResponderType_;
@@ -1948,27 +1566,9 @@ void All911Vertices::copyServingCallFromDevice(int numberOfVertices,
       HANDLE_ERROR(cudaMemcpy(callResponderTypeCpu,
                               allVerticesDevice.servingCallBufferResponderType_,
                               numberOfVertices * sizeof(int *), cudaMemcpyDeviceToHost));
-
-      // Using a vector since we are still on the CPU and it's convenient to call data()
-      // in memcpy and using the same vector over and over helps with stack memory
-      // management
-      vector<int> callResponderTypeInBuffer;
       for (int i = 0; i < numberOfVertices; i++) {
-         callResponderTypeInBuffer.resize(maxNumberOfServers_);
-         HANDLE_ERROR(cudaMemcpy(callResponderTypeInBuffer.data(), callResponderTypeCpu[i],
-                                 maxNumberOfServers_ * sizeof(int), cudaMemcpyDeviceToHost));
-         vector<Call> buffer = servingCall_[i];
-         for (int j = 0; j < buffer.size(); j++) {
-            if (callResponderTypeInBuffer[j] == 5) {
-               buffer[j].type = "EMS";
-            } else if (callResponderTypeInBuffer[j] == 6) {
-               buffer[j].type = "Fire";
-            } else if (callResponderTypeInBuffer[j] == 7) {
-               buffer[j].type = "Law";
-            }
-         }
-         // clear vector before filling with next vertex's call ids
-         callResponderTypeInBuffer.clear();
+         HANDLE_ERROR(cudaMemcpy(servingCall_[i].responderType().data(), callResponderTypeCpu[i],
+                                 intBufferBytes, cudaMemcpyDeviceToHost));
       }
    }
 }

--- a/Testing/UnitTesting/InputManagerTests.cpp
+++ b/Testing/UnitTesting/InputManagerTests.cpp
@@ -6,6 +6,7 @@
  * @ingroup Testing/UnitTesting
  */
 
+#include "CallCircularBuffer.h"
 #include "CircularBuffer.h"
 #include "InputEvent.h"
 #include "InputManager.h"
@@ -98,6 +99,44 @@ TEST_F(InputManagerFixture, getEpochEvents)
    ASSERT_EQ(v195Queue.size(), 3);   // should not include 401
    // Check that 3rd event is correct
    // pop and discard the first 2 events
+   v195Queue.get();
+   v195Queue.get();
+   std::optional<Call> call3 = v195Queue.get();
+   EXPECT_EQ(call3->vertexId, 195);
+   EXPECT_EQ(call3->time, 388);
+   EXPECT_EQ(call3->duration, 45);
+   EXPECT_EQ(call3->type, "Law");
+   EXPECT_FLOAT_EQ(call3->x, -122.37746466732693);
+   EXPECT_FLOAT_EQ(call3->y, 47.711139673719046);
+}
+
+TEST_F(InputManagerFixture, getEpochEventsCallCircularBuffer)
+{
+   CallCircularBuffer v194Queue(5);
+   inputManager.getEvents(194, 0, 37, v194Queue);
+   ASSERT_EQ(v194Queue.size(), 2);
+
+   std::optional<Call> call1 = v194Queue.get();
+   ASSERT_TRUE(call1);
+   EXPECT_EQ(call1->vertexId, 194);
+   EXPECT_EQ(call1->time, 0);
+   EXPECT_EQ(call1->duration, 0);
+   EXPECT_EQ(call1->type, "EMS");
+   EXPECT_FLOAT_EQ(call1->x, -122.38496236371942);
+   EXPECT_FLOAT_EQ(call1->y, 47.570236838209546);
+
+   std::optional<Call> call2 = v194Queue.get();
+   ASSERT_TRUE(call2);
+   EXPECT_EQ(call2->vertexId, 194);
+   EXPECT_EQ(call2->time, 34);
+   EXPECT_EQ(call2->duration, 230);
+   EXPECT_EQ(call2->type, "EMS");
+   EXPECT_FLOAT_EQ(call2->x, -122.37482094435583);
+   EXPECT_FLOAT_EQ(call2->y, 47.64839548276973);
+
+   CallCircularBuffer v195Queue(5);
+   inputManager.getEvents(195, 125, 401, v195Queue);
+   ASSERT_EQ(v195Queue.size(), 3);
    v195Queue.get();
    v195Queue.get();
    std::optional<Call> call3 = v195Queue.get();


### PR DESCRIPTION
<!-- Link to the issue and use the appropriate closing keyword (e.g., Closes, Resolves) -->
Closes #

<!-- Please provide a brief overview of the changes implemented -->
#### Description
Brief description
Refactored NG911 call storage from struct-of-arrays (Call, CircularBuffer<Call>, vector<vector<Call>>) to separate field vectors on the CPU, matching the existing GPU layout.

New helpers

CallCircularBuffer - vertex waiting queues
CallSlotArrays - calls being served per server
CallUtils - responder type conversion and Call assembly
Updated storage

Vertices: vertexQueues_ and servingCall_ now use the new buffer types
Edges: call_ replaced with separate vectors (callVertexId_, callTime_, callDuration_, etc.)
Benefits

CPU and GPU use the same field layout
Host/device copies are direct cudaMemcpy calls instead of unpacking Call structs
Sets up future use of RecordableVector / DeviceVector
The Call struct is still used for reading input XML via InputManager; only simulation state was moved to separate vectors.

<!-- Please check the boxes as applicable -->
#### Checklist (Mandatory for new features)
- [x] Added Documentation 
- [ ] Added Unit Tests 

<!-- Ensure all boxes are checked before submitting the PR -->
#### Testing (Mandatory for all changes)
- [x] GPU Test: `test-medium-connected.xml` Passed
- [x] GPU Test: `test-large-long.xml` Passed

<!-- 
PR Guidelines
1. Ensure that your changes are merged into the `development` branch. Only merge into the `master` branch if explicitly instructed.
     - On GitHub, at the top of the PR page, change the base branch from `master` to `development`.
2. Assign the PR to yourself and apply the appropriate labels.
3. Only add a reviewer after submitting the PR and confirming that all GitHub Actions have passed.

Thank you for your contribution!
-->
