### PR TITLE
[issue-779] Populate STDP edge recorder output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,7 @@ add_executable(tests
         Testing/UnitTesting/OperationManagerTestingClass.h
         Testing/UnitTesting/VerticesFactoryTests.cpp
         Testing/UnitTesting/ConnectionsFactoryTests.cpp
+        Testing/UnitTesting/ConnStaticTests.cpp
         Testing/UnitTesting/EdgesFactoryTests.cpp
         Testing/UnitTesting/LayoutFactoryTests.cpp
         Testing/UnitTesting/RecorderFactoryTests.cpp

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -93,11 +93,31 @@ void ConnStatic::printParameters() const
 void ConnStatic::registerHistoryVariables()
 {
    // Register the following variables to be recorded
-   // Note: There may be potential duplicate weight, source, destination vertices
    Recorder &recorder = Simulator::getInstance().getModel().getRecorder();
    recorder.registerVariable("weight", WCurrentEpoch_, Recorder::UpdatedType::DYNAMIC);
    recorder.registerVariable("sourceVertex", sourceVertexIndexCurrentEpoch_,
                              Recorder::UpdatedType::DYNAMIC);
    recorder.registerVariable("destinationVertex", destVertexIndexCurrentEpoch_,
                              Recorder::UpdatedType::DYNAMIC);
+}
+
+bool ConnStatic::updateConnections()
+{
+   AllEdges &edges = getEdges();
+   const vector<unsigned char> &inUse = edges.getInUse();
+   const vector<BGFLOAT> &weights = edges.getWeights();
+   const vector<int> &sourceVertices = edges.getSourceVertexIndices();
+   const vector<int> &destVertices = edges.getDestVertexIndices();
+
+   // Copy one value per active edge into parallel recorder vectors.
+   // weight/source/destination entries at the same index describe the same edge.
+   for (BGSIZE iEdg = 0; iEdg < inUse.size(); iEdg++) {
+      if (inUse[iEdg]) {
+         WCurrentEpoch_.push_back(weights[iEdg]);
+         sourceVertexIndexCurrentEpoch_.push_back(sourceVertices[iEdg]);
+         destVertexIndexCurrentEpoch_.push_back(destVertices[iEdg]);
+      }
+   }
+
+   return false;
 }

--- a/Simulator/Connections/Neuro/ConnStatic.cpp
+++ b/Simulator/Connections/Neuro/ConnStatic.cpp
@@ -103,6 +103,11 @@ void ConnStatic::registerHistoryVariables()
 
 bool ConnStatic::updateConnections()
 {
+   // GPU STDP is not implemented, so this only uses the CPU edge data.
+   WCurrentEpoch_.startNewEpoch();
+   sourceVertexIndexCurrentEpoch_.startNewEpoch();
+   destVertexIndexCurrentEpoch_.startNewEpoch();
+
    AllEdges &edges = getEdges();
    const vector<unsigned char> &inUse = edges.getInUse();
    const vector<BGFLOAT> &weights = edges.getWeights();
@@ -110,7 +115,7 @@ bool ConnStatic::updateConnections()
    const vector<int> &destVertices = edges.getDestVertexIndices();
 
    // Copy one value per active edge into parallel recorder vectors.
-   // weight/source/destination entries at the same index describe the same edge.
+   // Entries at the same index describe the same edge.
    for (BGSIZE iEdg = 0; iEdg < inUse.size(); iEdg++) {
       if (inUse[iEdg]) {
          WCurrentEpoch_.push_back(weights[iEdg]);

--- a/Simulator/Connections/Neuro/ConnStatic.h
+++ b/Simulator/Connections/Neuro/ConnStatic.h
@@ -64,6 +64,9 @@ public:
    /// Registers history variables for recording during simulation
    virtual void registerHistoryVariables() override;
 
+   /// Populates edge history variables for recording during the current epoch.
+   virtual bool updateConnections() override;
+
    /// Get array of vertex weights
    const vector<BGFLOAT> &getWCurrentEpoch() const
    {

--- a/Simulator/Edges/AllEdges.h
+++ b/Simulator/Edges/AllEdges.h
@@ -59,6 +59,30 @@ public:
    ///  Populate a edge index map.
    virtual void createEdgeIndexMap(EdgeIndexMap &edgeIndexMap);
 
+   /// Get array of source vertex indices.
+   const vector<int> &getSourceVertexIndices() const
+   {
+      return sourceVertexIndex_;
+   }
+
+   /// Get array of destination vertex indices.
+   const vector<int> &getDestVertexIndices() const
+   {
+      return destVertexIndex_;
+   }
+
+   /// Get array of edge weights.
+   const vector<BGFLOAT> &getWeights() const
+   {
+      return W_;
+   }
+
+   /// Get array of active edge flags.
+   const vector<unsigned char> &getInUse() const
+   {
+      return inUse_;
+   }
+
    ///  Cereal serialization method
    template <class Archive> void serialize(Archive &archive);
 

--- a/Testing/UnitTesting/ConnStaticTests.cpp
+++ b/Testing/UnitTesting/ConnStaticTests.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file ConnStaticTests.cpp
+ *
+ * @brief Unit tests for ConnStatic.
+ *
+ * @ingroup Testing/UnitTesting
+ */
+
+#include "AllSTDPSynapses.h"
+#include "ConnStatic.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <vector>
+
+namespace {
+
+class TestConnStatic : public ConnStatic {
+public:
+   void setEdges(std::unique_ptr<AllEdges> edges)
+   {
+      edges_ = std::move(edges);
+   }
+};
+
+TEST(ConnStatic, UpdateConnectionsCopiesActiveEdgesWithoutAccumulating)
+{
+   auto edges = std::make_unique<AllSTDPSynapses>(3, 2);
+   edges->addEdge(edgeType::EE, 0, 2, 0.001);
+   edges->addEdge(edgeType::II, 2, 0, 0.001);
+
+   const std::vector<int> expectedSources { 2, 0 };
+   const std::vector<int> expectedDestinations { 0, 2 };
+   const std::vector<BGFLOAT> expectedWeights { -10.0e-9, 10.0e-9 };
+
+   TestConnStatic connections;
+   connections.setEdges(std::move(edges));
+
+   connections.updateConnections();
+
+   EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
+   EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
+   EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
+
+   connections.updateConnections();
+
+   EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
+   EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
+   EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
+}
+
+}   // namespace

--- a/Testing/UnitTesting/ConnStaticTests.cpp
+++ b/Testing/UnitTesting/ConnStaticTests.cpp
@@ -9,44 +9,43 @@
 #include "AllSTDPSynapses.h"
 #include "ConnStatic.h"
 #include "gtest/gtest.h"
-
 #include <memory>
 #include <vector>
 
 namespace {
 
-class TestConnStatic : public ConnStatic {
-public:
-   void setEdges(std::unique_ptr<AllEdges> edges)
+   class TestConnStatic : public ConnStatic {
+   public:
+      void setEdges(std::unique_ptr<AllEdges> edges)
+      {
+         edges_ = std::move(edges);
+      }
+   };
+
+   TEST(ConnStatic, UpdateConnectionsCopiesActiveEdgesWithoutAccumulating)
    {
-      edges_ = std::move(edges);
+      auto edges = std::make_unique<AllSTDPSynapses>(3, 2);
+      edges->addEdge(edgeType::EE, 0, 2, 0.001);
+      edges->addEdge(edgeType::II, 2, 0, 0.001);
+
+      const std::vector<int> expectedSources {2, 0};
+      const std::vector<int> expectedDestinations {0, 2};
+      const std::vector<BGFLOAT> expectedWeights {-10.0e-9, 10.0e-9};
+
+      TestConnStatic connections;
+      connections.setEdges(std::move(edges));
+
+      connections.updateConnections();
+
+      EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
+      EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
+      EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
+
+      connections.updateConnections();
+
+      EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
+      EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
+      EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
    }
-};
-
-TEST(ConnStatic, UpdateConnectionsCopiesActiveEdgesWithoutAccumulating)
-{
-   auto edges = std::make_unique<AllSTDPSynapses>(3, 2);
-   edges->addEdge(edgeType::EE, 0, 2, 0.001);
-   edges->addEdge(edgeType::II, 2, 0, 0.001);
-
-   const std::vector<int> expectedSources { 2, 0 };
-   const std::vector<int> expectedDestinations { 0, 2 };
-   const std::vector<BGFLOAT> expectedWeights { -10.0e-9, 10.0e-9 };
-
-   TestConnStatic connections;
-   connections.setEdges(std::move(edges));
-
-   connections.updateConnections();
-
-   EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
-   EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
-   EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
-
-   connections.updateConnections();
-
-   EXPECT_EQ(expectedSources, connections.getSourceVertexIndexCurrentEpoch());
-   EXPECT_EQ(expectedDestinations, connections.getDestVertexIndexCurrentEpoch());
-   EXPECT_EQ(expectedWeights, connections.getWCurrentEpoch());
-}
 
 }   // namespace


### PR DESCRIPTION
Closes #779

#### Description

This change adds support for recording the source vertex, destination vertex, and weight of active edges during STDP simulations.

I added getters in `AllEdges` so `ConnStatic` can access the edge information. I also added `ConnStatic::updateConnections()` to copy the active edge values into the recorder vectors during each epoch.

I built the project and all 133 tests passed. I also ran `test-tiny-xml-stdp.xml`, which has 4 edges and runs for 3 epochs. The output included `sourceVertex`, `destinationVertex`, and `weight`, with 12 values in each matrix.

#### Checklist (Mandatory for new features)
- [ ] Added Documentation
- [ ] Added Unit Tests

#### Testing (Mandatory for all changes)
- [ ] GPU Test: `test-medium-connected.xml` Passed
- [ ] GPU Test: `test-large-long.xml` Passed